### PR TITLE
feat(cli): Podman-support voor huddle init (#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Twee servers draaien in hetzelfde proces:
 
 ## Getting Started
 
-**Vereisten:** Docker, Node.js 18+
+**Vereisten:** Docker of Podman, Node.js 18+
 
 ### 1. Maak een GitHub Personal Access Token aan
 
@@ -102,6 +102,8 @@ Kopieer het token.
 docker login ghcr.io -u JOUW_GITHUB_GEBRUIKERSNAAM -p JOUW_TOKEN
 ```
 
+Gebruik je Podman, vervang dan `docker` door `podman` in het commando hierboven.
+
 Voeg dit toe aan je gebruikersprofiel `.npmrc` (maak het bestand aan als het niet bestaat):
 - Windows: `C:\Users\JOUW_GEBRUIKERSNAAM\.npmrc`
 - Mac/Linux: `~/.npmrc`
@@ -118,7 +120,7 @@ npm install -g @infosupport/huddle-cli
 huddle init
 ```
 
-`huddle init` pullt de laatste Huddle-image en start de container. De web-UI is bereikbaar op `http://localhost:3000`.
+`huddle init` pullt de laatste Huddle-image en start de container. Het detecteert automatisch of Docker of Podman beschikbaar is; met `huddle init --runtime <docker|podman>` (of de env-var `HUDDLE_RUNTIME`) kies je expliciet een runtime. De web-UI is bereikbaar op `http://localhost:3000`.
 
 Daarna start je devcontainers direct vanuit een projectmap:
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -12,6 +12,8 @@ Login bij de registries:
 docker login ghcr.io -u JOUW_GITHUB_GEBRUIKERSNAAM -p JOUW_TOKEN
 ```
 
+Gebruik je Podman, vervang dan `docker` door `podman` in het commando hierboven.
+
 Voeg toe aan je gebruikersprofiel `.npmrc`:
 - Windows: `C:\Users\JOUW_GEBRUIKERSNAAM\.npmrc`
 - Mac/Linux: `~/.npmrc`
@@ -33,7 +35,7 @@ npm install -g @infosupport/huddle-cli
 huddle init
 ```
 
-Pullt `ghcr.io/infosupport/huddle:latest` en start de container. Als je `huddle` runt terwijl Huddle niet draait, krijg je automatisch de tip om dit commando uit te voeren.
+Pullt `ghcr.io/infosupport/huddle:latest` en start de container. Werkt met Docker en Podman: de runtime wordt automatisch gedetecteerd (Docker eerst, dan Podman), of kies expliciet met `huddle init --runtime <docker|podman>` of de env-var `HUDDLE_RUNTIME`. Als je `huddle` runt terwijl Huddle niet draait, krijg je automatisch de tip om dit commando uit te voeren.
 
 ## Devcontainers starten
 

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -12,7 +12,7 @@ interface ParsedArgs {
   flags: Record<string, string | boolean>;
 }
 
-const VALUE_FLAGS = new Set(['url', 'ide', 'name', 'image', 'workspace', 'container', 'status']);
+const VALUE_FLAGS = new Set(['url', 'ide', 'name', 'image', 'workspace', 'container', 'status', 'runtime']);
 const BOOLEAN_FLAGS = new Set(['help', 'h', 'empty', 'i', 'interactive']);
 const COMMANDS = new Set(['start', 'firewall', 'fw', 'init', 'help']);
 
@@ -76,9 +76,13 @@ function printHelp(): void {
 Gebruik:
   huddle [opties] [folder]           Devcontainer starten in huidige map of folder
   huddle start [opties] [folder]     Expliciet een devcontainer starten
-  huddle init                        Huddle pullen en opstarten via Docker
+  huddle init [opties]               Huddle pullen en opstarten via Docker of Podman
   huddle firewall list [opties]      Firewall-verzoeken weergeven
   huddle fw list [opties]            Alias voor firewall list
+
+Init opties:
+  --runtime <docker|podman>          Container runtime (standaard: automatisch
+                                     gedetecteerd; ook via env-var HUDDLE_RUNTIME)
 
 Start opties:
   --ide <intellij|rider|vscode>      IDE (standaard: intellij)
@@ -138,7 +142,7 @@ async function main(): Promise<void> {
   }
 
   if (cmd === 'init') {
-    await runInit();
+    await runInit({ runtime: flagString(flags, 'runtime') });
     return;
   }
 

--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -1,11 +1,16 @@
 import { execSync } from 'child_process';
 import { bold, green, dim } from './utils';
+import { resolveRuntime } from './runtime';
 
 const IMAGE = 'ghcr.io/infosupport/huddle:latest';
 const CONTAINER = 'huddle';
 const VOLUME = 'huddle-data';
 const INTERNAL_NET = 'devcontainer-net';
 const HOST_PORT = process.env.HUDDLE_PORT ?? '3000';
+
+export interface InitOptions {
+  runtime?: string;
+}
 
 function run(cmd: string): void {
   execSync(cmd, { stdio: 'inherit' });
@@ -20,36 +25,38 @@ function runSilent(cmd: string): boolean {
   }
 }
 
-export async function runInit(): Promise<void> {
+export async function runInit(opts: InitOptions = {}): Promise<void> {
   console.log(`${bold('Huddle opstarten...')}\n`);
 
+  const runtime = resolveRuntime(opts.runtime);
+  const rt = runtime.name;
+  console.log(dim(`Container runtime: ${rt}`));
+
   console.log(dim(`Pull ${IMAGE}`));
-  run(`docker pull ${IMAGE}`);
+  run(`${rt} pull ${IMAGE}`);
 
   console.log(dim(`Volume: ${VOLUME}`));
-  runSilent(`docker volume inspect ${VOLUME}`) || run(`docker volume create ${VOLUME}`);
+  runSilent(`${rt} volume inspect ${VOLUME}`) || run(`${rt} volume create ${VOLUME}`);
 
   console.log(dim(`Netwerk: ${INTERNAL_NET}`));
-  runSilent(`docker network inspect ${INTERNAL_NET}`) || run(`docker network create --internal ${INTERNAL_NET}`);
+  runSilent(`${rt} network inspect ${INTERNAL_NET}`) || run(`${rt} network create --internal ${INTERNAL_NET}`);
 
   console.log(dim(`Verwijder oude container als die bestaat`));
-  runSilent(`docker rm -f ${CONTAINER}`);
-
-  const dockerSock = process.platform === 'win32' ? '//var/run/docker.sock' : '/var/run/docker.sock';
+  runSilent(`${rt} rm -f ${CONTAINER}`);
 
   console.log(dim(`Start container`));
   run(
-    `docker run -d` +
+    `${rt} run -d` +
     ` --name ${CONTAINER}` +
     ` --network ${INTERNAL_NET}` +
     ` -p ${HOST_PORT}:3000` +
     ` -v ${VOLUME}:/data` +
-    ` -v ${dockerSock}:/var/run/docker.sock` +
+    ` -v ${runtime.socketPath}:/var/run/docker.sock` +
     ` -v /tmp/dc-sockets:/tmp/dc-sockets` +
     ` ${IMAGE}`,
   );
 
-  runSilent(`docker network connect bridge ${CONTAINER}`);
+  runSilent(`${rt} network connect ${runtime.defaultNetwork} ${CONTAINER}`);
 
   console.log();
   console.log(green(`[OK] Huddle draait op http://localhost:${HOST_PORT}`));

--- a/cli/src/runtime.ts
+++ b/cli/src/runtime.ts
@@ -1,0 +1,74 @@
+import { execSync } from 'child_process';
+
+export type RuntimeName = 'docker' | 'podman';
+
+export interface ContainerRuntime {
+  name: RuntimeName;
+  /** Pad op de host naar de container-socket, gemount als /var/run/docker.sock. */
+  socketPath: string;
+  /** Naam van het standaard bridge-netwerk ('bridge' bij Docker, 'podman' bij Podman). */
+  defaultNetwork: string;
+}
+
+function commandOutput(cmd: string): string | undefined {
+  try {
+    return execSync(cmd, { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim();
+  } catch {
+    return undefined;
+  }
+}
+
+function isAvailable(runtime: RuntimeName): boolean {
+  // 'info' slaagt alleen als de daemon/machine ook echt bereikbaar is.
+  return commandOutput(`${runtime} info`) !== undefined;
+}
+
+function podmanSocketPath(): string {
+  // Podman weet zelf waar zijn (rootless of rootful) socket staat.
+  const reported = commandOutput(`podman info --format "{{.Host.RemoteSocket.Path}}"`);
+  if (reported) {
+    return reported.replace(/^unix:\/\//, '');
+  }
+  return '/run/podman/podman.sock';
+}
+
+function dockerSocketPath(): string {
+  return process.platform === 'win32' ? '//var/run/docker.sock' : '/var/run/docker.sock';
+}
+
+function buildRuntime(name: RuntimeName): ContainerRuntime {
+  if (name === 'podman') {
+    return { name, socketPath: podmanSocketPath(), defaultNetwork: 'podman' };
+  }
+  return { name, socketPath: dockerSocketPath(), defaultNetwork: 'bridge' };
+}
+
+export function parseRuntimeName(value: string): RuntimeName {
+  const normalized = value.toLowerCase().trim();
+  if (normalized === 'docker' || normalized === 'podman') return normalized;
+  throw new Error(`Onbekende container runtime: ${value}. Kies docker of podman.`);
+}
+
+/**
+ * Bepaalt de te gebruiken container runtime.
+ * Expliciete keuze (via --runtime of HUDDLE_RUNTIME) wint; anders wordt
+ * automatisch gedetecteerd: eerst Docker, dan Podman.
+ */
+export function resolveRuntime(explicit?: string): ContainerRuntime {
+  const requested = explicit ?? process.env.HUDDLE_RUNTIME;
+  if (requested) {
+    const name = parseRuntimeName(requested);
+    if (!isAvailable(name)) {
+      throw new Error(`Container runtime '${name}' is niet beschikbaar. Draait de daemon/machine?`);
+    }
+    return buildRuntime(name);
+  }
+
+  if (isAvailable('docker')) return buildRuntime('docker');
+  if (isAvailable('podman')) return buildRuntime('podman');
+
+  throw new Error(
+    'Geen werkende container runtime gevonden. Installeer en start Docker of Podman,\n' +
+    'of kies er expliciet een met --runtime <docker|podman> of de env-var HUDDLE_RUNTIME.',
+  );
+}

--- a/init.sh
+++ b/init.sh
@@ -11,7 +11,15 @@ CONTAINER_PORT="3000"
 VOLUME_NAME="${HUDDLE_VOLUME:-huddle-data}"
 
 # Container runtime: expliciet via HUDDLE_RUNTIME, anders automatisch (docker, dan podman)
-RUNTIME="${HUDDLE_RUNTIME:-}"
+RUNTIME=""
+if [ -n "${HUDDLE_RUNTIME:-}" ]; then
+  if [ "${HUDDLE_RUNTIME}" = "docker" ] || [ "${HUDDLE_RUNTIME}" = "podman" ]; then
+    RUNTIME="${HUDDLE_RUNTIME}"
+  else
+    echo "Fout: HUDDLE_RUNTIME moet 'docker' of 'podman' zijn, niet '${HUDDLE_RUNTIME}'." >&2
+    exit 1
+  fi
+fi
 if [ -z "${RUNTIME}" ]; then
   if docker info >/dev/null 2>&1; then
     RUNTIME="docker"

--- a/init.sh
+++ b/init.sh
@@ -10,10 +10,33 @@ CONTAINER_PORT="3000"
 
 VOLUME_NAME="${HUDDLE_VOLUME:-huddle-data}"
 
-INTERNAL_NETWORK="${HUDDLE_INTERNAL_NETWORK:-devcontainer-net}"
-BRIDGE_NETWORK="${HUDDLE_BRIDGE_NETWORK:-bridge}"
+# Container runtime: expliciet via HUDDLE_RUNTIME, anders automatisch (docker, dan podman)
+RUNTIME="${HUDDLE_RUNTIME:-}"
+if [ -z "${RUNTIME}" ]; then
+  if docker info >/dev/null 2>&1; then
+    RUNTIME="docker"
+  elif podman info >/dev/null 2>&1; then
+    RUNTIME="podman"
+  else
+    echo "Fout: geen werkende container runtime gevonden (docker of podman)." >&2
+    echo "Kies er expliciet een met de env-var HUDDLE_RUNTIME." >&2
+    exit 1
+  fi
+fi
+echo "==> Container runtime: ${RUNTIME}"
 
-if [ -n "${MSYSTEM:-}" ]; then
+INTERNAL_NETWORK="${HUDDLE_INTERNAL_NETWORK:-devcontainer-net}"
+if [ "${RUNTIME}" = "podman" ]; then
+  BRIDGE_NETWORK="${HUDDLE_BRIDGE_NETWORK:-podman}"
+else
+  BRIDGE_NETWORK="${HUDDLE_BRIDGE_NETWORK:-bridge}"
+fi
+
+if [ "${RUNTIME}" = "podman" ]; then
+  PODMAN_SOCK="$(podman info --format '{{.Host.RemoteSocket.Path}}' 2>/dev/null || true)"
+  DOCKER_SOCK="${DOCKER_SOCK:-${PODMAN_SOCK#unix://}}"
+  DOCKER_SOCK="${DOCKER_SOCK:-/run/podman/podman.sock}"
+elif [ -n "${MSYSTEM:-}" ]; then
   # Git Bash / MSYS op Windows: voorkom verkeerde path-conversie
   DOCKER_SOCK="${DOCKER_SOCK:-//var/run/docker.sock}"
 else
@@ -23,21 +46,21 @@ fi
 DC_SOCKETS="${DC_SOCKETS:-/tmp/dc-sockets}"
 
 echo "==> Build image: ${IMAGE_NAME}"
-docker build "${BUILD_CONTEXT}" -t "${IMAGE_NAME}"
+"${RUNTIME}" build "${BUILD_CONTEXT}" -t "${IMAGE_NAME}"
 
 echo "==> Zorg dat volume bestaat: ${VOLUME_NAME}"
-docker volume inspect "${VOLUME_NAME}" >/dev/null 2>&1 || \
-  docker volume create "${VOLUME_NAME}"
+"${RUNTIME}" volume inspect "${VOLUME_NAME}" >/dev/null 2>&1 || \
+  "${RUNTIME}" volume create "${VOLUME_NAME}"
 
 echo "==> Zorg dat internal netwerk bestaat: ${INTERNAL_NETWORK}"
-docker network inspect "${INTERNAL_NETWORK}" >/dev/null 2>&1 || \
-  docker network create --internal "${INTERNAL_NETWORK}"
+"${RUNTIME}" network inspect "${INTERNAL_NETWORK}" >/dev/null 2>&1 || \
+  "${RUNTIME}" network create --internal "${INTERNAL_NETWORK}"
 
 echo "==> Zorg dat socket directory bestaat: ${DC_SOCKETS}"
 mkdir -p "${DC_SOCKETS}"
 
 echo "==> Verwijder oude container als die bestaat: ${CONTAINER_NAME}"
-docker rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
+"${RUNTIME}" rm -f "${CONTAINER_NAME}" >/dev/null 2>&1 || true
 
 MOUNTS=(
   "-v" "${VOLUME_NAME}:/data"
@@ -61,7 +84,7 @@ add_readonly_mount_if_exists "./base-devimage-intellij" "/base-devimage-intellij
 add_readonly_mount_if_exists "./base-devimage-vscode" "/base-devimage-vscode"
 
 echo "==> Start container op internal netwerk"
-docker run -d \
+"${RUNTIME}" run -d \
   --name "${CONTAINER_NAME}" \
   --network "${INTERNAL_NETWORK}" \
   -p "${HOST_PORT}:${CONTAINER_PORT}" \
@@ -69,8 +92,8 @@ docker run -d \
   "${IMAGE_NAME}"
 
 echo "==> Verbind container met bridge netwerk"
-if docker network inspect "${BRIDGE_NETWORK}" >/dev/null 2>&1; then
-  docker network connect "${BRIDGE_NETWORK}" "${CONTAINER_NAME}" || true
+if "${RUNTIME}" network inspect "${BRIDGE_NETWORK}" >/dev/null 2>&1; then
+  "${RUNTIME}" network connect "${BRIDGE_NETWORK}" "${CONTAINER_NAME}" || true
 else
   echo "Waarschuwing: netwerk ${BRIDGE_NETWORK} bestaat niet, bridge connect wordt overgeslagen"
 fi


### PR DESCRIPTION
Closes #28

## Wat

`huddle init` werkte alleen met Docker. Deze PR voegt Podman-ondersteuning toe, met beide varianten uit de issue:

- **Automatische detectie** (het ideale scenario): eerst wordt Docker geprobeerd, daarna Podman. De check gebruikt `<runtime> info`, zodat een geïnstalleerde maar niet-draaiende daemon/machine niet als beschikbaar telt.
- **Expliciete keuze**: `huddle init --runtime <docker|podman>` of de env-var `HUDDLE_RUNTIME`.

Runtime-specifieke verschillen worden afgehandeld in het nieuwe `cli/src/runtime.ts`:
- Bij Podman wordt het socket-pad opgevraagd via `podman info --format "{{.Host.RemoteSocket.Path}}"` (werkt voor rootless én rootful) en gemount als `/var/run/docker.sock` in de container.
- Het standaard bridge-netwerk heet bij Podman `podman` in plaats van `bridge`.

`init.sh` (lokale dev-flow) volgt dezelfde detectie en respecteert ook `HUDDLE_RUNTIME`. README's zijn bijgewerkt.

## Verificatie

End-to-end gedraaid in een sandbox met Docker-daemon:

- `huddle init` met alleen Docker: detecteert `docker`, doorloopt de flow (pull faalt daar alleen op ontbrekende ghcr-login, bestaand gedrag).
- `huddle init --runtime podman` en `HUDDLE_RUNTIME=podman` via een podman-shim: volledige flow draait door het Podman-pad; de container mount exact het door `podman info` gerapporteerde socket-pad.
- `init.sh` met Docker: volledige build + start, web-UI bereikbaar (HTTP 200); met de podman-shim: zelfde flow inclusief nette waarschuwing als het `podman`-netwerk ontbreekt.
- Foutpaden: `--runtime containerd` → duidelijke fout; `--runtime` zonder waarde → duidelijke fout; `--runtime podman` zonder podman → "niet beschikbaar"-fout; geen enkele runtime → hint naar `--runtime`/`HUDDLE_RUNTIME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)