### PR TITLE
fix: ship base-devimage Dockerfiles in de gateway-image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,19 @@
-# Base-image builds (base-devimage-*/Dockerfile) gebruiken de repo-root als
-# build-context zodat de `COPY .ai/…` regels bij de gedeelde AI-config kunnen.
-# We sturen daarom alléén .ai mee; al het andere (node_modules, logs, .git, …)
-# blijft buiten de context. De Dockerfile zelf komt via `-f` binnen en hoeft
-# niet in de context te zitten.
+# Alle image-builds gebruiken de repo-root als build-context; de Dockerfile
+# komt via `-f` binnen. We sturen alléén mee wat de builds nodig hebben:
+# - .ai: gedeelde AI-config voor de base-devimage builds (COPY .ai/…)
+# - gateway/**: bronbestanden voor de gateway-image (gateway/Dockerfile)
+# - base-devimage*/Dockerfile: worden in de gateway-image gebakken zodat de
+#   gateway ze on-demand kan bouwen, ook zonder repo-checkout
+# Al het andere (node_modules, logs, .git, …) blijft buiten de context.
 *
 !.ai
 !.ai/**
+!gateway/**
+gateway/node_modules
+gateway/frontend/node_modules
+gateway/dist
+gateway/frontend/dist
+!base-devimage/Dockerfile
+!base-devimage-intellij/Dockerfile
+!base-devimage-rider/Dockerfile
+!base-devimage-vscode/Dockerfile

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: ./gateway
+          context: .
+          file: ./gateway/Dockerfile
           push: true
           tags: ghcr.io/infosupport/huddle:latest
 

--- a/README.md
+++ b/README.md
@@ -130,9 +130,10 @@ huddle
 
 ## Base images bouwen (optioneel)
 
-Huddle bouwt base images automatisch wanneer je een devcontainer start. Wil je dit versnellen, bouw ze dan van tevoren:
+Huddle bouwt base images automatisch wanneer je een devcontainer start (de Dockerfiles zitten in de Huddle-image, een repo-checkout is niet nodig). Wil je dit versnellen, bouw ze dan van tevoren. Bouw eerst de gedeelde `base-devimage` — de IDE-specifieke images bouwen daarop voort:
 
 ```bash
+docker build -t base-devimage           -f base-devimage/Dockerfile           .
 docker build -t base-devimage-vscode    -f base-devimage-vscode/Dockerfile    .
 docker build -t base-devimage-intellij  -f base-devimage-intellij/Dockerfile  .
 docker build -t base-devimage-rider     -f base-devimage-rider/Dockerfile     .
@@ -330,6 +331,7 @@ Alle state-muterende endpoints sturen een WebSocket `{ type: "reload" }` event n
 │   └── extensions/aikido/       ← Ingebouwde Aikido Security extensie
 ├── cli/                         ← Cross-platform CLI (`huddle`)
 ├── .devcontainer/               ← Devcontainer setup voor de Huddle repo zelf
+├── base-devimage/               ← Gedeelde base Dockerfile voor alle devcontainers
 ├── base-devimage-rider/         ← Dockerfile voor Rider devcontainers
 ├── base-devimage-intellij/      ← Dockerfile voor IntelliJ devcontainers
 └── base-devimage-vscode/        ← Dockerfile voor VS Code devcontainers

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -1,19 +1,22 @@
+# Build-context is de repo-root (niet ./gateway), zodat de base-devimage
+# Dockerfiles mee de image in kunnen. Bouwen met:
+#   docker build -f gateway/Dockerfile -t huddle .
 FROM node:20-alpine AS builder
 WORKDIR /app
 RUN apk add --no-cache python3 make g++
 
 # Install gateway deps
-COPY package.json package-lock.json tsconfig.json ./
+COPY gateway/package.json gateway/package-lock.json gateway/tsconfig.json ./
 RUN npm ci
 
 # Install Angular frontend deps
-COPY frontend/package.json frontend/package-lock.json ./frontend/
+COPY gateway/frontend/package.json gateway/frontend/package-lock.json ./frontend/
 RUN npm ci --prefix frontend
 
 # Copy source and build
-COPY src ./src
-COPY frontend/src ./frontend/src
-COPY frontend/angular.json frontend/tsconfig*.json ./frontend/
+COPY gateway/src ./src
+COPY gateway/frontend/src ./frontend/src
+COPY gateway/frontend/angular.json gateway/frontend/tsconfig*.json ./frontend/
 RUN npm run build
 
 # Remove devDependencies so only production node_modules remain
@@ -25,8 +28,17 @@ WORKDIR /app
 RUN mkdir -p /data /tmp/dc-sockets
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
-COPY package.json ./
-COPY extensions ./extensions
+COPY gateway/package.json ./
+COPY gateway/extensions ./extensions
+
+# Base-devimage Dockerfiles meebakken zodat de gateway ze on-demand kan bouwen,
+# ook zonder repo-checkout (npm-installatie via `huddle init`). De read-only
+# mounts uit init.sh overschrijven deze paden tijdens lokale ontwikkeling.
+COPY base-devimage/Dockerfile /base-devimage/Dockerfile
+COPY base-devimage-intellij/Dockerfile /base-devimage-intellij/Dockerfile
+COPY base-devimage-rider/Dockerfile /base-devimage-rider/Dockerfile
+COPY base-devimage-vscode/Dockerfile /base-devimage-vscode/Dockerfile
+
 ENV DB_PATH=/data/huddle.db
 ENV EXT_DIR=/app/extensions
 EXPOSE 80 3000

--- a/gateway/src/docker.ts
+++ b/gateway/src/docker.ts
@@ -668,9 +668,20 @@ export async function createAndStartContainer(params: StartParams): Promise<stri
   }
 
   if (!(await imageExists(imageName))) {
+    // De IDE-specifieke Dockerfiles zijn `FROM base-devimage`; bouw die
+    // gedeelde base eerst als hij nog niet bestaat.
+    if (!(await imageExists('base-devimage'))) {
+      const baseDockerfilePath = '/base-devimage/Dockerfile';
+      if (!fs.existsSync(baseDockerfilePath)) {
+        throw new Error(`Image 'base-devimage' not found and ${baseDockerfilePath} is not available in the gateway image`);
+      }
+      console.log(`[huddle] Building shared base image 'base-devimage' from ${baseDockerfilePath}...`);
+      await buildImage('base-devimage', baseDockerfilePath);
+      console.log(`[huddle] Shared base image 'base-devimage' built successfully`);
+    }
     const dockerfilePath = `/base-devimage-${ideName}/Dockerfile`;
     if (!fs.existsSync(dockerfilePath)) {
-      throw new Error(`Image '${imageName}' not found and ${dockerfilePath} is not mounted`);
+      throw new Error(`Image '${imageName}' not found and ${dockerfilePath} is not available in the gateway image`);
     }
     console.log(`[huddle] Building base image '${imageName}' from ${dockerfilePath}...`);
     await buildImage(imageName, dockerfilePath);

--- a/huddle.ps1
+++ b/huddle.ps1
@@ -81,7 +81,7 @@ function Start-Huddle {
     if (-not $imageExists) {
         Write-Host "  Image '${HUDDLE_IMAGE}' niet gevonden -- bouwen..." -ForegroundColor DarkCyan
         $scriptDir = $PSScriptRoot
-        docker build -t $HUDDLE_IMAGE (Join-Path $scriptDir "gateway") --no-cache
+        docker build -t $HUDDLE_IMAGE -f (Join-Path $scriptDir "gateway/Dockerfile") $scriptDir --no-cache
         if ($LASTEXITCODE -ne 0) { Write-Host "  Build mislukt." -ForegroundColor Red; return }
     }
 
@@ -138,7 +138,7 @@ function Restart-Huddle {
 function Build-HuddleImage {
     $scriptDir = $PSScriptRoot
     Write-Host "  Image '${HUDDLE_IMAGE}' bouwen..." -ForegroundColor DarkCyan
-    docker build -t $HUDDLE_IMAGE (Join-Path $scriptDir "gateway") --no-cache
+    docker build -t $HUDDLE_IMAGE -f (Join-Path $scriptDir "gateway/Dockerfile") $scriptDir --no-cache
     if ($LASTEXITCODE -eq 0) {
         Write-Host "  [OK] Image '${HUDDLE_IMAGE}' klaar." -ForegroundColor Green
     } else {

--- a/init.sh
+++ b/init.sh
@@ -3,7 +3,10 @@ set -euo pipefail
 
 IMAGE_NAME="${HUDDLE_IMAGE:-huddle}"
 CONTAINER_NAME="${HUDDLE_CONTAINER:-huddle}"
-BUILD_CONTEXT="${HUDDLE_BUILD_CONTEXT:-./gateway}"
+# Build-context is de repo-root zodat de base-devimage Dockerfiles mee de
+# gateway-image in kunnen (zie gateway/Dockerfile).
+BUILD_CONTEXT="${HUDDLE_BUILD_CONTEXT:-.}"
+DOCKERFILE="${HUDDLE_DOCKERFILE:-gateway/Dockerfile}"
 
 HOST_PORT="${HUDDLE_PORT:-3000}"
 CONTAINER_PORT="3000"
@@ -23,7 +26,7 @@ fi
 DC_SOCKETS="${DC_SOCKETS:-/tmp/dc-sockets}"
 
 echo "==> Build image: ${IMAGE_NAME}"
-docker build "${BUILD_CONTEXT}" -t "${IMAGE_NAME}"
+docker build "${BUILD_CONTEXT}" -f "${DOCKERFILE}" -t "${IMAGE_NAME}"
 
 echo "==> Zorg dat volume bestaat: ${VOLUME_NAME}"
 docker volume inspect "${VOLUME_NAME}" >/dev/null 2>&1 || \
@@ -56,6 +59,7 @@ add_readonly_mount_if_exists() {
   fi
 }
 
+add_readonly_mount_if_exists "./base-devimage" "/base-devimage"
 add_readonly_mount_if_exists "./base-devimage-rider" "/base-devimage-rider"
 add_readonly_mount_if_exists "./base-devimage-intellij" "/base-devimage-intellij"
 add_readonly_mount_if_exists "./base-devimage-vscode" "/base-devimage-vscode"


### PR DESCRIPTION
Fixes #16

## Probleem

Devcontainers starten via de CLI (of UI) faalde zonder lokale repo-checkout:

1. De gepubliceerde `ghcr.io/infosupport/huddle`-image werd gebouwd met `./gateway` als build-context en bevatte de `base-devimage*/Dockerfile`s dus niet. `huddle init` (npm-installatie) mount ze ook niet, waardoor de on-demand image-build in de gateway stukliep op *"Dockerfile is not mounted"* — de foutmelding uit het issue.
2. Zelfs mét repo-checkout faalde de auto-build: de IDE-specifieke Dockerfiles zijn `FROM base-devimage`, maar die gedeelde base werd nergens gebouwd — niet door de gateway, niet gemount in `init.sh`, en de README noemde de stap ook niet.

## Oplossing

- **`gateway/Dockerfile`** bakt de vier `base-devimage*/Dockerfile`s in de image op `/base-devimage*/Dockerfile`. De build-context is daarvoor verplaatst naar de repo-root; de CI-workflow, `init.sh`, `huddle.ps1` en de root-`.dockerignore` zijn daarop aangepast. De read-only mounts uit `init.sh` blijven werken als dev-override over de ingebakken kopieën.
- **`gateway/src/docker.ts`** bouwt eerst de gedeelde `base-devimage` als die ontbreekt, en daarna pas de IDE-specifieke image.
- **`init.sh`** mount nu ook `./base-devimage`.
- **README**: `docker build -t base-devimage …` toegevoegd als eerste stap in de handmatige build-instructies, plus de map in het projectstructuur-overzicht.

## Verificatie

- `tsc --noEmit` en de unit tests van de gateway slagen.
- De gateway-image is volledig gebouwd met de nieuwe context; alle vier de Dockerfiles staan op de verwachte paden in de image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)