### PR TITLE
fix(cli): publish port 3000 on init instead of silently dropping it

### DIFF
--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -103,10 +103,18 @@ export async function runInit(opts: InitOptions, images: ResolvedImages): Promis
   }
 
   console.log(dim(`Starting container`));
+  // Create on the default (non-internal) network first, WITH -p: Docker only
+  // sets up the host port-forward (iptables/docker-proxy) for the network a
+  // container is created with. `--network` here is `runtime.defaultNetwork`
+  // (not INTERNAL_NET) on purpose — INTERNAL_NET is `--internal`, and Docker
+  // silently skips publishing ports for a container whose network at
+  // creation time is internal (see moby/moby#36174). Attaching INTERNAL_NET
+  // afterwards via `network connect` does NOT retroactively fix this: the
+  // publish decision is made once, at `run`, not re-evaluated on connect.
   run(
     `${rt} run -d` +
     ` --name ${CONTAINER}` +
-    ` --network ${INTERNAL_NET}` +
+    ` --network ${runtime.defaultNetwork}` +
     ` -p ${HOST_PORT}:3000` +
     ` -v ${VOLUME}:/data` +
     ` -v ${runtime.socketPath}:/var/run/docker.sock` +
@@ -115,7 +123,7 @@ export async function runInit(opts: InitOptions, images: ResolvedImages): Promis
     ` ${IMAGE}`,
   );
 
-  runSilent(`${rt} network connect ${runtime.defaultNetwork} ${CONTAINER}`);
+  runSilent(`${rt} network connect ${INTERNAL_NET} ${CONTAINER}`);
 
   console.log();
   console.log(green(`[OK] Huddle is running at http://localhost:${HOST_PORT}`));

--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -103,14 +103,6 @@ export async function runInit(opts: InitOptions, images: ResolvedImages): Promis
   }
 
   console.log(dim(`Starting container`));
-  // Create on the default (non-internal) network first, WITH -p: Docker only
-  // sets up the host port-forward (iptables/docker-proxy) for the network a
-  // container is created with. `--network` here is `runtime.defaultNetwork`
-  // (not INTERNAL_NET) on purpose — INTERNAL_NET is `--internal`, and Docker
-  // silently skips publishing ports for a container whose network at
-  // creation time is internal (see moby/moby#36174). Attaching INTERNAL_NET
-  // afterwards via `network connect` does NOT retroactively fix this: the
-  // publish decision is made once, at `run`, not re-evaluated on connect.
   run(
     `${rt} run -d` +
     ` --name ${CONTAINER}` +


### PR DESCRIPTION
## Summary

Fixes #59. `huddle init` created the `huddle` container on `devcontainer-net` (`--internal`) *with* `-p 3000:3000`, then attached `bridge` afterwards. Docker only sets up the host port-forward for the network a container is created with, and skips it entirely when that network is `--internal` ([moby/moby#36174](https://github.com/moby/moby/issues/36174)). Attaching a non-internal network later via `network connect` doesn't retroactively fix this — so the dashboard was never actually reachable at `localhost:3000`, silently.

- Create the container on the default (non-internal) network first, with `-p`.
- Attach `devcontainer-net` afterwards via `network connect`, same as before — just reversed order.
- The `huddle` DNS alias for devcontainers is unaffected: Docker auto-aliases a container's own name on every user-defined network it joins, regardless of connect order.

## Security

This only reorders which of the *same two* networks the `huddle` container joins at creation vs. afterwards — it does not add any new network, does not publish any port beyond the existing `3000`, and does not touch `devcontainer-net`'s `--internal` isolation for devcontainers (that network, and the compose files that reference it, are untouched). I specifically re-verified after the fix that the gateway's source-IP admin gate (`gateway/src/api.ts`) still rejects requests to unauthenticated `/api/*` routes when they originate from `devcontainer-net`, while the host retains admin access — see test plan.

## Test plan

- [x] `npm run cli:typecheck` passes
- [x] `npm run cli:build` passes
- [x] `npm --prefix gateway test` — 152/152 tests pass (unrelated to this change, run as a full regression check)
- [x] Rebuilt CLI, ran `huddle init` against the fixed code:
  - `docker port huddle` now shows `3000/tcp -> 0.0.0.0:3000`
  - `curl http://localhost:3000/` → `200`
  - `docker inspect huddle` — `NetworkSettings.Ports` now matches `HostConfig.PortBindings` (previously empty)
- [x] Brought up `.devcontainer/docker-compose.yml` and confirmed `postCreateCommand` (`curl http://huddle:3000/api/tls/ca.crt`) still succeeds — devcontainer-to-huddle connectivity unaffected
- [x] From a throwaway container on `devcontainer-net`: whitelisted endpoint (`/api/tls/ca.crt`) → `200`; non-whitelisted admin endpoint (`/api/authz/grants`) → `403` (unchanged — isolation gate still enforced)
- [x] From the host: `/api/authz/grants` → `200` (admin access still works)

## Note

No existing test infra covers `cli/src/init.ts` (it shells out directly to the Docker CLI; there's no mocking layer for that today), so this was validated manually end-to-end as above rather than with a new unit test. Happy to discuss adding a thin wrapper if maintainers want automated coverage here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)