### PR TITLE
fix(gateway): laat Aspire werken in devcontainers

### DIFF
--- a/gateway/src/docker.ts
+++ b/gateway/src/docker.ts
@@ -691,6 +691,12 @@ export async function createAndStartContainer(params: StartParams): Promise<stri
     'https_proxy=http://huddle:80',
     'HTTP_PROXY=http://huddle:80',
     'HTTPS_PROXY=http://huddle:80',
+    // Loopback mag nooit via de proxy: die kan de loopback van de container
+    // zelf niet bereiken. De bracketed vorm `[::1]` staat er expliciet bij
+    // omdat .NET/Aspire's DCP zijn targets als `http://[::1]:<port>` adresseert
+    // en NO_PROXY letterlijk tegen die bracketed host matcht (issue #12).
+    'no_proxy=localhost,127.0.0.1,::1,[::1]',
+    'NO_PROXY=localhost,127.0.0.1,::1,[::1]',
     // CA-trust op container-niveau zodat ELK proces de MITM-CA vertrouwt — niet
     // alleen login-shells die /etc/profile.d sourcen. Zonder dit valideren tools
     // die door de IDE/non-login-shell gestart worden tegen hun eigen bundle,
@@ -705,7 +711,7 @@ export async function createAndStartContainer(params: StartParams): Promise<stri
     ...(isVscode ? [] : [
       'DEVCONTAINER_CONFIG_PATH=/.jbdevcontainer/config/JetBrains/host-config.json',
       'XDG_DATA_HOME=/.jbdevcontainer/data',
-      'JAVA_TOOL_OPTIONS=-Dhttp.proxyHost=huddle -Dhttp.proxyPort=80 -Dhttps.proxyHost=huddle -Dhttps.proxyPort=80 -Dhttp.nonProxyHosts=',
+      'JAVA_TOOL_OPTIONS=-Dhttp.proxyHost=huddle -Dhttp.proxyPort=80 -Dhttps.proxyHost=huddle -Dhttps.proxyPort=80 -Dhttp.nonProxyHosts=localhost|127.*|[::1]',
     ]),
   ];
 

--- a/gateway/src/socket-proxy.ts
+++ b/gateway/src/socket-proxy.ts
@@ -249,6 +249,10 @@ export async function createContainerProxy(containerName: string, socketDir: str
           'https_proxy=http://huddle:80',
           'HTTP_PROXY=http://huddle:80',
           'HTTPS_PROXY=http://huddle:80',
+          // Loopback nooit via de proxy; `[::1]` bracketed voor .NET/Aspire
+          // (zie de toelichting bij dezelfde regels in docker.ts).
+          'no_proxy=localhost,127.0.0.1,::1,[::1]',
+          'NO_PROXY=localhost,127.0.0.1,::1,[::1]',
           'NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/huddle-ca.crt',
           'SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt',
           'REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt',
@@ -388,8 +392,9 @@ export async function createContainerProxy(containerName: string, socketDir: str
             return;
           }
 
-          // Inspect / logs / top — only on containers labeled by this devcontainer
-          const inspectCt = p.match(/^\/containers\/([^/]+)\/(json|logs|top)$/)?.[1];
+          // Inspect / logs / top / archive (docker cp stat+download) — only on
+          // containers labeled by this devcontainer
+          const inspectCt = p.match(/^\/containers\/([^/]+)\/(json|logs|top|archive)$/)?.[1];
           if (inspectCt) {
             if (devcontainerIds.has(inspectCt)) {
               deny403(client, 'inspect of devcontainer not permitted');
@@ -486,6 +491,32 @@ export async function createContainerProxy(containerName: string, socketDir: str
             return;
           }
 
+          deny403(client, 'operation not permitted');
+          return;
+        }
+
+        // ── PUT ──────────────────────────────────────────────────────────────
+        if (method === 'PUT') {
+          // Archive upload (docker cp naar een container) — o.a. Aspire's DCP
+          // kopieert dev-certs in elke gestarte container (CopyFile, issue #12).
+          // Alleen toegestaan op eigen spawned containers, nooit devcontainers.
+          const archiveCt = p.match(/^\/containers\/([^/]+)\/archive$/)?.[1];
+          if (archiveCt) {
+            if (devcontainerIds.has(archiveCt)) {
+              deny403(client, 'operation on devcontainer not permitted');
+              return;
+            }
+            client.pause();
+            hasOwnLabel('container', archiveCt, containerName).then(ok => {
+              if (ok) {
+                openUpstream(Buffer.concat([Buffer.from(headerPart + '\r\n\r\n'), remainder]));
+              } else {
+                deny403(client, 'container was not created by this devcontainer');
+              }
+              client.resume();
+            });
+            return;
+          }
           deny403(client, 'operation not permitted');
           return;
         }


### PR DESCRIPTION
Fixes #12 — .NET Aspire werkte niet in huddle-devcontainers door twee blokkades:

## 1. DCP-loopbackverkeer ging via de proxy

Devcontainers (en door hen gespawnde child-containers) kregen wel `HTTP_PROXY`/`HTTPS_PROXY=http://huddle:80` geïnjecteerd, maar **geen** `NO_PROXY`. Aspire's DCP adresseert zijn lokale services als `http://[::1]:<poort>`; die requests gingen dus naar de proxy, die de loopback van de container zelf niet kan bereiken → `The proxy tunnel request to proxy 'http://huddle/' failed with status code '403'`.

**Fix:** `NO_PROXY`/`no_proxy=localhost,127.0.0.1,::1,[::1]` wordt nu meegegeven aan devcontainers (`docker.ts`) en aan gespawnde containers (`socket-proxy.ts`). De bracketed vorm `[::1]` staat er expliciet bij omdat .NET `NO_PROXY` letterlijk tegen de bracketed host matcht. `JAVA_TOOL_OPTIONS` krijgt dezelfde loopback-uitzonderingen via `-Dhttp.nonProxyHosts=localhost|127.*|[::1]`.

Hiermee is de `env -u HTTP_PROXY …`-workaround uit het issue niet meer nodig.

## 2. `docker cp` (CopyFile) werd geweigerd door de socket-proxy

Aspire kopieert dev-certs in elke gestarte container via `HEAD`/`PUT /containers/{id}/archive`. De per-container Docker-socket-proxy stond `PUT` als methode helemaal niet toe en kende het archive-pad niet, waardoor Aspire permanent bleef hangen met de container op status `Unknown`.

**Fix:** archive-operaties (`GET`/`HEAD`/`PUT /containers/{id}/archive`) zijn nu toegestaan, met dezelfde eigenaarschapscontrole als bestaande container-operaties: alleen op containers met het eigen `huddle.parent`-label, en nooit op devcontainers zelf. De bestaande grant-check (docker-toegang moet actief verleend zijn) blijft onverkort gelden.

## Verificatie

- `tsc --noEmit` slaagt
- alle 72 unit tests slagen (`vitest run`)
- de minimale repro uit het issue (AppHost met `builder.AddContainer("repro", "nginx", "alpine")`) vereist een draaiende huddle-stack met .NET 10 SDK; graag meenemen in een live e2e-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)