### PR TITLE
fix(ci): laat CLI-versie per commit ophogen i.p.v. blijven staan op d…

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -107,8 +107,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-          # GitVersion heeft de volledige historie én tags nodig.
+          # GitVersion heeft de volledige historie én tags (het anker) nodig.
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@51d325634925d7d9ce0a7efc2c586c0bc2b9eee6 # v3.2.1
@@ -125,7 +126,14 @@ jobs:
           registry-url: https://npm.pkg.github.com
 
       - name: Set package version
-        run: cd cli && npm version "${{ steps.gitversion.outputs.semVer }}" --no-git-tag-version --allow-same-version
+        # patch = tag-patch + aantal commits sinds de tag -> uniek en oplopend
+        # per commit, onafhankelijk van de GitVersion-modus.
+        run: |
+          cd cli
+          PATCH=$(( ${{ steps.gitversion.outputs.patch }} + ${{ steps.gitversion.outputs.commitsSinceVersionSource }} ))
+          VERSION="${{ steps.gitversion.outputs.major }}.${{ steps.gitversion.outputs.minor }}.${PATCH}"
+          echo "Berekende versie: $VERSION (patch ${{ steps.gitversion.outputs.patch }} + ${{ steps.gitversion.outputs.commitsSinceVersionSource }} commits)"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
 
       - name: Install & build
         run: cd cli && npm install && npm run build

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,13 +1,11 @@
-# GitVersion-configuratie — berekent automatisch de SemVer voor de Huddle CLI.
+# GitVersion-configuratie voor de Huddle CLI.
 #
-# Mainline-modus: elke commit op main verhoogt automatisch de patch-versie
-# (1.0.1 -> 1.0.2 -> 1.0.3 ...). Grotere bumps stuur je via de commit-message:
-#   "+semver: minor"  -> 1.1.0
-#   "+semver: major"  -> 2.0.0
-# Op feature-/fix-branches krijg je een prerelease-versie (bv. 1.0.2-fix-12.3).
+# GitVersion levert de basis-SemVer (major.minor.patch) uit de laatste git-tag
+# (het anker, bv. v1.0.1) plus `commitsSinceVersionSource` = het aantal commits
+# sinds die tag. De publish-workflow telt dat aantal bij de patch op, zodat elke
+# commit op main een unieke, oplopende versie krijgt (1.0.1 -> 1.0.2 -> ...).
+# Dit werkt onafhankelijk van de versioning-modus (en van GitVersion 5 vs 6).
 #
-# Anker: maak eenmalig een git-tag op de huidige main zodat GitVersion niet de
-# volledige historie meetelt voor het patch-nummer:
-#   git tag v1.0.1 && git push origin v1.0.1
-mode: Mainline
+# Een nieuwe minor/major zet je door een nieuwe tag te pushen, bv.:
+#   git tag v1.1.0 && git push origin v1.1.0
 next-version: 1.0.1

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Twee servers draaien in hetzelfde proces:
 
 ### 1. Maak een GitHub Personal Access Token aan
 
-Ga naar [github.com/settings/tokens](https://github.com/settings/tokens) → **Generate new token (classic)**.
+Ga naar [github.com/settings/tokens](https://github.com/settings/tokens/new?description=Huddle&scopes=read%3Apackages&default_expires_at=7) → **Generate new token (classic)**.
 
 Instellingen:
 - Expiration: **7 days** (maximaal — de infosupport-organisatie staat geen langere tokens toe)


### PR DESCRIPTION
…e tag

De publish-run gaf `semVer` = 1.0.1 terug (de tag-waarde) zonder te bumpen, waardoor `npm publish` op 409 (versie bestaat al) liep. GitVersion hoogde de patch niet op — afhankelijk van de gedraaide modus/versie bleef hij op de tag.

Nu berekent de workflow de patch als tag-patch + commitsSinceVersionSource (aantal commits sinds de tag). Dat is uniek en oplopend per commit op main, onafhankelijk van de GitVersion-modus of -versie. Verder fetch-tags: true zodat het tag-anker in CI zichtbaar is en de nummering klein en schoon blijft.