### PR TITLE
fix(proxy): scrub OAuth-token uit audit-log bij token-exchange (#22)

### DIFF
--- a/gateway/src/proxy.ts
+++ b/gateway/src/proxy.ts
@@ -105,13 +105,12 @@ function rejectSocket(socket: stream.Duplex, status: number, blockStatus: string
 
 // Buffers en scrubt de OAuth token-exchange response zodat het echte access_token
 // nooit in de audit-log terechtkomt. Stuurt de gescrubde response naar innerRes
-// en roept completeWithBody aan met de veilige audit-body.
+// en roept complete aan met de veilige audit-body als derde argument.
 function handleTokenExchangeResponse(
   upstreamRes: http.IncomingMessage,
   innerRes: http.ServerResponse,
   containerId: string | null,
-  completeWithBody: (status: number | null, headers: http.IncomingHttpHeaders | undefined, body: string | null) => void,
-  complete: (status: number | null, headers?: http.IncomingHttpHeaders) => void,
+  complete: (status: number | null, headers?: http.IncomingHttpHeaders, body?: string | null) => void,
 ): void {
   const chunks: Buffer[] = [];
   upstreamRes.on('data', (chunk: Buffer) => chunks.push(chunk));
@@ -143,7 +142,7 @@ function handleTokenExchangeResponse(
     }
     innerRes.writeHead(upstreamRes.statusCode ?? 200, outHeaders);
     innerRes.end(outBuf);
-    completeWithBody(upstreamRes.statusCode ?? null, outHeaders, auditResBody);
+    complete(upstreamRes.statusCode ?? null, outHeaders, auditResBody);
   });
   upstreamRes.on('error', () => {
     if (!innerRes.writableEnded) innerRes.destroy();
@@ -480,7 +479,9 @@ export function createProxyServer(): http.Server {
         reqHeaders: headersToJson(innerReq.headers),
       });
       let completed = false;
-      const complete = (resStatus: number | null, resHeaders?: http.IncomingHttpHeaders) => {
+      // resBody: expliciet meegeven voor gescrubde paden (token-exchange) zodat het
+      // echte secret nooit in de audit-log terechtkomt. Weglaten = afleiden uit resChunks.
+      const complete = (resStatus: number | null, resHeaders?: http.IncomingHttpHeaders, resBody?: string | null) => {
         if (completed) return;
         completed = true;
         if (auditId == null) return;
@@ -488,25 +489,7 @@ export function createProxyServer(): http.Server {
           reqBody: reqBytes > 0 ? cap(Buffer.concat(reqChunks).toString('utf8')) : null,
           resStatus,
           resHeaders: resHeaders ? headersToJson(resHeaders as Record<string, any>) : null,
-          resBody: resBytes > 0 ? decodeBody(resChunks, resHeaders ?? {}) : null,
-        });
-      };
-      // Variant voor paden waar de response-body al gescrubd is (token-exchange):
-      // log de meegegeven body letterlijk i.p.v. hem uit resChunks af te leiden,
-      // zodat het echte secret nooit in de audit-log terechtkomt.
-      const completeWithBody = (
-        resStatus: number | null,
-        resHeaders: http.IncomingHttpHeaders | undefined,
-        resBody: string | null,
-      ) => {
-        if (completed) return;
-        completed = true;
-        if (auditId == null) return;
-        updateAuditResponse(auditId, {
-          reqBody: reqBytes > 0 ? cap(Buffer.concat(reqChunks).toString('utf8')) : null,
-          resStatus,
-          resHeaders: resHeaders ? headersToJson(resHeaders as Record<string, any>) : null,
-          resBody,
+          resBody: resBody !== undefined ? resBody : resBytes > 0 ? decodeBody(resChunks, resHeaders ?? {}) : null,
         });
       };
 
@@ -521,7 +504,7 @@ export function createProxyServer(): http.Server {
         },
         (upstreamRes) => {
           if (isTokenRequest && upstreamRes.statusCode === 200) {
-            handleTokenExchangeResponse(upstreamRes, innerRes, containerId, completeWithBody, complete);
+            handleTokenExchangeResponse(upstreamRes, innerRes, containerId, complete);
           } else {
             innerRes.writeHead(upstreamRes.statusCode || 502, sanitizeResHeaders(upstreamRes.headers));
             upstreamRes.on('data', (chunk: Buffer) => {

--- a/gateway/src/proxy.ts
+++ b/gateway/src/proxy.ts
@@ -103,6 +103,54 @@ function rejectSocket(socket: stream.Duplex, status: number, blockStatus: string
   socket.end();
 }
 
+// Buffers en scrubt de OAuth token-exchange response zodat het echte access_token
+// nooit in de audit-log terechtkomt. Stuurt de gescrubde response naar innerRes
+// en roept completeWithBody aan met de veilige audit-body.
+function handleTokenExchangeResponse(
+  upstreamRes: http.IncomingMessage,
+  innerRes: http.ServerResponse,
+  containerId: string | null,
+  completeWithBody: (status: number | null, headers: http.IncomingHttpHeaders | undefined, body: string | null) => void,
+  complete: (status: number | null, headers?: http.IncomingHttpHeaders) => void,
+): void {
+  const chunks: Buffer[] = [];
+  upstreamRes.on('data', (chunk: Buffer) => chunks.push(chunk));
+  upstreamRes.on('end', () => {
+    let outBuf: Buffer;
+    let outHeaders = { ...upstreamRes.headers };
+    // Fail-safe: log null bij scrub-fouten i.p.v. het echte token te lekken.
+    let auditResBody: string | null = null;
+    try {
+      const rawBody = decodeBody(chunks, upstreamRes.headers);
+      const json = rawBody ? JSON.parse(rawBody) : null;
+      if (json?.access_token) {
+        const placeholder = storeTokenExchange(containerId ?? 'unknown', json.access_token as string);
+        json.access_token = placeholder;
+        console.log(`[token-exchange] placeholder issued voor container ${containerId}`);
+        outBuf = Buffer.from(JSON.stringify(json));
+        delete outHeaders['content-encoding'];
+        delete outHeaders['transfer-encoding'];
+        outHeaders['content-length'] = String(outBuf.length);
+        auditResBody = cap(JSON.stringify(json));
+      } else {
+        outBuf = Buffer.concat(chunks);
+        outHeaders['content-length'] = String(outBuf.length);
+        auditResBody = rawBody;
+      }
+    } catch {
+      outBuf = Buffer.concat(chunks);
+      outHeaders = { ...upstreamRes.headers };
+    }
+    innerRes.writeHead(upstreamRes.statusCode ?? 200, outHeaders);
+    innerRes.end(outBuf);
+    completeWithBody(upstreamRes.statusCode ?? null, outHeaders, auditResBody);
+  });
+  upstreamRes.on('error', () => {
+    if (!innerRes.writableEnded) innerRes.destroy();
+    complete(0, upstreamRes.headers);
+  });
+}
+
 export function createProxyServer(): http.Server {
   const server = http.createServer();
 
@@ -473,51 +521,7 @@ export function createProxyServer(): http.Server {
         },
         (upstreamRes) => {
           if (isTokenRequest && upstreamRes.statusCode === 200) {
-            // Buffer de volledige OAuth-response zodat we het token kunnen vervangen.
-            // BELANGRIJK: de rauwe respons bevat het ECHTE access_token en mag NIET
-            // in resChunks/de audit-log belanden. We loggen straks alleen de
-            // gescrubde (placeholder) versie via auditResBody.
-            const tokenResChunks: Buffer[] = [];
-            upstreamRes.on('data', (chunk: Buffer) => {
-              tokenResChunks.push(chunk);
-            });
-            upstreamRes.on('end', () => {
-              let outBuf: Buffer;
-              let outHeaders = { ...upstreamRes.headers };
-              // Wat we in de audit-log zetten: nooit het echte token. null =
-              // niets loggen (fail-safe wanneer we niet konden scrubben).
-              let auditResBody: string | null = null;
-              try {
-                const rawBody = decodeBody(tokenResChunks, upstreamRes.headers);
-                const json = rawBody ? JSON.parse(rawBody) : null;
-                if (json?.access_token) {
-                  const placeholder = storeTokenExchange(containerId ?? 'unknown', json.access_token as string);
-                  json.access_token = placeholder;
-                  console.log(`[token-exchange] placeholder issued voor container ${containerId}`);
-                  outBuf = Buffer.from(JSON.stringify(json));
-                  delete outHeaders['content-encoding'];
-                  delete outHeaders['transfer-encoding'];
-                  outHeaders['content-length'] = String(outBuf.length);
-                  // De placeholder-versie bevat geen secret → veilig te loggen.
-                  auditResBody = cap(JSON.stringify(json));
-                } else {
-                  outBuf = Buffer.concat(tokenResChunks);
-                  outHeaders['content-length'] = String(outBuf.length);
-                  auditResBody = rawBody; // geen token aanwezig
-                }
-              } catch {
-                outBuf = Buffer.concat(tokenResChunks);
-                outHeaders = { ...upstreamRes.headers };
-                auditResBody = null; // niet kunnen scrubben → niets loggen i.p.v. lekken
-              }
-              innerRes.writeHead(upstreamRes.statusCode ?? 200, outHeaders);
-              innerRes.end(outBuf);
-              completeWithBody(upstreamRes.statusCode ?? null, outHeaders, auditResBody);
-            });
-            upstreamRes.on('error', () => {
-              if (!innerRes.writableEnded) innerRes.destroy();
-              complete(0, upstreamRes.headers);
-            });
+            handleTokenExchangeResponse(upstreamRes, innerRes, containerId, completeWithBody, complete);
           } else {
             innerRes.writeHead(upstreamRes.statusCode || 502, sanitizeResHeaders(upstreamRes.headers));
             upstreamRes.on('data', (chunk: Buffer) => {

--- a/gateway/src/proxy.ts
+++ b/gateway/src/proxy.ts
@@ -443,6 +443,24 @@ export function createProxyServer(): http.Server {
           resBody: resBytes > 0 ? decodeBody(resChunks, resHeaders ?? {}) : null,
         });
       };
+      // Variant voor paden waar de response-body al gescrubd is (token-exchange):
+      // log de meegegeven body letterlijk i.p.v. hem uit resChunks af te leiden,
+      // zodat het echte secret nooit in de audit-log terechtkomt.
+      const completeWithBody = (
+        resStatus: number | null,
+        resHeaders: http.IncomingHttpHeaders | undefined,
+        resBody: string | null,
+      ) => {
+        if (completed) return;
+        completed = true;
+        if (auditId == null) return;
+        updateAuditResponse(auditId, {
+          reqBody: reqBytes > 0 ? cap(Buffer.concat(reqChunks).toString('utf8')) : null,
+          resStatus,
+          resHeaders: resHeaders ? headersToJson(resHeaders as Record<string, any>) : null,
+          resBody,
+        });
+      };
 
       const upstreamReq = https.request(
         {
@@ -456,14 +474,19 @@ export function createProxyServer(): http.Server {
         (upstreamRes) => {
           if (isTokenRequest && upstreamRes.statusCode === 200) {
             // Buffer de volledige OAuth-response zodat we het token kunnen vervangen.
+            // BELANGRIJK: de rauwe respons bevat het ECHTE access_token en mag NIET
+            // in resChunks/de audit-log belanden. We loggen straks alleen de
+            // gescrubde (placeholder) versie via auditResBody.
             const tokenResChunks: Buffer[] = [];
             upstreamRes.on('data', (chunk: Buffer) => {
               tokenResChunks.push(chunk);
-              if (resBytes < CAP) { resChunks.push(chunk); resBytes += chunk.length; }
             });
             upstreamRes.on('end', () => {
               let outBuf: Buffer;
               let outHeaders = { ...upstreamRes.headers };
+              // Wat we in de audit-log zetten: nooit het echte token. null =
+              // niets loggen (fail-safe wanneer we niet konden scrubben).
+              let auditResBody: string | null = null;
               try {
                 const rawBody = decodeBody(tokenResChunks, upstreamRes.headers);
                 const json = rawBody ? JSON.parse(rawBody) : null;
@@ -475,17 +498,21 @@ export function createProxyServer(): http.Server {
                   delete outHeaders['content-encoding'];
                   delete outHeaders['transfer-encoding'];
                   outHeaders['content-length'] = String(outBuf.length);
+                  // De placeholder-versie bevat geen secret → veilig te loggen.
+                  auditResBody = cap(JSON.stringify(json));
                 } else {
                   outBuf = Buffer.concat(tokenResChunks);
                   outHeaders['content-length'] = String(outBuf.length);
+                  auditResBody = rawBody; // geen token aanwezig
                 }
               } catch {
                 outBuf = Buffer.concat(tokenResChunks);
                 outHeaders = { ...upstreamRes.headers };
+                auditResBody = null; // niet kunnen scrubben → niets loggen i.p.v. lekken
               }
               innerRes.writeHead(upstreamRes.statusCode ?? 200, outHeaders);
               innerRes.end(outBuf);
-              complete(upstreamRes.statusCode ?? null, upstreamRes.headers);
+              completeWithBody(upstreamRes.statusCode ?? null, outHeaders, auditResBody);
             });
             upstreamRes.on('error', () => {
               if (!innerRes.writableEnded) innerRes.destroy();


### PR DESCRIPTION
Sluit **#22** (HIGH).

## Probleem
Op het OAuth-responsepad werden de rauwe upstream-chunks (met het **echte** `access_token`) in `resChunks` gebufferd en via `complete()` als `res_body` opgeslagen — vóór de placeholder-vervanging. Het echte token stond daardoor plaintext in de SQLite-DB en was opvraagbaar via `GET /api/audit`, wat de hele token-exchange ondergraaft.

## Fix
- De rauwe respons wordt niet langer in `resChunks`/de audit-buffer gestopt.
- Nieuwe `completeWithBody()` logt alléén de gescrubde (placeholder) body.
- Bij een parse-/decode-fout wordt de response-body niet gelogd (fail-safe).

De devcontainer krijgt nog steeds de placeholder; alleen de audit-registratie bevat geen secret meer.

## Tests
- `tsc --noEmit` groen; unit-suite 72/72 groen. Het token-pad zelf loopt via de live e2e-flow (geen isoleerbare unit).