### PR TITLE
fix(gate): source-IP-gate fail-closed tegen IPv6-bypass + startup-race (#23)

### DIFF
--- a/gateway/src/api.ts
+++ b/gateway/src/api.ts
@@ -94,8 +94,10 @@ export async function createApiServer(): Promise<FastifyInstance> {
   const app = Fastify({ logger: false });
 
   // Build the blocked-subnet cache and refresh it periodically so new
-  // dc-net-* networks (created when a devcontainer starts) get picked up.
-  refreshBlockedSubnets().catch(() => {});
+  // dc-net-* networks (created when a devcontainer starts) get picked up. De
+  // eerste vulling wordt vóór app.listen() afgewacht (zie onderaan), zodat er
+  // geen opstart-venster is waarin een devcontainer de gate omzeilt doordat de
+  // cache nog leeg is.
   setInterval(refreshBlockedSubnets, 5000).unref();
 
   // Devcontainers may only reach a tiny whitelist of endpoints (currently just
@@ -882,6 +884,10 @@ export async function createApiServer(): Promise<FastifyInstance> {
       reply.code(500).send({ error: err.message });
     }
   });
+
+  // Vul de blocked-subnet cache vóór we verbindingen accepteren, zodat de
+  // source-IP-gate meteen vanaf de eerste request werkt (geen fail-open venster).
+  await refreshBlockedSubnets();
 
   const address = await app.listen({ port: API_PORT, host: '0.0.0.0' });
   console.log(`[api] listening on ${address}`);

--- a/gateway/src/net-gate.ts
+++ b/gateway/src/net-gate.ts
@@ -26,15 +26,26 @@ export function cidrToRange(cidr: string): IpRange | null {
   return [(baseInt & mask) >>> 0, mask];
 }
 
-// True als `remoteAddr` binnen één van de geblokkeerde subnets valt.
+// True als `remoteAddr` als een devcontainer-bron behandeld moet worden (en dus
+// de management-API NIET mag bereiken). Fail-closed: alles wat we niet positief
+// als "veilige" bron kunnen vaststellen (loopback of een IPv4-adres buiten de
+// devcontainer-subnetten) wordt als devcontainer beschouwd. Zo kan een container
+// de gate niet omzeilen via IPv6 of een niet-parseerbaar bronadres.
 export function isDevcontainerSource(
   remoteAddr: string | null | undefined,
   subnets: IpRange[],
 ): boolean {
-  if (!remoteAddr) return false;
+  // Geen bronadres te bepalen → fail-closed.
+  if (!remoteAddr) return true;
   const ip = remoteAddr.replace(/^::ffff:/, '');
-  if (!ip.includes('.')) return false;
+  // Loopback = de huddle-host zelf (o.a. de -p 127.0.0.1 port-forward via de
+  // docker-proxy en lokale healthchecks) → nooit een devcontainer.
+  if (ip === '127.0.0.1' || ip === '::1') return false;
+  // Raw IPv6 (of ander niet-IPv4 adres): niet te matchen tegen de IPv4-subnet-
+  // lijst → fail-closed i.p.v. doorlaten (dit was de IPv6-bypass).
+  if (!ip.includes('.')) return true;
   const ipInt = ipv4ToInt(ip);
-  if (ipInt < 0) return false;
+  // Onparseerbaar IPv4 → fail-closed.
+  if (ipInt < 0) return true;
   return subnets.some(([base, mask]) => ((ipInt & mask) >>> 0) === base);
 }

--- a/gateway/test/source-ip-gate.test.ts
+++ b/gateway/test/source-ip-gate.test.ts
@@ -52,14 +52,25 @@ describe('isDevcontainerSource', () => {
     expect(isDevcontainerSource('::ffff:172.18.0.9', subnets)).toBe(true);
   });
 
-  it('staat een IP buiten elk subnet toe (= geen devcontainer-bron)', () => {
+  it('staat een IPv4 buiten elk subnet toe (= geen devcontainer-bron, bv. docker-gateway)', () => {
     expect(isDevcontainerSource('10.0.0.1', subnets)).toBe(false);
     expect(isDevcontainerSource('172.20.1.5', subnets)).toBe(false); // /24 → buiten bereik
+    expect(isDevcontainerSource('172.17.0.1', subnets)).toBe(false); // bridge-gateway (admin via -p)
   });
 
-  it('behandelt ontbrekend/ongeldig adres als niet-devcontainer (fail-open op herkenning, niet op toegang)', () => {
-    expect(isDevcontainerSource(undefined, subnets)).toBe(false);
-    expect(isDevcontainerSource(null, subnets)).toBe(false);
-    expect(isDevcontainerSource('garbage', subnets)).toBe(false);
+  it('staat loopback toe (huddle-host zelf / port-forward)', () => {
+    expect(isDevcontainerSource('127.0.0.1', subnets)).toBe(false);
+    expect(isDevcontainerSource('::1', subnets)).toBe(false);
+  });
+
+  it('is fail-closed: raw IPv6 wordt als devcontainer behandeld (IPv6-bypass gedicht)', () => {
+    expect(isDevcontainerSource('fd00::5', subnets)).toBe(true);
+    expect(isDevcontainerSource('2001:db8::1', subnets)).toBe(true);
+  });
+
+  it('is fail-closed op ontbrekend/ongeldig adres', () => {
+    expect(isDevcontainerSource(undefined, subnets)).toBe(true);
+    expect(isDevcontainerSource(null, subnets)).toBe(true);
+    expect(isDevcontainerSource('garbage', subnets)).toBe(true);
   });
 });


### PR DESCRIPTION
Sluit **#23** (MEDIUM).

## Probleem
`isDevcontainerSource` gaf `false` voor elk niet-IPv4-adres → een devcontainer die huddle over IPv6 benaderde omzeilde de gate en kreeg volledige admin-API. Daarnaast was `blockedSubnets` bij startup leeg (fail-open venster van ~5s).

## Fix
- `isDevcontainerSource` is nu **fail-closed**: alleen loopback (`127.0.0.1`/`::1`) en IPv4 buiten de devcontainer-subnetten zijn "veilig"; raw IPv6 en onparseerbare/ontbrekende adressen worden als devcontainer behandeld.
- De subnet-cache wordt vóór `app.listen()` gevuld → geen opstart-venster meer.
- Gate-tests bijgewerkt naar fail-closed + cases voor loopback en raw IPv6.

## Tests
`tsc --noEmit` groen; unit-suite 74/74 groen.

## Let op
Op IPv6-enabled docker-bridges kan admin-verkeer via een raw IPv6-gateway nu geblokkeerd worden. Volledige IPv6/CIDR-matching (subnetten uit IPAM ook voor v6) is de complete vervolgstap; deze PR kiest bewust voor veilig-boven-permissief.