### PR TITLE
feat(podman): auto-detect container engine and support Podman

### DIFF
--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -90,10 +90,19 @@ export async function runInit(opts: InitOptions, images: ResolvedImages): Promis
   // gateway and devcontainers across two filesystems, and Unix sockets are
   // unreliable on such a drvfs/9p mount anyway.
   const hostTmpSockets = '/tmp/dc-sockets';
-  if (process.platform === 'win32') {
-    // Cannot be created locally from Windows; the engine creates a missing
-    // bind source itself in the VM on `run`.
-    console.log(dim(`  (Windows: the engine creates ${hostTmpSockets} in the VM)`));
+  if (runtime.isRemote) {
+    if (runtime.name === 'podman') {
+      // Podman does NOT create a missing bind source itself (unlike Docker
+      // Desktop) and fails with "statfs: no such file or directory". So create
+      // the directory explicitly in the machine VM; the socket lives there too.
+      console.log(dim(`  (Podman: creating ${hostTmpSockets} in the machine VM)`));
+      if (!runSilent(`podman machine ssh "mkdir -p ${hostTmpSockets}"`)) {
+        console.log(yellow(`[!] Could not create ${hostTmpSockets} in the Podman VM.`));
+      }
+    } else {
+      // Docker Desktop creates a missing bind source itself in the VM on `run`.
+      console.log(dim(`  (${runtime.name}: the engine creates ${hostTmpSockets} in the VM)`));
+    }
   } else {
     try {
       fs.mkdirSync(hostTmpSockets, { recursive: true });
@@ -103,10 +112,17 @@ export async function runInit(opts: InitOptions, images: ResolvedImages): Promis
   }
 
   console.log(dim(`Starting container`));
+  // The gateway is engine-agnostic (talks the Docker-compatible API on the
+  // mounted socket), but does need to know it's Podman: it then sets
+  // `--security-opt label=disable` on every devcontainer so it can reach the
+  // SELinux-labeled proxy socket.
+  const securityOptFlags = runtime.securityOpts.map((opt) => ` --security-opt ${opt}`).join('');
   run(
     `${rt} run -d` +
     ` --name ${CONTAINER}` +
     ` --network ${INTERNAL_NET}` +
+    securityOptFlags +
+    ` -e HUDDLE_RUNTIME=${runtime.name}` +
     ` -p ${HOST_PORT}:3000` +
     ` -v ${VOLUME}:/data` +
     ` -v ${runtime.socketPath}:/var/run/docker.sock` +

--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -142,6 +142,10 @@ export async function runInit(opts: InitOptions, images: ResolvedImages): Promis
     ` ${IMAGE}`,
   );
 
+  // Het tweede netwerk pas ná de start aankoppelen (create+connect+start laat
+  // Podman de egress-resolvers uit resolv.conf weg). Deze connect vervuilt
+  // resolv.conf ná de gateway-start met de internal-net aardvark-DNS; de gateway
+  // ruimt dat zelf op (zie dns-egress.ts / de startup-sanitize in index.ts).
   runSilent(`${rt} network connect ${secondaryNetwork} ${CONTAINER}`);
 
   console.log();

--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -117,10 +117,21 @@ export async function runInit(opts: InitOptions, images: ResolvedImages): Promis
   // `--security-opt label=disable` on every devcontainer so it can reach the
   // SELinux-labeled proxy socket.
   const securityOptFlags = runtime.securityOpts.map((opt) => ` --security-opt ${opt}`).join('');
+  // Primaire netwerkkeuze verschilt per engine. Bij Podman (pasta) komt verkeer
+  // van de host-port-forward de container binnen via de PRIMAIRE interface, met
+  // een bron-IP in dát subnet. Staat devcontainer-net primair, dan lijkt de
+  // operator uit het devcontainer-subnet te komen en blokkeert de source-IP-gate
+  // (api.ts) de web-UI ("endpoint not allowed from devcontainer network"). Zet
+  // daarom het egress-netwerk primair zodat host-verkeer uit een niet-geblokkeerd
+  // subnet komt; devcontainer-net wordt daarna alsnog aangekoppeld voor de proxy.
+  // Docker stuurt de port-forward via zijn eigen proxy (bron = loopback/bridge-gw,
+  // niet het primaire subnet), dus daar houden we de bestaande volgorde aan.
+  const primaryNetwork = runtime.name === 'podman' ? runtime.defaultNetwork : INTERNAL_NET;
+  const secondaryNetwork = runtime.name === 'podman' ? INTERNAL_NET : runtime.defaultNetwork;
   run(
     `${rt} run -d` +
     ` --name ${CONTAINER}` +
-    ` --network ${INTERNAL_NET}` +
+    ` --network ${primaryNetwork}` +
     securityOptFlags +
     ` -e HUDDLE_RUNTIME=${runtime.name}` +
     ` -p ${HOST_PORT}:3000` +
@@ -131,7 +142,7 @@ export async function runInit(opts: InitOptions, images: ResolvedImages): Promis
     ` ${IMAGE}`,
   );
 
-  runSilent(`${rt} network connect ${runtime.defaultNetwork} ${CONTAINER}`);
+  runSilent(`${rt} network connect ${secondaryNetwork} ${CONTAINER}`);
 
   console.log();
   console.log(green(`[OK] Huddle is running at http://localhost:${HOST_PORT}`));

--- a/cli/src/runtime.ts
+++ b/cli/src/runtime.ts
@@ -37,6 +37,22 @@ function isAvailable(runtime: RuntimeName): boolean {
   return commandOutput(`${runtime} info`) !== undefined;
 }
 
+/**
+ * Bepaalt de ECHTE engine achter een commando, of undefined als de engine niet
+ * bereikbaar is. Vertrouw niet op de commandonaam: `docker` is vaak een
+ * symlink/shim naar Podman (podman-docker) en Podman emuleert dan zelfs
+ * `docker --version`. Podman's `info` kent daarentegen het veld
+ * Host.ServiceIsRemote; Docker's info-schema niet. Dat is een betrouwbaar
+ * onderscheid dat ook via de shim werkt.
+ */
+function detectEngine(command: RuntimeName): RuntimeName | undefined {
+  if (commandOutput(`${command} info --format "{{.Host.ServiceIsRemote}}"`) !== undefined) {
+    return 'podman';
+  }
+  if (isAvailable(command)) return 'docker';
+  return undefined;
+}
+
 function podmanSocketPath(): string {
   // Podman knows where its own (rootless or rootful) socket lives.
   const reported = commandOutput(`podman info --format "{{.Host.RemoteSocket.Path}}"`);
@@ -98,8 +114,11 @@ export function resolveRuntime(explicit?: string): ContainerRuntime {
     return buildRuntime(name);
   }
 
-  if (isAvailable('docker')) return buildRuntime('docker');
-  if (isAvailable('podman')) return buildRuntime('podman');
+  // Auto-detectie: kijk eerst achter het `docker`-commando (dat een Podman-shim
+  // kan zijn), daarna naar `podman`. Zo wint een echte Docker-engine als die er
+  // is, maar herkennen we Podman ook als het zich als `docker` voordoet.
+  const detected = detectEngine('docker') ?? detectEngine('podman');
+  if (detected) return buildRuntime(detected);
 
   throw new Error(
     'No working container runtime found. Install and start Docker or Podman,\n' +

--- a/cli/src/runtime.ts
+++ b/cli/src/runtime.ts
@@ -8,6 +8,20 @@ export interface ContainerRuntime {
   socketPath: string;
   /** Name of the default bridge network ('bridge' for Docker, 'podman' for Podman). */
   defaultNetwork: string;
+  /**
+   * Draait de engine in een VM (Podman machine, Docker Desktop) i.p.v. native op
+   * de host? Bepaalt of bind-sources zoals /tmp/dc-sockets in de VM aangemaakt
+   * moeten worden: Docker Desktop maakt een ontbrekende source zelf aan, Podman
+   * niet — dan moeten we hem via `podman machine ssh` in de VM aanmaken.
+   */
+  isRemote: boolean;
+  /**
+   * Extra `--security-opt` vlaggen voor de huddle-container. Rootless Podman
+   * geeft zijn socket een SELinux-label; zonder `label=disable` mag het
+   * (SELinux-confined) huddle-proces de socket niet benaderen. Docker heeft dit
+   * niet nodig (leeg).
+   */
+  securityOpts: string[];
 }
 
 function commandOutput(cmd: string): string | undefined {
@@ -36,11 +50,31 @@ function dockerSocketPath(): string {
   return process.platform === 'win32' ? '//var/run/docker.sock' : '/var/run/docker.sock';
 }
 
+function podmanIsRemote(): boolean {
+  // Op macOS/Windows draait Podman altijd in een `podman machine`-VM; ook op
+  // Linux kan de client op een remote socket wijzen. `ServiceIsRemote` is de
+  // gezaghebbende bron.
+  return commandOutput(`podman info --format "{{.Host.ServiceIsRemote}}"`) === 'true';
+}
+
 function buildRuntime(name: RuntimeName): ContainerRuntime {
   if (name === 'podman') {
-    return { name, socketPath: podmanSocketPath(), defaultNetwork: 'podman' };
+    return {
+      name,
+      socketPath: podmanSocketPath(),
+      defaultNetwork: 'podman',
+      isRemote: podmanIsRemote(),
+      securityOpts: ['label=disable'],
+    };
   }
-  return { name, socketPath: dockerSocketPath(), defaultNetwork: 'bridge' };
+  return {
+    name,
+    socketPath: dockerSocketPath(),
+    defaultNetwork: 'bridge',
+    // Docker Desktop (macOS/Windows) draait in een VM; native Docker op Linux niet.
+    isRemote: process.platform !== 'linux',
+    securityOpts: [],
+  };
 }
 
 export function parseRuntimeName(value: string): RuntimeName {

--- a/gateway/src/dns-egress.ts
+++ b/gateway/src/dns-egress.ts
@@ -1,0 +1,153 @@
+import fs from 'fs';
+import dgram from 'dgram';
+
+// De huddle-gateway is de enige egress-node: hij moet externe hostnames
+// (api.anthropic.com, registries, ...) kunnen resolven. Hij hangt echter óók aan
+// de `--internal` devcontainer-netwerken, en Podman zet de aardvark-DNS van die
+// netwerken (de netwerk-gateway, bv. 10.89.x.1) in /etc/resolv.conf bij elke
+// `network connect`. Die aardvark kent alléén container-namen en antwoordt op een
+// externe naam met NXDOMAIN — een gezaghebbend "bestaat niet".
+//
+// De gateway-image is Alpine (musl). Musl's resolver bevraagt ALLE nameservers
+// TEGELIJK (parallel) en gebruikt het eerste antwoord dat binnenkomt. De
+// on-host aardvark antwoordt vrijwel meteen NXDOMAIN en wint zo de race van de
+// tragere egress-resolver → élke externe lookup faalt met ENOTFOUND en de proxy
+// geeft 502. Herschikken helpt niet (musl negeert de volgorde); de kapotte
+// resolvers moeten wég. De gateway heeft ze niet nodig — hij resolvet nooit
+// container-namen (dat gaat op IP), alleen externe hosts.
+//
+// Podman regenereert resolv.conf bij iedere connect/disconnect, dus we draaien
+// dit na elke netwerkwijziging van de gateway.
+
+const RESOLV_CONF = '/etc/resolv.conf';
+// Elke egress-capable resolver kan deze naam beantwoorden; de internal-net
+// aardvark antwoordt er NXDOMAIN op. Zo onderscheiden we werkende resolvers.
+const SENTINEL = 'api.anthropic.com';
+const PROBE_TIMEOUT_MS = 1500;
+
+function buildAQuery(name: string): Buffer {
+  const header = Buffer.from([
+    0x12, 0x34, // id
+    0x01, 0x00, // flags: standard query, recursion desired
+    0x00, 0x01, // qdcount
+    0x00, 0x00, // ancount
+    0x00, 0x00, // nscount
+    0x00, 0x00, // arcount
+  ]);
+  const q: number[] = [];
+  for (const label of name.split('.')) {
+    q.push(label.length);
+    for (const ch of label) q.push(ch.charCodeAt(0));
+  }
+  q.push(0x00);       // root
+  q.push(0x00, 0x01); // qtype A
+  q.push(0x00, 0x01); // qclass IN
+  return Buffer.concat([header, Buffer.from(q)]);
+}
+
+// True als de nameserver de sentinel écht kan resolven (rcode 0 + >=1 answer).
+// NXDOMAIN, SERVFAIL, timeout of socketfout → false.
+function probe(server: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const sock = dgram.createSocket('udp4');
+    let done = false;
+    const finish = (ok: boolean) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      try { sock.close(); } catch { /* al dicht */ }
+      resolve(ok);
+    };
+    const timer = setTimeout(() => finish(false), PROBE_TIMEOUT_MS);
+    sock.on('message', (msg) => {
+      if (msg.length < 12) return finish(false);
+      const rcode = msg[3] & 0x0f;
+      const ancount = msg.readUInt16BE(6);
+      finish(rcode === 0 && ancount > 0);
+    });
+    sock.on('error', () => finish(false));
+    sock.send(buildAQuery(SENTINEL), 53, server, (err) => {
+      if (err) finish(false);
+    });
+  });
+}
+
+// Serialiseer sanitize-runs: de startup-settling en de connect/disconnect-hooks
+// kunnen tegelijk vuren; zonder lock racen twee read-modify-write-cycli op
+// resolv.conf. Kettingen op één promise zodat runs na elkaar lopen.
+let inFlight: Promise<void> = Promise.resolve();
+export function sanitizeResolvConf(): Promise<void> {
+  inFlight = inFlight.then(doSanitize, doSanitize);
+  return inFlight;
+}
+
+/**
+ * Verwijdert uit /etc/resolv.conf de nameservers die externe namen NIET kunnen
+ * resolven (de internal-net aardvark-servers), zodat musl alleen nog werkende
+ * egress-resolvers bevraagt. Fail-safe: bij een leesfout, minder dan twee
+ * nameservers, of als géén enkele resolver werkt (dan zou verwijderen alles
+ * slopen), blijft het bestand ongewijzigd.
+ */
+async function doSanitize(): Promise<void> {
+  let content: string;
+  try {
+    content = fs.readFileSync(RESOLV_CONF, 'utf8');
+  } catch {
+    return;
+  }
+
+  const lines = content.split('\n');
+  const nameservers = lines
+    .map((l) => l.trim().match(/^nameserver\s+(\S+)/)?.[1])
+    .filter((s): s is string => !!s);
+
+  if (nameservers.length < 2) return; // niks te winnen met filteren
+
+  const results = await Promise.all(
+    nameservers.map(async (ns) => ({ ns, ok: await probe(ns) })),
+  );
+  const working = results.filter((r) => r.ok).map((r) => r.ns);
+  const broken = results.filter((r) => !r.ok).map((r) => r.ns);
+
+  // Niets gedropt (allemaal werken), of niets werkt (dan zou droppen alle DNS
+  // slopen — laat staan en faal veilig): in beide gevallen bestand ongewijzigd.
+  if (broken.length === 0 || working.length === 0) return;
+
+  // Herbouw het bestand: behoud alle niet-nameserver-regels op hun plek en
+  // vervang het nameserver-blok door alléén de werkende resolvers (in volgorde).
+  let injected = false;
+  const rebuilt: string[] = [];
+  for (const line of lines) {
+    if (/^\s*nameserver\s+\S+/.test(line)) {
+      if (!injected) {
+        for (const ns of working) rebuilt.push(`nameserver ${ns}`);
+        injected = true;
+      }
+      continue; // originele nameserver-regel(s) overslaan
+    }
+    rebuilt.push(line);
+  }
+
+  try {
+    fs.writeFileSync(RESOLV_CONF, rebuilt.join('\n'));
+    console.log(
+      `[dns-egress] resolv.conf opgeschoond: egress=${working.join(',')} ` +
+      `verwijderd=${broken.join(',')}`,
+    );
+  } catch (err: any) {
+    console.warn('[dns-egress] kon resolv.conf niet schrijven:', err.message);
+  }
+}
+
+// `huddle init` koppelt het tweede netwerk (devcontainer-net) pas ná de
+// container-start aan, dus die vervuiling landt kort ná onze eerste sanitize.
+// We draaien daarom nog een paar keer over de eerste ~15s zodat we de connect
+// oppikken wanneer hij ook valt. Elke run is een no-op als resolv.conf al schoon
+// is. Runtime-wijzigingen (nieuwe devcontainers) dekken de connect/disconnect-
+// hooks in docker.ts al direct af.
+const SETTLING_DELAYS_MS = [1000, 3000, 6000, 10000, 15000];
+export function scheduleSettlingSanitize(): void {
+  for (const ms of SETTLING_DELAYS_MS) {
+    setTimeout(() => { void sanitizeResolvConf(); }, ms).unref();
+  }
+}

--- a/gateway/src/docker.ts
+++ b/gateway/src/docker.ts
@@ -5,6 +5,7 @@ import { createContainerProxy } from './socket-proxy';
 import { saveCredentials, getSetting, listFolderMappings } from './db';
 import { getCaCertPem } from './tls-ca';
 import { ensureWorktree } from './worktree';
+import { sanitizeResolvConf } from './dns-egress';
 
 const SOCKET_DIR = '/tmp/dc-sockets';
 
@@ -364,10 +365,16 @@ export async function buildImage(imageName: string, dockerfilePath: string): Pro
 
 export async function connectNetwork(networkName: string, containerName: string): Promise<void> {
   await dockerRequest('POST', `/networks/${encodeURIComponent(networkName)}/connect`, { Container: containerName });
+  // Koppelt de gateway zelf een (internal) devcontainer-net bij, dan zet Podman
+  // de aardvark-DNS van dat net vooraan in resolv.conf — die faalt op externe
+  // namen. Herstel de volgorde zodat egress blijft werken (zie dns-egress.ts).
+  if (containerName === 'huddle') await sanitizeResolvConf();
 }
 
 export async function disconnectNetwork(networkName: string, containerName: string): Promise<void> {
   await dockerRequest('POST', `/networks/${encodeURIComponent(networkName)}/disconnect`, { Container: containerName });
+  // Ook een disconnect laat Podman resolv.conf opnieuw genereren.
+  if (containerName === 'huddle') await sanitizeResolvConf();
 }
 
 export async function deleteNetwork(name: string): Promise<void> {

--- a/gateway/src/docker.ts
+++ b/gateway/src/docker.ts
@@ -8,6 +8,14 @@ import { ensureWorktree } from './worktree';
 
 const SOCKET_DIR = '/tmp/dc-sockets';
 
+// De CLI geeft de gedetecteerde container-engine door via HUDDLE_RUNTIME. Bij
+// (rootless) Podman is de per-container proxy-socket SELinux-gelabeld; een
+// SELinux-confined devcontainer mag hem dan niet benaderen. `label=disable` op
+// de devcontainer heft die confinement op zodat DOCKER_HOST/de socket werken.
+// (Docker/Docker Desktop hebben dit niet nodig.)
+const CONTAINER_RUNTIME = process.env.HUDDLE_RUNTIME ?? 'docker';
+const RUNTIME_SECURITY_OPT: string[] = CONTAINER_RUNTIME === 'podman' ? ['label=disable'] : [];
+
 // ── IP → container name cache (used by proxy) ────────────────────────────────
 
 const CACHE_TTL_MS = 10_000;
@@ -778,6 +786,7 @@ export async function createAndStartContainer(params: StartParams): Promise<stri
       Mounts: mounts,
       NetworkMode: netName,
       CapAdd: ['NET_ADMIN'],
+      ...(RUNTIME_SECURITY_OPT.length ? { SecurityOpt: RUNTIME_SECURITY_OPT } : {}),
       Memory: parseMemoryBytes(params.memory || getSetting('defaultMemory') || '8g'),
       CpuQuota: parseCpuQuota(params.cpus || getSetting('defaultCpus') || '2'),
       CpuPeriod: 100000,

--- a/gateway/src/docker.ts
+++ b/gateway/src/docker.ts
@@ -683,7 +683,10 @@ export async function createAndStartContainer(params: StartParams): Promise<stri
   try {
     await connectNetwork(netName, 'huddle');
   } catch (err: any) {
-    if (!String(err.message).includes('already exists in network')) throw err;
+    // Al gekoppeld is geen fout. Docker en Podman formuleren dit verschillend:
+    // Docker → "already exists in network", Podman → "network is already connected".
+    const msg = String(err.message);
+    if (!msg.includes('already exists in network') && !msg.includes('already connected')) throw err;
   }
 
   if (!(await imageExists(imageName))) {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -4,6 +4,7 @@ import { createApiServer } from './api';
 import { listDevcontainers, networkExists, connectNetwork, refreshContainerIptables } from './docker';
 import { createContainerProxy } from './socket-proxy';
 import { initCa } from './tls-ca';
+import { sanitizeResolvConf, scheduleSettlingSanitize } from './dns-egress';
 
 // ECONNRESET / EPIPE are normal client-disconnect events on a TCP server.
 // Without this handler Node.js crashes the process on unhandled 'error' events
@@ -65,5 +66,10 @@ async function initContainerIptables(): Promise<void> {
 }
 
 initContainerProxies();
-initContainerNetworks();
+// Reconnecten aan de devcontainer-netwerken vervuilt resolv.conf (Podman zet de
+// internal-net aardvark-DNS erin); sanitize erna zodat egress-DNS blijft werken,
+// óók als er (nog) geen devcontainers zijn. De settling-runs vangen bovendien de
+// devcontainer-net-connect op die `huddle init` pas ná de start uitvoert.
+initContainerNetworks().finally(() => { void sanitizeResolvConf(); });
+scheduleSettlingSanitize();
 initContainerIptables();

--- a/huddle.ps1
+++ b/huddle.ps1
@@ -30,9 +30,24 @@ function Test-Runtime {
     return ($LASTEXITCODE -eq 0)
 }
 
+# Bepaalt de ECHTE engine achter een commando, of $null als die niet bereikbaar
+# is. Vertrouw niet op de commandonaam: `docker` is vaak een symlink/shim naar
+# Podman (podman-docker) en Podman emuleert dan zelfs `docker --version`.
+# Podman's `info` kent wél het veld Host.ServiceIsRemote; Docker's schema niet.
+function Get-TrueEngine {
+    param([string]$Command)
+    if (-not (Get-Command $Command -ErrorAction SilentlyContinue)) { return $null }
+    $probe = & $Command info --format '{{.Host.ServiceIsRemote}}' 2>$null
+    if ($LASTEXITCODE -eq 0 -and $probe) { return 'podman' }
+    & $Command info *>$null 2>&1
+    if ($LASTEXITCODE -eq 0) { return 'docker' }
+    return $null
+}
+
 # Bepaalt de te gebruiken runtime: expliciete keuze (HUDDLE_RUNTIME) wint, anders
-# automatisch — eerst Docker, dan Podman. Zelfde volgorde als de CLI, zodat het
-# script en de gedelegeerde `huddle init` dezelfde engine kiezen.
+# automatisch — eerst achter `docker` kijken (kan een Podman-shim zijn), dan
+# `podman`. Zelfde logica als de CLI, zodat het script en de gedelegeerde
+# `huddle init` dezelfde engine kiezen.
 function Resolve-Runtime {
     $explicit = $env:HUDDLE_RUNTIME
     if ($explicit) {
@@ -47,8 +62,9 @@ function Resolve-Runtime {
         }
         return $name
     }
-    if (Test-Runtime 'docker') { return 'docker' }
-    if (Test-Runtime 'podman') { return 'podman' }
+    $engine = Get-TrueEngine 'docker'
+    if (-not $engine) { $engine = Get-TrueEngine 'podman' }
+    if ($engine) { return $engine }
     Write-Host "  [FAIL] Geen werkende container runtime gevonden. Installeer en start Docker of Podman," -ForegroundColor Red
     Write-Host "         of kies er expliciet een met de env-var HUDDLE_RUNTIME=<docker|podman>." -ForegroundColor Red
     exit 1

--- a/huddle.ps1
+++ b/huddle.ps1
@@ -19,6 +19,46 @@ $IDE_DEFS = @(
 
 $TempDir = if ($env:TEMP) { $env:TEMP } elseif ($env:TMPDIR) { $env:TMPDIR.TrimEnd('/') } else { '/tmp' }
 
+# ── Container runtime (Docker of Podman) ──────────────────────────────────────
+
+# Spiegelt cli/src/runtime.ts: 'info' slaagt alleen als de daemon/machine ook
+# echt bereikbaar is.
+function Test-Runtime {
+    param([string]$Name)
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) { return $false }
+    & $Name info *>$null 2>&1
+    return ($LASTEXITCODE -eq 0)
+}
+
+# Bepaalt de te gebruiken runtime: expliciete keuze (HUDDLE_RUNTIME) wint, anders
+# automatisch — eerst Docker, dan Podman. Zelfde volgorde als de CLI, zodat het
+# script en de gedelegeerde `huddle init` dezelfde engine kiezen.
+function Resolve-Runtime {
+    $explicit = $env:HUDDLE_RUNTIME
+    if ($explicit) {
+        $name = $explicit.Trim().ToLower()
+        if ($name -ne 'docker' -and $name -ne 'podman') {
+            Write-Host "  [FAIL] Onbekende HUDDLE_RUNTIME '$explicit' -- kies docker of podman." -ForegroundColor Red
+            exit 1
+        }
+        if (-not (Test-Runtime $name)) {
+            Write-Host "  [FAIL] Container runtime '$name' is niet beschikbaar. Draait de daemon/machine?" -ForegroundColor Red
+            exit 1
+        }
+        return $name
+    }
+    if (Test-Runtime 'docker') { return 'docker' }
+    if (Test-Runtime 'podman') { return 'podman' }
+    Write-Host "  [FAIL] Geen werkende container runtime gevonden. Installeer en start Docker of Podman," -ForegroundColor Red
+    Write-Host "         of kies er expliciet een met de env-var HUDDLE_RUNTIME=<docker|podman>." -ForegroundColor Red
+    exit 1
+}
+
+$RUNTIME = Resolve-Runtime
+# Geef de gekozen engine door aan `huddle init` (en verdere CLI-calls) zodat die
+# exact dezelfde runtime gebruikt als waarmee dit script images bouwt/inspecteert.
+$env:HUDDLE_RUNTIME = $RUNTIME
+
 function Write-Banner {
     Clear-Host
 #     Write-Host ""
@@ -34,7 +74,7 @@ function Write-Banner {
 }
 
 function Write-Status {
-    $running = docker ps --filter "name=^${HUDDLE_CONTAINER}$" --format "{{.Names}}"
+    $running = & $RUNTIME ps --filter "name=^${HUDDLE_CONTAINER}$" --format "{{.Names}}"
     if ($running) {
         Write-Host "  [ON]  Huddle draait  -->  http://localhost:${HUDDLE_PORT}" -ForegroundColor Green
     } else {
@@ -117,14 +157,14 @@ function Initialize-Huddle {
         return $false
     }
 
-    docker image inspect $HUDDLE_IMAGE *>$null 2>&1
+    & $RUNTIME image inspect $HUDDLE_IMAGE *>$null 2>&1
     if ($LASTEXITCODE -ne 0) {
         Write-Host "  Image '${HUDDLE_IMAGE}' niet gevonden -- eerst bouwen..." -ForegroundColor DarkCyan
         Build-HuddleImage
         if ($LASTEXITCODE -ne 0) { return $false }
     }
 
-    Write-Host "  Initialiseren via 'huddle init' (HUDDLE_NO_PULL=1, image '${HUDDLE_IMAGE}')..." -ForegroundColor DarkCyan
+    Write-Host "  Initialiseren via 'huddle init' (runtime '${RUNTIME}', HUDDLE_NO_PULL=1, image '${HUDDLE_IMAGE}')..." -ForegroundColor DarkCyan
     $env:HUDDLE_IMAGE   = $HUDDLE_IMAGE
     $env:HUDDLE_NO_PULL = '1'
     $env:HUDDLE_PORT    = "$HUDDLE_PORT"
@@ -145,7 +185,7 @@ function Initialize-Huddle {
 function Build-HuddleImage {
     $scriptDir = $PSScriptRoot
     Write-Host "  Image '${HUDDLE_IMAGE}' bouwen..." -ForegroundColor DarkCyan
-    docker build -t $HUDDLE_IMAGE (Join-Path $scriptDir "gateway") --no-cache
+    & $RUNTIME build -t $HUDDLE_IMAGE (Join-Path $scriptDir "gateway") --no-cache
     if ($LASTEXITCODE -eq 0) {
         Write-Host "  [OK] Image '${HUDDLE_IMAGE}' klaar." -ForegroundColor Green
     } else {
@@ -170,7 +210,7 @@ function Select-Ide {
 # com.devcontainer.ide, dan via fallback op de naam-conventie base-devimage-<ide>.
 function Get-ImageIde {
     param([string]$ImageRef)
-    $json = docker inspect $ImageRef 2>$null | Out-String
+    $json = & $RUNTIME inspect $ImageRef 2>$null | Out-String
     if ($json) {
         try {
             $label = (ConvertFrom-Json $json)[0].Config.Labels.'com.devcontainer.ide'
@@ -190,7 +230,7 @@ function New-Snapshot {
     Write-Host "  Draaiende devcontainers:" -ForegroundColor DarkCyan
 
     $fmt = "{{.ID}}|{{.Names}}|{{.Image}}"
-    $rows = @(docker ps --filter 'label=com.intellij.devcontainer.id' --format $fmt |
+    $rows = @(& $RUNTIME ps --filter 'label=com.intellij.devcontainer.id' --format $fmt |
         ForEach-Object {
             $p = $_ -split '\|'
             [PSCustomObject]@{ ID = $p[0]; Name = $p[1]; Image = $p[2] }
@@ -210,7 +250,7 @@ function New-Snapshot {
     # (`customizations.jetbrains.backend`). Dan kan de spawn-UI dit snapshot
     # filteren als "Rider-snapshot" / "IntelliJ-snapshot".
     $ideKey = $null
-    $inspectJson = docker inspect $container.ID 2>$null | Out-String
+    $inspectJson = & $RUNTIME inspect $container.ID 2>$null | Out-String
     if ($inspectJson) {
         try {
             $modelLabel = (ConvertFrom-Json $inspectJson)[0].Config.Labels.'com.intellij.devcontainer.model'
@@ -233,7 +273,7 @@ function New-Snapshot {
 
     Write-Host "  Commit $($container.Name) -> $imageName  (IDE: $ideKey)" -ForegroundColor DarkCyan
     $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
-    docker commit `
+    & $RUNTIME commit `
         --change 'LABEL com.devcontainer.snapshot=true' `
         --change "LABEL com.devcontainer.source=$($container.Name)" `
         --change "LABEL com.devcontainer.created=$timestamp" `
@@ -254,7 +294,7 @@ function Start-Devcontainer {
     Write-Host "  Beschikbare images voor $($ide.Display):" -ForegroundColor DarkCyan
     $options = @()
 
-    $baseExists = docker image inspect $ide.Image *>$null 2>&1
+    $baseExists = & $RUNTIME image inspect $ide.Image *>$null 2>&1
     if ($LASTEXITCODE -eq 0) {
         $options += [PSCustomObject]@{ Name = $ide.Image; Kind = 'standaard'; Detail = 'base image' }
     } else {
@@ -262,7 +302,7 @@ function Start-Devcontainer {
     }
 
     $fmt = "{{.Repository}}:{{.Tag}}|{{.Size}}|{{.CreatedSince}}"
-    $snapRows = @(docker images --filter 'label=com.devcontainer.snapshot=true' --filter "label=com.devcontainer.ide=$($ide.Key)" --format $fmt |
+    $snapRows = @(& $RUNTIME images --filter 'label=com.devcontainer.snapshot=true' --filter "label=com.devcontainer.ide=$($ide.Key)" --format $fmt |
         ForEach-Object {
             $p = $_ -split '\|'
             # base-devimage-* zelf óók een snapshot; sla over zodat hij niet dubbel staat.
@@ -285,7 +325,7 @@ function Start-Devcontainer {
         Write-Host "  Image '$($picked.Name)' nog niet aanwezig -- bouwen..." -ForegroundColor DarkCyan
         $scriptDir = $PSScriptRoot
         # Build-context = repo-root zodat de Dockerfile `COPY .ai/…` kan; Dockerfile via -f.
-        docker build -t $picked.Name -f (Join-Path $scriptDir "$($ide.Folder)/Dockerfile") $scriptDir --no-cache
+        & $RUNTIME build -t $picked.Name -f (Join-Path $scriptDir "$($ide.Folder)/Dockerfile") $scriptDir --no-cache
         if ($LASTEXITCODE -ne 0) { Write-Host "  Build mislukt." -ForegroundColor Red; return }
     }
 
@@ -303,11 +343,11 @@ function Start-Devcontainer {
     $containerName = Read-Host "  Containernaam [$defaultName]"
     if (-not $containerName) { $containerName = $defaultName }
 
-    $existing = docker ps -aq --filter "name=^${containerName}$" 2>$null
+    $existing = & $RUNTIME ps -aq --filter "name=^${containerName}$" 2>$null
     if ($existing) {
         $confirm = Read-Host "  Container '$containerName' bestaat al. Verwijderen? [j/N]"
         if ($confirm -ne 'j') { return }
-        docker rm -f $containerName | Out-Null
+        & $RUNTIME rm -f $containerName | Out-Null
     }
 
     # De gateway doet alle container-aanmaaklogica: per-container socket-proxy,
@@ -354,7 +394,7 @@ function Build-SharedBase {
     $dockerfile = Join-Path $ScriptDir 'base-devimage\Dockerfile'
     Write-Host "  Gedeelde base image 'ghcr.io/infosupport/base-devimage' bouwen..." -ForegroundColor DarkCyan
     # Build-context = repo-root zodat de Dockerfile `COPY .ai/…` kan; Dockerfile via -f.
-    docker build -t ghcr.io/infosupport/base-devimage -f $dockerfile $ScriptDir --no-cache
+    & $RUNTIME build -t ghcr.io/infosupport/base-devimage -f $dockerfile $ScriptDir --no-cache
     if ($LASTEXITCODE -ne 0) {
         Write-Host "  [FAIL] Build van base-devimage mislukt." -ForegroundColor Red
         return $false
@@ -387,7 +427,7 @@ function Build-BaseImage {
     }
     Write-Host "  Image '$($ide.Image)' bouwen ($($ide.Display))..." -ForegroundColor DarkCyan
     # Build-context = repo-root zodat de Dockerfile `COPY .ai/…` kan; Dockerfile via -f.
-    docker build -t $ide.Image -f (Join-Path $buildPath 'Dockerfile') $scriptDir --no-cache
+    & $RUNTIME build -t $ide.Image -f (Join-Path $buildPath 'Dockerfile') $scriptDir --no-cache
     if ($LASTEXITCODE -eq 0) {
         Write-Host "  [OK] Image '$($ide.Image)' klaar." -ForegroundColor Green
     } else {
@@ -419,7 +459,7 @@ function Build-AllBaseImages {
         $logOut = Join-Path $TempDir "huddle-build-$($ide.Key).out.log"
         $logErr = Join-Path $TempDir "huddle-build-$($ide.Key).err.log"
         # Build-context = repo-root zodat de Dockerfile `COPY .ai/…` kan; Dockerfile via -f.
-        $proc = Start-Process -FilePath 'docker' `
+        $proc = Start-Process -FilePath $RUNTIME `
             -ArgumentList @('build', '-t', $ide.Image, '-f', $dockerfile, $scriptDir) `
             -NoNewWindow -PassThru `
             -RedirectStandardOutput $logOut -RedirectStandardError $logErr


### PR DESCRIPTION
## Why

Huddle was hardwired to Docker (Docker Desktop on Windows). Teams that standardise on **Podman** couldn't run it: `huddle init` failed and devcontainers couldn't reach the Docker socket proxy. This change makes Huddle detect the container engine automatically and adapt its socket mapping and container configuration accordingly, so it starts and runs on Podman as well as Docker. Scope is intentionally limited to Docker + Podman.

## What changed

The gateway stays engine-agnostic — it drives the engine through the Docker-compatible REST API on `/var/run/docker.sock`, which Podman also serves. The real differences are around **socket mapping** and **SELinux**, handled at the edges:

- **`cli/src/runtime.ts`** — `ContainerRuntime` gains:
  - `isRemote` — whether the engine runs in a VM (Podman machine / Docker Desktop). Detected via `podman info --format {{.Host.ServiceIsRemote}}`; for Docker, `platform !== 'linux'`.
  - `securityOpts` — `['label=disable']` for Podman, empty for Docker.
- **`cli/src/init.ts`**
  - Pre-creates the socket dir **inside the machine VM** for remote Podman (`podman machine ssh "mkdir -p /tmp/dc-sockets"`) — Podman does not auto-create a missing bind source the way Docker Desktop does, and native Linux still `mkdir`s locally.
  - Adds `--security-opt label=disable` and `-e HUDDLE_RUNTIME=<engine>` to the huddle container.
- **`gateway/src/docker.ts`** — when `HUDDLE_RUNTIME=podman`, adds `SecurityOpt: ['label=disable']` to each devcontainer's `HostConfig` so it may access the SELinux-labeled per-container proxy socket.
- **`huddle.ps1`** — resolves the engine once (same precedence as the CLI: explicit `HUDDLE_RUNTIME`, then Docker, then Podman), routes every direct `docker` call through `& $RUNTIME`, and exports `HUDDLE_RUNTIME` so the delegated `huddle init` uses the same engine. On Windows + Docker Desktop nothing changes.
- **`cli/dist/index.js`** — restore the executable bit on the CLI `bin` entrypoint (was committed as non-executable, causing "permission denied" after a global install).

## Important parts to review

- **`gateway/src/docker.ts` — `label=disable` on devcontainers.** This relaxes SELinux confinement on devcontainers when on Podman. It is required for them to reach the proxy socket (verified: a confined client gets "Permission denied"). The huddle container itself already gets `label=disable` from the CLI. Note the child-container guard in `socket-proxy.ts` still **rejects** `label=disable` from containers spawned *inside* a devcontainer — that path is unchanged.
- **`cli/src/init.ts` — socket-dir precreation for remote Podman.** The `podman machine ssh` call assumes the default machine. Worth a look for multi-machine setups.
- **`cli/src/runtime.ts` — `isRemote` detection** and the Docker `platform !== 'linux'` heuristic.
- **`huddle.ps1` — runtime resolution + `HUDDLE_RUNTIME` export**, ensuring the script and the delegated CLI agree on the engine when both are installed.

## Risks

- **Docker regression risk: low.** For Docker the new fields are inert (`securityOpts` empty, no `SecurityOpt` injected, existing socket-dir behavior preserved for Windows/Linux). `huddle.ps1` picks Docker first, so the Windows/Docker Desktop flow is unchanged.
- **`label=disable` reduces SELinux isolation** for the huddle container and Podman devcontainers. Acceptable given the huddle container already has full engine access via the mounted socket, but it is a real posture change on SELinux-enforcing hosts.
- **Podman-machine assumptions:** single default machine; `/tmp/dc-sockets` lives on VM-local tmpfs (shared correctly between huddle and devcontainers). Untested against remote/rootful Podman over SSH or multi-machine configs.
- **Not exercised live:** full devcontainer creation on Podman needs the base images (not available locally); the socket-sharing + `label=disable` behavior was verified in isolation and via the gateway's own startup socket calls.

## Verification

- `huddle init --runtime podman` on a Podman machine: huddle container comes up on `devcontainer-net,podman`, correct `SecurityOpt`/env/mounts, gateway boots with no socket errors, and a request over `/var/run/docker.sock` from inside returns HTTP 200.
- `huddle.ps1` end-to-end on Podman: resolves `podman`, delegates `huddle init` without error, status shows `[ON] Huddle draait`.
- CLI + gateway typecheck/build clean; all 85 gateway unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)