### PR TITLE
fix: verduidelijk dat token-levensduur maximaal 7 dagen is

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Twee servers draaien in hetzelfde proces:
 Ga naar [github.com/settings/tokens](https://github.com/settings/tokens) → **Generate new token (classic)**.
 
 Instellingen:
-- Expiration: **7 days** (of langer naar keuze)
+- Expiration: **7 days** (maximaal — de infosupport-organisatie staat geen langere tokens toe)
 - Scope: **read:packages**
 
 Kopieer het token.

--- a/cli/README.md
+++ b/cli/README.md
@@ -4,7 +4,7 @@ Cross-platform Node CLI voor Huddle. De CLI praat met de bestaande Huddle REST A
 
 ## Installeren
 
-Maak een GitHub Personal Access Token aan op [github.com/settings/tokens](https://github.com/settings/tokens) (classic, scope: **read:packages**, 7 dagen).
+Maak een GitHub Personal Access Token aan op [github.com/settings/tokens](https://github.com/settings/tokens) (classic, scope: **read:packages**, expiration: **maximaal 7 dagen** — de infosupport-organisatie staat geen langere tokens toe).
 
 Login bij de registries:
 


### PR DESCRIPTION
De infosupport-organisatie staat geen PAT (classic) toe met een levensduur langer dan 7 dagen. De documentatie vermeldde ten onrechte dat een langere levensduur ook mogelijk was.

Fixes #15