### PR TITLE
fix(socket-proxy): blokkeer container-escape via local bind-backed volumes (#20)

### DIFF
--- a/gateway/src/socket-proxy.ts
+++ b/gateway/src/socket-proxy.ts
@@ -81,7 +81,7 @@ function checkPolicy(containerName: string): boolean {
 // Reject HostConfig shapes that would let a spawned container escape the
 // devcontainer sandbox (read host fs, see host PIDs, talk to host dockerd).
 // Returns a denial reason, or null if the config is safe.
-function validateHostConfig(hostConfig: any): string | null {
+export function validateHostConfig(hostConfig: any): string | null {
   if (!hostConfig || typeof hostConfig !== 'object') return null;
 
   if (hostConfig.Privileged === true) return 'Privileged containers not permitted';
@@ -127,7 +127,13 @@ function validateHostConfig(hostConfig: any): string | null {
 
   if (Array.isArray(hostConfig.Mounts)) {
     for (const mount of hostConfig.Mounts) {
-      if (mount && mount.Type === 'bind') return 'bind-type mounts not permitted';
+      if (!mount) continue;
+      if (mount.Type === 'bind') return 'bind-type mounts not permitted';
+      // Een `local`-volume met inline driver-config kan een willekeurig hostpad
+      // bind-backen (type=none, o=bind, device=/…) — net zo gevaarlijk als een
+      // host bind. Weiger elke volume-mount die zelf een driver meebrengt.
+      if (mount.Type === 'volume' && mount.VolumeOptions?.DriverConfig)
+        return 'volume DriverConfig not permitted';
     }
   }
 
@@ -145,6 +151,25 @@ function validateHostConfig(hostConfig: any): string | null {
     }
   }
 
+  return null;
+}
+
+// Reject volume-create bodies that map a named volume onto a host path via the
+// `local` driver (type=none / o=bind / device=…). Zo'n volume kan daarna onder
+// een niet-`/` bron-naam in een container gebonden worden en omzeilt daarmee de
+// host-path-check in validateHostConfig. Returns een denial reason, of null.
+export function validateVolumeCreate(body: any): string | null {
+  if (!body || typeof body !== 'object') return null;
+  const driver = typeof body.Driver === 'string' ? body.Driver.toLowerCase() : 'local';
+  const opts = body.DriverOpts;
+  if (driver !== 'local' || !opts || typeof opts !== 'object') return null;
+  const norm: Record<string, string> = {};
+  for (const [k, v] of Object.entries(opts)) norm[k.toLowerCase()] = String(v).toLowerCase();
+  // `device` dekt zowel bind- (o=bind) als externe-storage-mounts (nfs/cifs);
+  // een devcontainer heeft geen van beide nodig en beide kunnen data buiten de
+  // sandbox koppelen.
+  if (norm.device || (norm.o ?? '').includes('bind') || norm.type === 'none')
+    return 'local bind-backed volumes not permitted';
   return null;
 }
 
@@ -286,6 +311,22 @@ export async function createContainerProxy(containerName: string, socketDir: str
           `Content-Length: ${newBodyBuf.length}`
         ) + '\r\n\r\n';
         openUpstream(Buffer.concat([Buffer.from(newHeader), newBodyBuf, rest]));
+      }
+
+      function processVolumeCreate(): void {
+        const bodyBytes = bodyBuf.slice(0, bodyContentLength);
+        const rest = bodyBuf.slice(bodyContentLength);
+        let body: any;
+        try {
+          body = JSON.parse(bodyBytes.toString());
+        } catch {
+          deny403(client, 'invalid volume create body');
+          return;
+        }
+        const denial = validateVolumeCreate(body);
+        if (denial) { deny403(client, denial); return; }
+        // Body ongewijzigd doorsturen (alleen validatie, geen injectie).
+        openUpstream(Buffer.concat([Buffer.from(savedHeaderPart + '\r\n\r\n'), bodyBytes, rest]));
       }
 
       client.on('data', (chunk: Buffer) => {
@@ -469,9 +510,17 @@ export async function createContainerProxy(containerName: string, socketDir: str
             return;
           }
 
-          // Volume create — needed for docker compose named volumes
+          // Volume create — needed for docker compose named volumes. Body wordt
+          // gebufferd en gevalideerd: local bind-backed volumes (host-path
+          // escape) worden geweigerd.
           if (p === '/volumes/create') {
-            openUpstream(Buffer.concat([Buffer.from(headerPart + '\r\n\r\n'), remainder]));
+            const clMatch = headerPart.match(/content-length:\s*(\d+)/i);
+            bodyContentLength = clMatch ? parseInt(clMatch[1]) : 0;
+            savedHeaderPart = headerPart;
+            bodyHandler = processVolumeCreate;
+            phase = 'body';
+            bodyBuf = remainder;
+            if (bodyBuf.length >= bodyContentLength) bodyHandler();
             return;
           }
 

--- a/gateway/test/e2e/boundary.e2e.ts
+++ b/gateway/test/e2e/boundary.e2e.ts
@@ -73,6 +73,25 @@ describe.skipIf(!E2E_ENABLED)('live security boundary', () => {
       expect(`${r.stdout}${r.stderr}`).toMatch(/not permitted/i);
     });
 
+    it('weigert een named local bind-backed volume (host-path escape)', async () => {
+      // grant staat nog actief. Maak een local volume dat host-/ bind-backt en
+      // probeer het te mounten — de bind-source ("hostroot") begint niet met "/"
+      // maar mag evengoed niet host-/ koppelen.
+      const create = execIn(E2E_NAME, `docker volume create --driver local --opt type=none --opt device=/ --opt o=bind hostroot`);
+      expect(`${create.stdout}${create.stderr}`).toMatch(/not permitted/i);
+      const run = execIn(E2E_NAME, `docker run --rm -v hostroot:/host ${E2E_IMAGE} cat /host/etc/hostname`);
+      expect(run.status).not.toBe(0);
+    });
+
+    it('weigert een volume-mount met inline DriverConfig (host-path escape)', async () => {
+      const r = execIn(
+        E2E_NAME,
+        `docker run --rm --mount 'type=volume,dst=/host,volume-driver=local,volume-opt=type=none,volume-opt=device=/,volume-opt=o=bind' ${E2E_IMAGE} cat /host/etc/hostname`,
+      );
+      expect(r.status).not.toBe(0);
+      expect(`${r.stdout}${r.stderr}`).toMatch(/not permitted/i);
+    });
+
     it('weigert --privileged óók met grant', async () => {
       const r = execIn(E2E_NAME, `docker run --rm --privileged ${E2E_IMAGE} true`);
       expect(r.status).not.toBe(0);

--- a/gateway/test/host-config.test.ts
+++ b/gateway/test/host-config.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { validateHostConfig, validateVolumeCreate } from '../src/socket-proxy';
+
+// ── Boundary — socket-proxy HostConfig / volume policy ──────────────────────
+// De per-container Docker-socket-proxy moet elke poging blokkeren om via een
+// gespawnde container of via een volume uit de devcontainer-sandbox te breken.
+
+describe('validateHostConfig', () => {
+  it('staat een onschuldige config toe', () => {
+    expect(validateHostConfig({})).toBeNull();
+    expect(validateHostConfig({ Binds: ['myvol:/data'] })).toBeNull();
+    expect(validateHostConfig({ Mounts: [{ Type: 'volume', Source: 'myvol', Target: '/data' }] })).toBeNull();
+  });
+
+  it('weigert de klassieke escape-vectoren', () => {
+    expect(validateHostConfig({ Privileged: true })).toMatch(/privileged/i);
+    expect(validateHostConfig({ PidMode: 'host' })).toMatch(/pidmode/i);
+    expect(validateHostConfig({ CapAdd: ['SYS_ADMIN'] })).toMatch(/capadd/i);
+    expect(validateHostConfig({ Binds: ['/:/host'] })).toMatch(/host-path bind/i);
+    expect(validateHostConfig({ Mounts: [{ Type: 'bind', Source: '/', Target: '/host' }] })).toMatch(/bind-type/i);
+  });
+
+  it('weigert een volume-mount met inline driver-config (local bind escape)', () => {
+    const denial = validateHostConfig({
+      Mounts: [{
+        Type: 'volume',
+        Target: '/host',
+        VolumeOptions: { DriverConfig: { Name: 'local', Options: { type: 'none', device: '/', o: 'bind' } } },
+      }],
+    });
+    expect(denial).toMatch(/driverconfig not permitted/i);
+  });
+});
+
+describe('validateVolumeCreate', () => {
+  it('staat een gewoon named volume toe', () => {
+    expect(validateVolumeCreate({ Name: 'data' })).toBeNull();
+    expect(validateVolumeCreate({ Name: 'data', Driver: 'local' })).toBeNull();
+    expect(validateVolumeCreate({ Name: 'data', Driver: 'local', DriverOpts: {} })).toBeNull();
+  });
+
+  it('weigert een local bind-backed volume (host-path escape)', () => {
+    expect(validateVolumeCreate({
+      Name: 'hostroot', Driver: 'local',
+      DriverOpts: { type: 'none', device: '/', o: 'bind' },
+    })).toMatch(/bind-backed/i);
+  });
+
+  it('weigert varianten: alleen o=bind, alleen device, of type=none', () => {
+    expect(validateVolumeCreate({ Driver: 'local', DriverOpts: { o: 'bind' } })).toMatch(/bind-backed/i);
+    expect(validateVolumeCreate({ Driver: 'local', DriverOpts: { device: '/etc' } })).toMatch(/bind-backed/i);
+    expect(validateVolumeCreate({ Driver: 'local', DriverOpts: { type: 'none' } })).toMatch(/bind-backed/i);
+  });
+
+  it('is case-insensitief op sleutels en waarden', () => {
+    expect(validateVolumeCreate({ Driver: 'LOCAL', DriverOpts: { O: 'BIND' } })).toMatch(/bind-backed/i);
+  });
+});


### PR DESCRIPTION
Sluit **#20** (KRITIEK).

## Probleem
De host-path-bind-check in de socket-proxy weigerde alleen bind-sources die met `/` beginnen. Een named volume begint niet met `/`, maar Docker's `local` driver kan een named volume aan een willekeurig hostpad bind-backen (`type=none`/`o=bind`/`device=/`). Ook `Mounts` van type `volume` met inline `DriverConfig` deed dit. Beide gaven een devcontainer met docker-grant volledige host-fs-toegang + de onge-proxy'de host-`docker.sock` → root op de host.

## Fix
- `validateHostConfig` weigert nu volume-mounts met `VolumeOptions.DriverConfig`.
- Nieuwe `validateVolumeCreate` weigert local bind-backed `/volumes/create`-bodies (`device`/`o=bind`/`type=none`).
- `/volumes/create` wordt nu gebufferd en gevalideerd i.p.v. onvoorwaardelijk doorgestuurd.
- `validateHostConfig`/`validateVolumeCreate` geëxporteerd voor tests.

## Tests
- Nieuwe `test/host-config.test.ts` (unit) — beide escape-varianten + happy path.
- E2e-regressietests in `boundary.e2e.ts` naast de bestaande `-v /:/host`-test.
- `tsc --noEmit` groen; volledige unit-suite 79/79 groen.

> Named volumes zonder driver-opties (docker compose) blijven werken; alleen bind-/externe-storage-volumes worden geweigerd.