### PR TITLE
fix(launch): bind management-API standaard aan 127.0.0.1 (#21)

### DIFF
--- a/huddle.ps1
+++ b/huddle.ps1
@@ -6,6 +6,11 @@ $HUDDLE_CONTAINER = "huddle"
 $HUDDLE_IMAGE     = "huddle"
 $HUDDLE_VOLUME    = "huddle-data"
 $HUDDLE_PORT      = 3000
+# De management-API/UI heeft geen eigen authenticatie; toegang leunt op
+# netwerkpositie. Publiceer daarom standaard alleen op de loopback zodat de
+# admin-API niet op het LAN bereikbaar is. Zet HUDDLE_BIND_ADDR bewust op
+# "0.0.0.0" (env var) als je hem breder wilt blootstellen (op eigen risico).
+$HUDDLE_BIND_ADDR = if ($env:HUDDLE_BIND_ADDR) { $env:HUDDLE_BIND_ADDR } else { "127.0.0.1" }
 
 # Per-IDE base images. Elke IDE heeft een eigen base-devimage-<ide>/ folder met
 # een Dockerfile en draagt LABEL com.devcontainer.ide=<ide>. Snapshots inheriten
@@ -97,7 +102,7 @@ function Start-Huddle {
         '-d',
         '--name', $HUDDLE_CONTAINER,
         '--network', 'devcontainer-net',
-        '-p', "${HUDDLE_PORT}:3000",
+        '-p', "${HUDDLE_BIND_ADDR}:${HUDDLE_PORT}:3000",
         '-v', "${HUDDLE_VOLUME}:/data",
         '-v', '/var/run/docker.sock:/var/run/docker.sock',
         '-v', '/tmp/dc-sockets:/tmp/dc-sockets',

--- a/init.sh
+++ b/init.sh
@@ -8,6 +8,12 @@ BUILD_CONTEXT="${HUDDLE_BUILD_CONTEXT:-./gateway}"
 HOST_PORT="${HUDDLE_PORT:-3000}"
 CONTAINER_PORT="3000"
 
+# De management-API/UI heeft geen eigen authenticatie; toegang leunt op
+# netwerkpositie. Publiceer daarom standaard alléén op de loopback zodat de
+# admin-API niet op het LAN bereikbaar is. Zet HUDDLE_BIND_ADDR bewust op
+# 0.0.0.0 als je hem breder wilt blootstellen (op eigen risico).
+HUDDLE_BIND_ADDR="${HUDDLE_BIND_ADDR:-127.0.0.1}"
+
 VOLUME_NAME="${HUDDLE_VOLUME:-huddle-data}"
 
 INTERNAL_NETWORK="${HUDDLE_INTERNAL_NETWORK:-devcontainer-net}"
@@ -64,7 +70,7 @@ echo "==> Start container op internal netwerk"
 docker run -d \
   --name "${CONTAINER_NAME}" \
   --network "${INTERNAL_NETWORK}" \
-  -p "${HOST_PORT}:${CONTAINER_PORT}" \
+  -p "${HUDDLE_BIND_ADDR}:${HOST_PORT}:${CONTAINER_PORT}" \
   "${MOUNTS[@]}" \
   "${IMAGE_NAME}"
 


### PR DESCRIPTION
Sluit **#21** (HIGH).

## Probleem
De management-API/UI op poort 3000 kent **geen authenticatie**; de enige bescherming is een source-IP-gate die alleen devcontainer-subnetten weigert. Met `-p 3000:3000` (bind op `0.0.0.0`) was de admin-API bereikbaar voor elke host op het LAN → grants uitdelen, folder-mappings/host-mounts maken, containerwachtwoorden en audit-log (met secrets) uitlezen.

## Fix
- `init.sh` en `huddle.ps1` publiceren de poort nu standaard op `127.0.0.1`.
- Nieuwe override `HUDDLE_BIND_ADDR` (default `127.0.0.1`) voor wie bewust breder wil publiceren.

Devcontainers bereiken de API via het docker-netwerk (`huddle:3000`), niet via de host-poort, dus dit breekt de normale flow niet. De UI in de host-browser (`http://localhost:3000`) blijft werken.

## Vervolg
Dit dekt de LAN-blootstelling af. Echte authenticatie op `/api/*` (zodat veiligheid niet alleen op netwerkpositie leunt) is een grotere wijziging en kan als aparte issue worden opgepakt.