### PR TITLE
ci: bump actions naar node24-runtime (checkout/setup-node v5, docker …

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -12,25 +12,25 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./gateway
           push: true
@@ -44,25 +44,25 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push base-devimage
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: base-devimage/Dockerfile
@@ -71,7 +71,7 @@ jobs:
           tags: ghcr.io/infosupport/base-devimage:latest
 
       - name: Build and push base-devimage-vscode
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: base-devimage-vscode/Dockerfile
@@ -80,7 +80,7 @@ jobs:
           tags: ghcr.io/infosupport/base-devimage-vscode:latest
 
       - name: Build and push base-devimage-intellij
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: base-devimage-intellij/Dockerfile
@@ -89,7 +89,7 @@ jobs:
           tags: ghcr.io/infosupport/base-devimage-intellij:latest
 
       - name: Build and push base-devimage-rider
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: base-devimage-rider/Dockerfile

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -20,7 +20,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
           # GitVersion heeft de volledige historie én tags (het anker) nodig.
@@ -36,7 +36,7 @@ jobs:
         id: gitversion
         uses: gittools/actions/gitversion/execute@51d325634925d7d9ce0a7efc2c586c0bc2b9eee6 # v3.2.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           # Node 24 levert npm >= 11.5.1, vereist voor trusted publishing
           # (npm 10.x faalt met een misleidende 404).
@@ -71,7 +71,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -91,7 +91,7 @@ jobs:
           echo "tag=experiment-$ISSUE" >> "$GITHUB_OUTPUT"
           echo "Experiment-tag: experiment-$ISSUE"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           # Node 24 levert npm >= 11.5.1, vereist voor trusted publishing
           # (npm 10.x faalt met een misleidende 404).

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,11 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
 
@@ -34,12 +34,12 @@ jobs:
       packages: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
 
@@ -72,7 +72,7 @@ jobs:
           done
 
       - name: Login ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
…v4/v7)

GitHub deprecate node20 op de runners (removal 16-09-2026); node20-actions geven nu een waarschuwing en draaien op node24 by-default. Bump naar de node24-majors zodat de workflows schoon draaien.

gittools/actions blijft bewust op v3.2.1 (GitVersion 5.x): een bump naar v4 schakelt naar GitVersion 6.x en kan de berekende CLI-versie wijzigen — aparte afweging.