### PR TITLE
feat(gateway): security-hardening (findings #1–#15, excl. Aikido)

### DIFF
--- a/base-devimage/Dockerfile
+++ b/base-devimage/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
         gnupg \
+        inotify-tools \
         iptables \
     && install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@infosupport/huddle-cli",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Huddle CLI — start devcontainers and manage firewall rules",
   "license": "GPL-3.0-or-later",
   "author": "Info Support B.V.",

--- a/gateway/src/api.ts
+++ b/gateway/src/api.ts
@@ -390,10 +390,13 @@ export async function createApiServer(): Promise<FastifyInstance> {
   app.post<{
     Body: { domain: string; container_id?: string | null; status: RuleStatus; expires_at?: number | null; path_pattern?: string | null };
   }>('/api/rules', async (req, reply) => {
-    const { domain, container_id = null, status, expires_at = null, path_pattern = null } = req.body;
-    if (!domain || !['requested', 'allow', 'deny'].includes(status)) {
+    const { domain: rawDomain, container_id = null, status, expires_at = null, path_pattern = null } = req.body;
+    if (!rawDomain || !['requested', 'allow', 'deny'].includes(status)) {
       return reply.code(400).send({ error: 'invalid payload' });
     }
+    // Domeinen canoniek (lowercase) opslaan zodat de rule-engine hoofdletter-
+    // ongevoelig matcht (finding #3). Wildcards (`*.example.com`) blijven intact.
+    const domain = rawDomain.toLowerCase();
     try {
       const info = db
         .prepare(

--- a/gateway/src/api.ts
+++ b/gateway/src/api.ts
@@ -390,13 +390,17 @@ export async function createApiServer(): Promise<FastifyInstance> {
   app.post<{
     Body: { domain: string; container_id?: string | null; status: RuleStatus; expires_at?: number | null; path_pattern?: string | null };
   }>('/api/rules', async (req, reply) => {
-    const { domain: rawDomain, container_id = null, status, expires_at = null, path_pattern = null } = req.body;
-    if (!rawDomain || !['requested', 'allow', 'deny'].includes(status)) {
+    const { domain, container_id = null, status, expires_at = null, path_pattern = null } = req.body;
+    // Eis expliciet een non-lege string: een truthy niet-string domain (bv. een
+    // getal/object in de JSON) zou anders verderop klappen met een 500 i.p.v.
+    // deze nette 400.
+    if (typeof domain !== 'string' || !domain || !['requested', 'allow', 'deny'].includes(status)) {
       return reply.code(400).send({ error: 'invalid payload' });
     }
-    // Domeinen canoniek (lowercase) opslaan zodat de rule-engine hoofdletter-
-    // ongevoelig matcht (finding #3). Wildcards (`*.example.com`) blijven intact.
-    const domain = rawDomain.toLowerCase();
+    // Domein opslaan zoals aangeleverd — géén casing-mutatie. De rule-engine
+    // matcht al hoofdletter-ongevoelig (COLLATE NOCASE in db.ts + canonicalizeHost/
+    // matchDomain, finding #3), dus lowercasen is overbodig en zou de echo-back
+    // naar clients veranderen.
     try {
       const info = db
         .prepare(
@@ -405,9 +409,11 @@ export async function createApiServer(): Promise<FastifyInstance> {
         .run(domain, container_id, status, expires_at, path_pattern);
       const inserted = db.prepare(`SELECT * FROM rules WHERE id = ?`).get(info.lastInsertRowid) as Rule;
       // Ruim alleen de host-only requested-rij op; padregels per domein blijven
-      // staan zodat fijnmazig beleid naast elkaar kan bestaan.
+      // staan zodat fijnmazig beleid naast elkaar kan bestaan. COLLATE NOCASE:
+      // requested-rijen worden lowercase aangemaakt (proxy/canonicalizeHost), dus
+      // matchen ook als de operator hier mixed-case aanlevert.
       if (container_id === null && path_pattern === null && (status === 'allow' || status === 'deny')) {
-        db.prepare(`DELETE FROM rules WHERE domain = ? AND status = 'requested' AND path_pattern IS NULL`).run(domain);
+        db.prepare(`DELETE FROM rules WHERE domain = ? COLLATE NOCASE AND status = 'requested' AND path_pattern IS NULL`).run(domain);
       }
       logAudit({ containerId: container_id, domain, action: `admin:rule-${status}`, ruleId: Number(info.lastInsertRowid) });
       notifyStateChanged();

--- a/gateway/src/db.ts
+++ b/gateway/src/db.ts
@@ -118,23 +118,33 @@ export function initDb(): void {
     db.exec('ALTER TABLE rules ADD COLUMN last_path TEXT');
   }
 
+  // Domeinen worden voortaan canoniek (lowercase) opgeslagen zodat de exacte
+  // lookup en de wildcard-match op dezelfde vorm werken (finding #3). Migreer
+  // bestaande rijen idempotent naar lowercase VÓÓR de dedup hieronder, zodat
+  // case-varianten (`GIST.github.com` vs `gist.github.com`) samenvallen en de
+  // dedup ze tot één rij terugbrengt in plaats van op de unieke index te botsen.
+  db.exec('UPDATE rules SET domain = lower(domain) WHERE domain <> lower(domain)');
+
   // Uniciteit geldt nu op (domain, container, pad): meerdere padregels per
   // domein moeten naast elkaar kunnen bestaan. De oude domain+container index
   // wordt vervangen.
   // Opschonen voorkomt dat een migratie crasht wanneer oude data per ongeluk
-  // meerdere rijen met dezelfde unieke sleutel bevat.
+  // meerdere rijen met dezelfde unieke sleutel bevat. NOCASE in de GROUP BY
+  // zodat de dedup dezelfde hoofdletter-ongevoeligheid hanteert als de index.
   db.exec(`
     DELETE FROM rules
     WHERE id NOT IN (
       SELECT MAX(id)
       FROM rules
-      GROUP BY domain, COALESCE(container_id, ''), COALESCE(path_pattern, '')
+      GROUP BY domain COLLATE NOCASE, COALESCE(container_id, ''), COALESCE(path_pattern, '')
     )
   `);
   db.exec('DROP INDEX IF EXISTS idx_rules_domain_container');
+  // De oude index kon nog zonder NOCASE bestaan; herbouw hem case-insensitief.
+  db.exec('DROP INDEX IF EXISTS idx_rules_domain_container_path');
   db.exec(
     `CREATE UNIQUE INDEX IF NOT EXISTS idx_rules_domain_container_path
-       ON rules (domain, COALESCE(container_id, ''), COALESCE(path_pattern, ''))`
+       ON rules (domain COLLATE NOCASE, COALESCE(container_id, ''), COALESCE(path_pattern, ''))`
   );
 
   // Seed the global allow rule for huddle's own domain so the sudo-audit

--- a/gateway/src/docker.ts
+++ b/gateway/src/docker.ts
@@ -430,6 +430,62 @@ const DOCKER_SOCK_SYMLINK = `# Docker-toegang loopt via de socket in de gemounte
 # (zie DOCKER_HOST). Symlink het defaultpad voor tools die DOCKER_HOST negeren.
 ln -sfn /var/run/huddle/docker.sock /var/run/docker.sock 2>/dev/null || true`;
 
+// Finding #15 (IDE-kanaal, VS Code Remote + JetBrains Gateway): het attach-kanaal
+// loopt over `docker exec`/stdio en wordt door NOCH de egress-proxy NOCH de
+// socket-proxy gezien. Het echte host-token komt NOOIT als bestand binnen; VS
+// Code laat de container het on-demand ophalen. De werkelijke route (bevestigd
+// live) is een git `credential.helper` die bij attach in ZOWEL /etc/gitconfig ALS
+// de van de host gekopieerde ~/.gitconfig wordt gezet:
+//     helper = !… node /tmp/vscode-remote-containers-<id>.js git-credential-helper …
+// die via de algemene remote-containers IPC-socket de host-credential-helper
+// aanroept. (Oudere VS Code gebruikte GIT_ASKPASS + /tmp/vscode-git-*.sock; die
+// dekken we ook nog af.) We knippen het op drie niveaus:
+//   1. env-scrub voor ELKE shell — /etc/profile.d (login) én /etc/bash.bashrc
+//      (interactive non-login; wat de VS Code-terminal standaard sourcet). Dekt
+//      de GIT_ASKPASS-variant.
+//   2. de git `credential.helper` die naar de remote-containers-helper wijst
+//      strippen uit /etc/gitconfig én ~/.gitconfig — dít is de daadwerkelijke
+//      route. Value-regex 'vscode-remote-containers' zodat een door de gebruiker
+//      zélf gezette helper blijft staan.
+//   3. de doorgestuurde GPG-agent-socket(s) (~/.gnupg/S.gpg-agent*) weghalen —
+//      daarmee vervalt commit-signing met de host-GPG-key.
+//   4. de oude askpass-sockets opruimen (voor VS Code-versies die die nog maken).
+// De remote-containers IPC-socket zelf NIET verwijderen: die is multiplexed met
+// de hele Remote-sessie; strippen we de helper, dan heeft git er toch geen route
+// meer naartoe. Een guard draait de hele container-levensduur, want de helper/
+// sockets verschijnen pas bij attach (ná dit script) en keren terug bij reconnect.
+const IDE_CRED_SCRUB = `# Finding #15: ontneem de untrusted container de door de IDE doorgestuurde
+# host-credentials (git-token via credential.helper/askpass, SSH-agent, GPG).
+SCRUB_VARS='GIT_ASKPASS SSH_AUTH_SOCK SSH_AGENT_PID GPG_AGENT_INFO GPG_TTY VSCODE_GIT_ASKPASS_NODE VSCODE_GIT_ASKPASS_MAIN VSCODE_GIT_ASKPASS_EXTRA_ARGS VSCODE_GIT_IPC_HANDLE'
+SCRUB_LINE="unset \$SCRUB_VARS"
+printf '%s\\n' "\$SCRUB_LINE" > /etc/profile.d/99-huddle-scrub-ide-creds.sh
+chmod 644 /etc/profile.d/99-huddle-scrub-ide-creds.sh
+# Interactive non-login shells (o.a. de VS Code-terminal) lezen /etc/profile.d
+# NIET; /etc/bash.bashrc is daar de plek.
+grep -qF "\$SCRUB_LINE" /etc/bash.bashrc 2>/dev/null || printf '%s\\n' "\$SCRUB_LINE" >> /etc/bash.bashrc
+# ~/.gnupg moet bestaan (mode 700) zodat de inotify-watch erop kan starten, ook
+# als de IDE de GPG-socket pas later neerzet.
+install -d -m 700 -o vscode -g vscode /home/vscode/.gnupg 2>/dev/null || true
+# Credential-guard: strip de doorgestuurde git-credential-helper + ruim de
+# GPG-agent- en oude askpass-sockets op. Idempotent, zodat een herhaalde run
+# niets herschrijft.
+_huddle_cred_guard() {
+  for cfg in /etc/gitconfig /home/vscode/.gitconfig; do
+    [ -f "\$cfg" ] && git config --file "\$cfg" --unset-all credential.helper 'vscode-remote-containers' 2>/dev/null || true
+  done
+  rm -f /home/vscode/.gnupg/S.gpg-agent /home/vscode/.gnupg/S.gpg-agent.* 2>/dev/null || true
+  find /tmp -maxdepth 1 \\( -name 'vscode-git-*.sock' -o -name 'vscode-ssh-auth-*.sock' \\) -delete 2>/dev/null || true
+}
+_huddle_cred_guard   # ruim op wat er bij attach al stond
+if command -v inotifywait >/dev/null 2>&1; then
+  # Reageer meteen als de IDE de helper/sockets (opnieuw) neerzet (race ~sub-ms).
+  ( inotifywait -q -m -e create -e modify -e moved_to --format '%f' /tmp /etc /home/vscode /home/vscode/.gnupg 2>/dev/null | while IFS= read -r f; do
+      case "\$f" in gitconfig|.gitconfig|S.gpg-agent|S.gpg-agent.*|vscode-git-*.sock|vscode-ssh-auth-*.sock) _huddle_cred_guard ;; esac
+    done ) &
+else
+  ( while true; do _huddle_cred_guard; sleep 1; done ) &
+fi`;
+
 // ── jb-config.sh — same logic as devcontainer-manager.ps1 ───────────────────
 
 function buildJbConfigScript(containerWorkspace: string, containerName: string, ideName: IdeName, password: string, caCertPem: string, seedScript: string): string {
@@ -494,6 +550,8 @@ command -v update-ca-certificates >/dev/null 2>&1 && update-ca-certificates >/de
 printf 'export NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/huddle-ca.crt\\n' > /etc/profile.d/99-huddle-ca.sh
 chmod 644 /etc/profile.d/99-huddle-ca.sh
 
+${IDE_CRED_SCRUB}
+
 # De JetBrains-IDE (IntelliJ/Rider) draait op de JBR, een eigen JVM die TLS niet
 # tegen de system store of NODE_EXTRA_CA_CERTS valideert maar tegen z'n eigen
 # cacerts-keystore. Zonder import hieronder weigert de IDE het MITM-leaf-cert en
@@ -556,8 +614,47 @@ fi
 // Zelfde firewall/sudo/audit-setup als de JB-flow, maar zónder JB host-config en
 // zónder remote-dev-server: VS Code installeert zijn eigen backend (VS Code Server)
 // bij het attachen. Houd dit in sync met de vscode-branch in huddle.ps1.
+// Machine-level VS Code Remote-instellingen die het IDE-kanaal hardenen
+// (finding #15). Het VS Code-Remote-kanaal loopt over `docker exec`/stdio en
+// wordt NOCH door de egress-proxy NOCH door de socket-proxy gezien — het is een
+// derde brug tussen host en (untrusted) container. Zonder deze policy erft een
+// in-container terminal (waar een AI-agent draait) de door VS Code doorgestuurde
+// host-credentials, en draait een aanvaller-gecontroleerde `tasks.json`
+// automatisch bij het openen van de map. Deze settings sluiten dat:
+//   - terminal.integrated.env.linux → null de doorgestuurde credential-env, zodat
+//     terminals/agents GIT_ASKPASS / SSH_AUTH_SOCK / GPG e.d. niet meer zien
+//     (VS Code's eigen git-integratie via de extension-host blijft werken).
+//   - task.allowAutomaticTasks=off → geen folderOpen-autorun.
+//   - security.workspace.trust.* → open mappen starten in Restricted Mode.
+//   - terminal.integrated.allowLocalTerminal=false → blokkeer het openen van een
+//     HOST-terminal vanuit het remote-venster (newLocal).
+// Volledig dichttimmeren vereist dat Huddle de attach zelf beheert (managed
+// devcontainer.json met copyGitConfig:false); dit is de container-side laag.
+export function buildVscodeMachineSettings(): Record<string, unknown> {
+  return {
+    'security.workspace.trust.enabled': true,
+    'security.workspace.trust.startupPrompt': 'always',
+    'security.workspace.trust.banner': 'always',
+    'security.workspace.trust.emptyWindow': false,
+    'task.allowAutomaticTasks': 'off',
+    'terminal.integrated.allowLocalTerminal': false,
+    // null verwijdert de variabele uit de terminal-omgeving.
+    'terminal.integrated.env.linux': {
+      GIT_ASKPASS: null,
+      VSCODE_GIT_ASKPASS_NODE: null,
+      VSCODE_GIT_ASKPASS_MAIN: null,
+      VSCODE_GIT_ASKPASS_EXTRA_ARGS: null,
+      VSCODE_GIT_IPC_HANDLE: null,
+      SSH_AUTH_SOCK: null,
+      GPG_AGENT_INFO: null,
+      GPG_TTY: null,
+    },
+  };
+}
+
 function buildVscodeConfigScript(containerWorkspace: string, containerName: string, password: string, caCertPem: string, seedScript: string): string {
   const caB64 = Buffer.from(caCertPem, 'utf8').toString('base64');
+  const settingsB64 = Buffer.from(JSON.stringify(buildVscodeMachineSettings(), null, 2), 'utf8').toString('base64');
   return `#!/bin/sh
 CURL_LINE='--proxy-header "X-Container-ID: ${containerName}"'
 grep -qF "$CURL_LINE" /home/vscode/.curlrc 2>/dev/null || echo "$CURL_LINE" >> /home/vscode/.curlrc
@@ -580,6 +677,8 @@ command -v update-ca-certificates >/dev/null 2>&1 && update-ca-certificates >/de
 printf 'export NODE_EXTRA_CA_CERTS=/usr/local/share/ca-certificates/huddle-ca.crt\\n' > /etc/profile.d/99-huddle-ca.sh
 chmod 644 /etc/profile.d/99-huddle-ca.sh
 
+${IDE_CRED_SCRUB}
+
 # Install sudo + passwd if missing (update index first; base image wipes /var/lib/apt/lists)
 export DEBIAN_FRONTEND=noninteractive
 command -v sudo >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y --no-install-recommends sudo passwd; }
@@ -593,6 +692,15 @@ chown -R vscode:vscode "${containerWorkspace}" 2>/dev/null || true
 chmod -R u+rwX "${containerWorkspace}" 2>/dev/null || true
 
 ${seedScript}
+
+# Finding #15: harden het VS Code Remote IDE-kanaal met machine-level settings.
+# Attach-to-running-container leest deze uit ~/.vscode-server/data/Machine/ (en
+# de insiders-variant). We schrijven ze voor de attach zodat ze meteen gelden.
+for VSCODE_HOME in /home/vscode/.vscode-server /home/vscode/.vscode-server-insiders; do
+  mkdir -p "$VSCODE_HOME/data/Machine"
+  echo '${settingsB64}' | base64 -d > "$VSCODE_HOME/data/Machine/settings.json"
+done
+chown -R vscode:vscode /home/vscode/.vscode-server /home/vscode/.vscode-server-insiders 2>/dev/null || true
 
 # Configure sudo audit logging
 mkdir -p /etc/sudoers.d

--- a/gateway/src/extensions/loader.ts
+++ b/gateway/src/extensions/loader.ts
@@ -2,6 +2,7 @@ import AdmZip from 'adm-zip';
 import path from 'path';
 import fs from 'fs';
 import net from 'net';
+import crypto from 'crypto';
 import type { FastifyInstance } from 'fastify';
 import type { Database } from 'better-sqlite3';
 import { stateEvents } from '../events';
@@ -149,9 +150,44 @@ function parseManifest(raw: string): ExtensionManifest {
   return manifest;
 }
 
+// ── Extensie-integriteit (finding #11) ──────────────────────────────────────
+// Een geüploade extensie draait IN-PROCESS in de gateway (await import → raw
+// docker.sock) = host-root-equivalent. Sinds de operator-auth zit de upload
+// achter authenticatie, maar dat beschermt niet tegen een operator die een
+// gemanipuleerde/kwaadaardige bundel uploadt. Daarom: bereken de SHA-256 van de
+// bundel en toets die tegen een pinned allowlist. Consistent met het Phase 0-
+// patroon (HUDDLE_HOSTCONFIG_ENFORCE): standaard LOG-ONLY (logt de hash zodat de
+// operator hem kan pinnen); zet HUDDLE_EXTENSION_SHA256_ALLOWLIST (komma-
+// gescheiden hashes) om alleen die bundels toe te laten en de rest te weigeren.
+export function bundleSha256(zipBuffer: Buffer): string {
+  return crypto.createHash('sha256').update(zipBuffer).digest('hex');
+}
+
+// Retourneert een weigeringsreden, of null wanneer de bundel is toegestaan.
+export function checkExtensionIntegrity(zipBuffer: Buffer): string | null {
+  const hash = bundleSha256(zipBuffer);
+  const raw = process.env.HUDDLE_EXTENSION_SHA256_ALLOWLIST?.trim();
+  if (!raw) {
+    console.warn(
+      `[ext] integriteit (log-only): bundel sha256=${hash}. ` +
+      `Zet HUDDLE_EXTENSION_SHA256_ALLOWLIST=${hash}[,…] om uploads tot vertrouwde bundels te beperken.`,
+    );
+    return null;
+  }
+  const allow = new Set(raw.split(',').map(h => h.trim().toLowerCase()).filter(Boolean));
+  if (!allow.has(hash.toLowerCase())) {
+    return `extension bundle sha256 ${hash} is not on HUDDLE_EXTENSION_SHA256_ALLOWLIST`;
+  }
+  return null;
+}
+
 export async function installExtension(
   zipBuffer: Buffer,
 ): Promise<{ id: string; name: string; restartRequired: boolean }> {
+  // Integriteit vóór we ook maar iets uitpakken of laden (fail-closed).
+  const integrityError = checkExtensionIntegrity(zipBuffer);
+  if (integrityError) throw new Error(integrityError);
+
   const zip = new AdmZip(zipBuffer);
 
   const manifestEntry = zip.getEntry('manifest.json');

--- a/gateway/src/proxy.ts
+++ b/gateway/src/proxy.ts
@@ -5,7 +5,7 @@ import tls from 'tls';
 import stream from 'stream';
 import zlib from 'zlib';
 import { URL } from 'url';
-import { checkRule, isPathMode } from './rules';
+import { checkRule, isPathMode, canonicalizeHost, normalizePathname } from './rules';
 import { resolveContainerByIp } from './docker';
 import { logAudit, updateAuditResponse } from './db';
 import { signLeafCert } from './tls-ca';
@@ -123,14 +123,20 @@ function handleTokenExchangeResponse(
       const rawBody = decodeBody(chunks, upstreamRes.headers);
       const json = rawBody ? JSON.parse(rawBody) : null;
       if (json?.access_token) {
-        const placeholder = storeTokenExchange(containerId ?? 'unknown', json.access_token as string);
+        // Bind de placeholder aan de aanvragende container (finding #12); geen
+        // 'unknown'-fallback meer. Een null container levert een niet-inwissel-
+        // bare placeholder op (fail-closed).
+        const placeholder = storeTokenExchange(containerId, json.access_token as string);
         json.access_token = placeholder;
         console.log(`[token-exchange] placeholder issued voor container ${containerId}`);
         outBuf = Buffer.from(JSON.stringify(json));
         delete outHeaders['content-encoding'];
         delete outHeaders['transfer-encoding'];
         outHeaders['content-length'] = String(outBuf.length);
-        auditResBody = cap(JSON.stringify(json));
+        // De placeholder is zelf een inwisselbare bearer-credential: redact hem
+        // uit de audit-body (finding #12) — de audit toont dat er een exchange
+        // was, niet de bruikbare waarde.
+        auditResBody = cap(JSON.stringify({ ...json, access_token: '<redacted-placeholder>' }));
       } else {
         outBuf = Buffer.concat(chunks);
         outHeaders['content-length'] = String(outBuf.length);
@@ -169,11 +175,34 @@ export function createProxyServer(): http.Server {
       return;
     }
 
+    // Canoniseer de host één keer aan de rand naar de vorm waarop we matchen,
+    // loggen én dialen — zodat de gecontroleerde en de verstuurde host niet
+    // kunnen divergeren (parser-differential, finding #3 + staart).
+    const host = canonicalizeHost(target.hostname);
+    if (host === null) {
+      send502(res, 'invalid target host');
+      return;
+    }
+
+    // Normaliseer het pad naar de vorm die de upstream zal interpreteren en
+    // forward exact dat pad. `new URL` heeft `../` al weggevouwen; normalizePathname
+    // dekt daarnaast `%2f`-getruceerde traversal (finding #7) en weigert fail-closed.
+    const normPath = normalizePathname(target.pathname);
+    if (normPath === null) {
+      logAudit({
+        containerId, domain: host, action: 'deny', ruleId: null,
+        method: req.method ?? null, path: `${target.pathname}${target.search}`, resStatus: 403,
+      });
+      send403(res, host, 'deny', containerId);
+      return;
+    }
+    const forwardPath = `${normPath}${target.search}`;
+
     let ruleId: number | null;
-    if (target.hostname === 'huddle') {
+    if (host === 'huddle') {
       // Self-traffic: devcontainers may only reach a fixed set of huddle paths.
       const allowed =
-        (target.port === '3000' && req.method === 'POST' && target.pathname === '/api/audit/sudo');
+        (target.port === '3000' && req.method === 'POST' && normPath === '/api/audit/sudo');
       if (!allowed) {
         logAudit({
           containerId,
@@ -181,7 +210,7 @@ export function createProxyServer(): http.Server {
           action: 'deny',
           ruleId: null,
           method: req.method ?? null,
-          path: `${target.pathname}${target.search}`,
+          path: forwardPath,
           resStatus: 403,
         });
         send403(res, 'huddle', 'deny', containerId);
@@ -189,18 +218,18 @@ export function createProxyServer(): http.Server {
       }
       ruleId = null;
     } else {
-      const result = checkRule(target.hostname, containerId, target.pathname);
+      const result = checkRule(host, containerId, normPath);
       if (result.status !== 'allow') {
         logAudit({
           containerId,
-          domain: target.hostname,
+          domain: host,
           action: result.status,
           ruleId: null,
           method: req.method ?? null,
-          path: `${target.pathname}${target.search}`,
+          path: forwardPath,
           resStatus: 403,
         });
-        send403(res, target.hostname, result.status, containerId);
+        send403(res, host, result.status, containerId);
         return;
       }
       ruleId = result.ruleId;
@@ -218,11 +247,11 @@ export function createProxyServer(): http.Server {
     // response (en de volledige req_body) bij zodra upstream afrondt.
     const auditId = logAudit({
       containerId,
-      domain: target.hostname,
+      domain: host,
       action: 'allow',
       ruleId,
       method: req.method ?? null,
-      path: `${target.pathname}${target.search}`,
+      path: forwardPath,
       reqHeaders: headersToJson(req.headers),
     });
     let completed = false;
@@ -243,10 +272,10 @@ export function createProxyServer(): http.Server {
 
     const upstream = http.request(
       {
-        hostname: target.hostname,
+        hostname: host,
         port: upstreamPort,
         method: req.method,
-        path: `${target.pathname}${target.search}`,
+        path: forwardPath,
         headers: outgoingHeaders,
       },
       (upstreamRes) => {
@@ -283,9 +312,15 @@ export function createProxyServer(): http.Server {
     const containerId = await resolveContainerByIp(
       (clientSocket as net.Socket).remoteAddress ?? ''
     );
-    const [hostname, portStr] = (req.url || '').split(':');
+    const [rawHostname, portStr] = (req.url || '').split(':');
     const port = Number(portStr) || 443;
 
+    // Canoniseer de CONNECT-host op dezelfde manier als het plain-HTTP-pad
+    // (`new URL().hostname`) zodat beide paden op één canonieke vorm matchen,
+    // loggen, het cert genereren en dialen. Zonder dit omzeilde een
+    // ge-kapitaliseerde host (`GIST.GITHUB.COM`) een exacte deny-regel terwijl
+    // de wildcard-allow wél matchte (finding #3).
+    const hostname = canonicalizeHost(rawHostname);
     if (!hostname) {
       rejectSocket(clientSocket, 400, 'deny', '', null);
       return;
@@ -399,7 +434,21 @@ export function createProxyServer(): http.Server {
     innerHttp.on('request', (innerReq, innerRes) => {
       // De CONNECT stond de host al toe (pad was toen versleuteld). Nu de TLS
       // getermineerd is kennen we het pad: pas padbeleid alsnog toe per request.
-      const pathResult = checkRule(hostname, containerId, innerReq.url ?? null);
+      //
+      // Normaliseer het pad één keer naar de vorm die de upstream zal
+      // interpreteren en forward EXACT dat pad — zo kunnen de gecontroleerde en
+      // de verstuurde bytes niet divergeren (finding #7). Traversal (`../`,
+      // `..%2f`) of kapotte encoding → fail closed (403), nooit doorsturen.
+      const rawUrl = innerReq.url ?? '/';
+      const qi = rawUrl.indexOf('?');
+      const rawPathPart = qi === -1 ? rawUrl : rawUrl.slice(0, qi);
+      const query = qi === -1 ? '' : rawUrl.slice(qi);
+      const normPath = normalizePathname(rawPathPart);
+      const forwardUrl = normPath === null ? null : `${normPath}${query}`;
+
+      const pathResult = normPath === null
+        ? { status: 'deny' as const, ruleId: null }
+        : checkRule(hostname, containerId, forwardUrl);
       // Alles behalve 'allow' blokkeren: een 'deny'-padregel, maar ook een nog
       // niet beoordeeld subpad ('requested') van een pad-allowlist-domein —
       // fail-closed tot de operator het pad expliciet toestaat.
@@ -442,12 +491,13 @@ export function createProxyServer(): http.Server {
       if (hostname === 'api.anthropic.com') {
         const authVal = upstreamHeaders['authorization'] as string | undefined;
         if (authVal?.startsWith('Bearer ') && isPlaceholderToken(authVal.slice(7))) {
-          const real = resolveToken(authVal.slice(7));
+          // Alleen inwisselen als deze container de placeholder ook kreeg (#12).
+          const real = resolveToken(authVal.slice(7), containerId);
           if (real) upstreamHeaders['authorization'] = `Bearer ${real}`;
         }
         const apiKey = upstreamHeaders['x-api-key'] as string | undefined;
         if (apiKey && isPlaceholderToken(apiKey)) {
-          const real = resolveToken(apiKey);
+          const real = resolveToken(apiKey, containerId);
           if (real) upstreamHeaders['x-api-key'] = real;
         }
       }
@@ -498,7 +548,9 @@ export function createProxyServer(): http.Server {
           hostname,
           port,
           method: innerReq.method,
-          path: innerReq.url,
+          // Forward het genormaliseerde pad dat we ook gecontroleerd hebben, niet
+          // de rauwe (mogelijk traversal-getruceerde) innerReq.url (finding #7).
+          path: forwardUrl ?? innerReq.url,
           headers: upstreamHeaders,
           servername: hostname,
         },

--- a/gateway/src/pty-manager.ts
+++ b/gateway/src/pty-manager.ts
@@ -46,8 +46,19 @@ class PtyManager {
     }
 
     const active = session;
+    // Finding #13: een tweede client die op een bestaande sessie aanhaakt deelt
+    // dezelfde shell (leest alle I/O, kan toetsaanslagen injecteren). We kunnen
+    // in het single-operator-token-model geen per-operator identiteit afdwingen,
+    // maar we maken de join expliciet zichtbaar: log 'attach:join' met het aantal
+    // clients zodat een stille overname niet meer mogelijk is (operators zien 'm
+    // in de audit-log). De eerste client is de eigenaar ('attach:owner').
+    const isJoin = active.clients.size > 0;
     active.clients.add(ws);
-    logAudit({ containerId: containerName, domain: 'terminal', action: 'attach' });
+    logAudit({
+      containerId: containerName,
+      domain: 'terminal',
+      action: isJoin ? `attach:join(${active.clients.size} clients)` : 'attach:owner',
+    });
 
     ws.on('message', (data, isBinary) => {
       if (isBinary) {

--- a/gateway/src/rules.ts
+++ b/gateway/src/rules.ts
@@ -17,6 +17,74 @@ interface RuleRow {
 // Bewust los van de DB zodat ze deterministisch testbaar zijn zonder draaiende
 // SQLite-binding.
 
+// Canoniseer een host naar precies de vorm waarop de downstream (OS-resolver,
+// SNI, upstream-server) hem zal interpreteren, zodat de proxy op één plek — aan
+// de grens — normaliseert en daarna zowel matcht als forward't op diezelfde
+// waarde. Voorkomt de parser-differential-klasse (finding #3 en de staart:
+// hoofdletters, IDN/punycode, trailing dot, control chars).
+//
+// Retourneert de canonieke host (lowercase, punycode, zonder trailing dot) of
+// null wanneer de host ongeldig/verdacht is (control chars, whitespace, lege of
+// onparseerbare host) — de caller moet dan fail-closed weigeren.
+export function canonicalizeHost(raw: string): string | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  // Control chars en whitespace horen nooit in een host (request-smuggling /
+  // log-injectie) — weiger ze expliciet vóór het parsen.
+  // eslint-disable-next-line no-control-regex
+  if (/[\s\u0000-\u001f\u007f]/.test(trimmed)) return null;
+  let host: string;
+  try {
+    // De WHATWG-URL-parser doet precies de canonicalisatie die de downstream
+    // ook doet: lowercasen, IDNA/punycode toepassen, de host valideren en
+    // bracketed IPv6 normaliseren. We voeren enkel de authority in.
+    host = new URL(`http://${trimmed}`).hostname;
+  } catch {
+    return null;
+  }
+  if (!host) return null;
+  // Eén trailing dot (FQDN-root) strippen: `a.b.` en `a.b` zijn dezelfde host
+  // voor DNS/SNI. Een dubbele punt aan het eind is ongeldig → laten vallen.
+  if (host.endsWith('.') && !host.endsWith('..')) host = host.slice(0, -1);
+  return host.toLowerCase();
+}
+
+// Normaliseer een request-pad naar de vorm waarop de upstream het zal
+// interpreteren, zodat pad-allowlist-matching niet te omzeilen is met traversal
+// (finding #7). Strategie: query/fragment eraf, één keer percent-decoden, en
+// fail-closed weigeren (null) zodra er een `..`-segment overblijft of de
+// encoding kapot is. `.`-segmenten worden weggevouwen. Bewust NIET verder
+// canonicaliseren dan dat: het pad dat we forwarden blijft de originele
+// (encoded) bytes, zodat legitieme %-encoded tekens niet verminkt worden — we
+// beslissen op de gedecodeerde vorm, maar traversal wordt altijd geblokkeerd,
+// dus er worden nooit `..`-bytes doorgestuurd.
+export function normalizePathname(raw: string | null): string | null {
+  const input = raw ?? '';
+  // Query en fragment horen niet bij het pad; strip ze vóór het decoden.
+  let p = input.split('#')[0].split('?')[0];
+  if (p === '') p = '/';
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(p);
+  } catch {
+    // Kapotte percent-encoding (bv. `%zz`, `%2`) → fail closed.
+    return null;
+  }
+  const segs = decoded.split('/');
+  // Elk `..`-segment na één decode is traversal — legitieme flows hebben het
+  // niet nodig. Fail closed i.p.v. proberen te resolven (dat opent double-decode
+  // en clamp-tot-root varianten).
+  if (segs.some(s => s === '..')) return null;
+  // `.`-segmenten (huidige map) zijn onschuldig maar vervuilen de match; vouw ze
+  // weg. Lege segmenten (`//`, leidende `/`) blijven staan zodat een trailing
+  // slash behouden blijft.
+  const out = segs.filter(s => s !== '.');
+  let result = out.join('/');
+  if (!result.startsWith('/')) result = '/' + result;
+  return result;
+}
+
 // Matcht een domein-patroon tegen een host. Exacte gelijkheid, of een wildcard
 // `*.example.com` die elke subdomein-host matcht (maar NIET kaal `example.com`).
 // Bewust strikt: split op punten en vergelijk segment-voor-segment, zodat
@@ -37,13 +105,27 @@ export function matchDomain(pattern: string, host: string): boolean {
 }
 
 // Matcht een padpatroon tegen een pad. Een null/leeg patroon is een host-only
-// regel en matcht elk pad. `*` aan het eind is een prefix-match
-// (`/api/v1/*` matcht `/api/v1/foo`); anders exacte gelijkheid.
+// regel en matcht elk pad. `*` aan het eind is een prefix-match op
+// SEGMENT-grens (`/api/v1/*` matcht `/api/v1/foo` maar `/safe*` matcht NIET
+// `/safe-danger`); anders exacte gelijkheid.
+//
+// Het pad wordt eerst genormaliseerd (query eraf, één decode, `..` fail-closed)
+// zodat traversal-trucs (`/foo/../secret`, `/foo/..%2fsecret`) niet door een
+// `/foo/*`-allow glippen (finding #7). Een pad dat niet veilig normaliseert
+// matcht nooit.
 export function matchPath(pattern: string | null, path: string | null): boolean {
   if (pattern === null || pattern === '') return true;
-  const reqPath = path ?? '';
+  const reqPath = normalizePathname(path);
+  if (reqPath === null) return false; // traversal / kapotte encoding → fail closed
   if (pattern.endsWith('*')) {
-    return reqPath.startsWith(pattern.slice(0, -1));
+    const prefix = pattern.slice(0, -1);
+    if (!reqPath.startsWith(prefix)) return false;
+    // Prefix die al op een segment-grens eindigt (`/foo/`) — of leeg is —
+    // matcht direct. Anders moet het volgende teken een `/` zijn (of het eind),
+    // zodat `/safe*` niet `/safe-danger` vangt.
+    if (prefix === '' || prefix.endsWith('/')) return true;
+    const rest = reqPath.slice(prefix.length);
+    return rest === '' || rest.startsWith('/');
   }
   return reqPath === pattern;
 }
@@ -63,11 +145,16 @@ let stmts: ReturnType<typeof prepareStmts> | null = null;
 
 function prepareStmts() {
   return {
+    // COLLATE NOCASE: de exacte-host lookup moet hoofdletter-ongevoelig zijn,
+    // net als matchDomain (dat beide kanten lowercase't). Zonder dit werd een
+    // exacte deny-regel omzeild door de host anders te kapitaliseren (finding
+    // #3). Domeinen worden bovendien lowercase opgeslagen (zie checkRule +
+    // db.ts-migratie) — dit is de belt-and-suspenders SQL-kant.
     selectPerContainer: db.prepare<[string, string]>(
-      `SELECT id, domain, status, expires_at, container_id, path_pattern, path_mode FROM rules WHERE domain = ? AND container_id = ?`
+      `SELECT id, domain, status, expires_at, container_id, path_pattern, path_mode FROM rules WHERE domain = ? COLLATE NOCASE AND container_id = ?`
     ),
     selectGlobal: db.prepare<[string]>(
-      `SELECT id, domain, status, expires_at, container_id, path_pattern, path_mode FROM rules WHERE domain = ? AND container_id IS NULL`
+      `SELECT id, domain, status, expires_at, container_id, path_pattern, path_mode FROM rules WHERE domain = ? COLLATE NOCASE AND container_id IS NULL`
     ),
     selectWildcardPerContainer: db.prepare<[string]>(
       `SELECT id, domain, status, expires_at, container_id, path_pattern, path_mode FROM rules WHERE domain LIKE '*.%' AND container_id = ?`
@@ -111,10 +198,15 @@ function specificity(c: Candidate): number {
 }
 
 export function checkRule(
-  domain: string,
+  rawDomain: string,
   containerId: string | null,
   path: string | null = null,
 ): { status: RuleStatus; ruleId: number | null } {
+  // Canoniseer de host één keer aan de rand: lowercase zodat exacte lookups en
+  // wildcard-matching op dezelfde vorm werken (finding #3). De proxy voert al de
+  // volledige punycode/trailing-dot-canonicalisatie uit via canonicalizeHost;
+  // hier lowercasen we defensief voor directe callers/tests.
+  const domain = rawDomain.toLowerCase();
   const {
     selectPerContainer, selectGlobal, selectWildcardPerContainer, selectWildcardGlobal,
     touchRule, setLastPath, insertRequested, insertRequestedPath, resetExpired,

--- a/gateway/src/socket-proxy.ts
+++ b/gateway/src/socket-proxy.ts
@@ -103,12 +103,67 @@ function rewriteFirstLine(headerPart: string, newUrl: string): string {
 // per-actie-autorisatie: classifyRequest bepaalt de actie, authorizeAction
 // (docker-actions.ts) combineert de toggle-stand met de grant-timer.
 
+// ── HostConfig-policy: allowlist i.p.v. denylist ────────────────────────────
+// Root-cause van findings #1 (VolumesFrom) en #2 (DeviceCgroupRules): de oude
+// validatie was een DENYLIST over een spec die Huddle niet bezit — elk veld dat
+// Docker toevoegt (of dat we vergaten) glipte er ongezien doorheen. De nieuwe
+// aanpak:
+//   1. Value-specifieke HARD-DENIES voor de bevestigde escape-vectoren en de
+//      klassiekers — altijd afgedwongen, ongeacht de mode. Dit sluit #1/#2/etc.
+//   2. Een generieke ALLOWLIST-sweep over de overige sleutels: een sleutel die
+//      we niet kennen én die een niet-lege waarde draagt is verdacht. Dit vangt
+//      elk TOEKOMSTIG veld zonder dat we het hoeven te kennen.
+//
+// De Docker-CLI/compose stuurt vrijwel de hele HostConfig-struct mee, meestal
+// met nul-/lege waarden. Daarom flag't de sweep alleen NIET-lege waarden op
+// onbekende sleutels. Omdat de exacte set "genuinely-needed" velden alleen
+// empirisch (tegen echte dev-flows) vast te stellen is, draait de sweep default
+// in LOG-ONLY modus (waarschuwt, weigert niet). Zet HUDDLE_HOSTCONFIG_ENFORCE=1
+// om te handhaven zodra de allowlist tegen echt verkeer gevalideerd is. De
+// hard-denies staan hier los van en zijn altijd actief.
+
+// Sleutels die een gespawnde sandbox-container legitiem met een betekenisvolle
+// waarde mag zetten (resource-limieten, lifecycle, logging, poorten, named
+// volumes). Bewust géén host-/device-/privilege-velden.
+const ALLOWED_HOSTCONFIG_KEYS = new Set<string>([
+  'NetworkMode',
+  'Memory', 'MemoryReservation', 'MemorySwap', 'MemorySwappiness', 'KernelMemory',
+  'NanoCpus', 'CpuShares', 'CpuQuota', 'CpuPeriod', 'CpuRealtimePeriod',
+  'CpuRealtimeRuntime', 'CpusetCpus', 'CpusetMems', 'CpuCount', 'CpuPercent',
+  'BlkioWeight', 'PidsLimit', 'OomKillDisable', 'OomScoreAdj', 'ShmSize',
+  'RestartPolicy', 'AutoRemove', 'LogConfig', 'Init',
+  'Binds', 'Mounts', 'VolumeDriver',
+  'PortBindings', 'PublishAllPorts',
+  'Ulimits', 'Dns', 'DnsOptions', 'DnsSearch', 'ExtraHosts', 'GroupAdd',
+  'CapDrop', 'ReadonlyRootfs', 'Isolation', 'ConsoleSize', 'Annotations',
+  'MaskedPaths', 'ReadonlyPaths',
+]);
+
+// Sleutels met een eigen value-specifieke hard-deny hieronder. Ze zijn "bekend"
+// voor de sweep (hun gevaarlijke waarde is al eerder geweigerd; een onschuldige
+// waarde — bv. Privileged:false, IpcMode:'private' — mag door).
+const HARD_CHECKED_HOSTCONFIG_KEYS = new Set<string>([
+  'Privileged', 'PidMode', 'IpcMode', 'UsernsMode', 'CgroupnsMode', 'UTSMode',
+  'CgroupParent', 'CapAdd', 'Devices', 'Sysctls', 'SecurityOpt',
+  'VolumesFrom', 'DeviceCgroupRules', 'DeviceRequests',
+  'BlkioDeviceReadBps', 'BlkioDeviceWriteBps', 'BlkioDeviceReadIOps', 'BlkioDeviceWriteIOps',
+]);
+
+// Draagt een HostConfig-waarde een betekenisvolle (niet-default) instelling?
+function isMeaningfulValue(v: unknown): boolean {
+  if (v === undefined || v === null || v === false || v === 0 || v === '') return false;
+  if (Array.isArray(v)) return v.length > 0;
+  if (typeof v === 'object') return Object.keys(v as object).length > 0;
+  return true;
+}
+
 // Reject HostConfig shapes that would let a spawned container escape the
-// devcontainer sandbox (read host fs, see host PIDs, talk to host dockerd).
-// Returns a denial reason, or null if the config is safe.
+// devcontainer sandbox (read host fs, see host PIDs/devices, talk to host
+// dockerd). Returns a denial reason, or null if the config is acceptable.
 export function validateHostConfig(hostConfig: any): string | null {
   if (!hostConfig || typeof hostConfig !== 'object') return null;
 
+  // ── Hard-denies (altijd afgedwongen) ──────────────────────────────────────
   if (hostConfig.Privileged === true) return 'Privileged containers not permitted';
   if (hostConfig.PidMode && hostConfig.PidMode !== '') return 'PidMode not permitted';
   if (hostConfig.IpcMode === 'host') return 'IpcMode=host not permitted';
@@ -121,6 +176,21 @@ export function validateHostConfig(hostConfig: any): string | null {
     return 'CapAdd not permitted';
   if (Array.isArray(hostConfig.Devices) && hostConfig.Devices.length > 0)
     return 'Devices not permitted';
+
+  // Finding #1: VolumesFrom laat de nieuwe container de mounts (incl. huddle's
+  // echte docker.sock + CA-key + DB) van een andere container erven → host-takeover.
+  if (Array.isArray(hostConfig.VolumesFrom) && hostConfig.VolumesFrom.length > 0)
+    return 'VolumesFrom not permitted';
+
+  // Finding #2 + device-familie: cgroup/whitelist- en device-request-velden
+  // geven toegang tot host block-/char-devices (raw-disk via default CAP_MKNOD).
+  if (Array.isArray(hostConfig.DeviceCgroupRules) && hostConfig.DeviceCgroupRules.length > 0)
+    return 'DeviceCgroupRules not permitted';
+  if (Array.isArray(hostConfig.DeviceRequests) && hostConfig.DeviceRequests.length > 0)
+    return 'DeviceRequests not permitted';
+  for (const k of ['BlkioDeviceReadBps', 'BlkioDeviceWriteBps', 'BlkioDeviceReadIOps', 'BlkioDeviceWriteIOps'] as const) {
+    if (Array.isArray(hostConfig[k]) && hostConfig[k].length > 0) return `${k} not permitted`;
+  }
 
   const sys = hostConfig.Sysctls;
   if (sys && typeof sys === 'object' && Object.keys(sys).length > 0)
@@ -162,6 +232,24 @@ export function validateHostConfig(hostConfig: any): string | null {
     }
   }
 
+  // ── Generieke allowlist-sweep (log-only default, enforce via env) ──────────
+  // Elke sleutel die we niet herkennen én die een betekenisvolle waarde draagt
+  // is verdacht — dit vangt toekomstige/onbekende velden zonder ze te kennen.
+  const unknown: string[] = [];
+  for (const key of Object.keys(hostConfig)) {
+    if (ALLOWED_HOSTCONFIG_KEYS.has(key) || HARD_CHECKED_HOSTCONFIG_KEYS.has(key)) continue;
+    if (isMeaningfulValue(hostConfig[key])) unknown.push(key);
+  }
+  if (unknown.length > 0) {
+    if (process.env.HUDDLE_HOSTCONFIG_ENFORCE === '1') {
+      return `HostConfig field(s) not permitted: ${unknown.join(', ')}`;
+    }
+    console.warn(
+      `[socket-proxy] HostConfig allowlist (log-only): would reject non-empty field(s): ${unknown.join(', ')}. ` +
+      `Set HUDDLE_HOSTCONFIG_ENFORCE=1 to enforce once validated against real workflows.`
+    );
+  }
+
   if (hostConfig.PortBindings && typeof hostConfig.PortBindings === 'object') {
     for (const [containerPortProto, bindings] of Object.entries(hostConfig.PortBindings)) {
       if (!Array.isArray(bindings)) continue;
@@ -196,6 +284,27 @@ export function validateVolumeCreate(body: any): string | null {
   if (norm.device || (norm.o ?? '').includes('bind') || norm.type === 'none')
     return 'local bind-backed volumes not permitted';
   return null;
+}
+
+// Verzamel de named-volume bronnen uit een HostConfig (Binds + Mounts). Host-
+// path binds en bind-type mounts zijn al door validateHostConfig geweigerd;
+// anonieme volumes (geen Source) worden overgeslagen. Wordt gebruikt voor de
+// ownership-check bij container-create (finding #8).
+function namedVolumeSources(hostConfig: any): string[] {
+  const out: string[] = [];
+  if (Array.isArray(hostConfig?.Binds)) {
+    for (const bind of hostConfig.Binds) {
+      if (typeof bind !== 'string') continue;
+      const src = bind.split(':')[0] ?? '';
+      if (src && !src.startsWith('/') && !src.startsWith('.')) out.push(src);
+    }
+  }
+  if (Array.isArray(hostConfig?.Mounts)) {
+    for (const m of hostConfig.Mounts) {
+      if (m && m.Type === 'volume' && typeof m.Source === 'string' && m.Source) out.push(m.Source);
+    }
+  }
+  return out;
 }
 
 function deny403(client: net.Socket, msg: string): void {
@@ -290,7 +399,7 @@ export async function createContainerProxy(containerName: string, socketDir: str
         openUpstream(Buffer.concat([Buffer.from(newHeader), remainder]));
       }
 
-      function processInjectedBody(): void {
+      async function processInjectedBody(): Promise<void> {
         const bodyBytes = bodyBuf.slice(0, bodyContentLength);
         const rest = bodyBuf.slice(bodyContentLength);
         let body: any;
@@ -312,6 +421,19 @@ export async function createContainerProxy(containerName: string, socketDir: str
             }
           } else {
             deny403(client, denial);
+            return;
+          }
+        }
+        // Finding #8: named-volume ownership. Een devcontainer mag alleen zijn
+        // eigen (huddle.parent) of ongelabelde/operator-volumes mounten — nooit
+        // een volume dat aan een ANDERE devcontainer toebehoort (cross-container
+        // diefstal van source-/credential-volumes). Zelfde semantiek als de
+        // delete/prune-paden. Ongelabelde (pre-bestaande) volumes blijven toe-
+        // gestaan; een nog niet bestaand named volume (404) telt als ongelabeld.
+        for (const src of namedVolumeSources(body.HostConfig)) {
+          const { parent } = await lookupParentLabel('volume', src);
+          if (parent && parent !== containerName) {
+            deny403(client, `cannot mount volume owned by another devcontainer: ${src}`);
             return;
           }
         }
@@ -530,8 +652,15 @@ export async function createContainerProxy(containerName: string, socketDir: str
             return;
           }
 
-          // Volume listing and inspect — needed for docker compose named volumes
-          if (p === '/volumes' || /^\/volumes\/[^/]+$/.test(p)) {
+          // Volume listing — filter tot eigen volumes zodat peer-volumenamen
+          // niet enumereerbaar zijn (finding #8), consistent met de container-
+          // en netwerk-listings hierboven.
+          if (p === '/volumes') {
+            forwardWithRewrittenUrl(headerPart, withLabelFilter(rawUrl, `huddle.parent=${containerName}`), remainder);
+            return;
+          }
+          // Volume inspect — nodig voor docker compose named volumes.
+          if (/^\/volumes\/[^/]+$/.test(p)) {
             openUpstream(Buffer.concat([Buffer.from(headerPart + '\r\n\r\n'), remainder]));
             return;
           }

--- a/gateway/src/token-exchange.ts
+++ b/gateway/src/token-exchange.ts
@@ -2,25 +2,60 @@ import crypto from 'crypto';
 
 const PREFIX = 'huddle_tok_';
 
+// Hoe lang een placeholder inwisselbaar blijft. Dekt een lange dev-sessie; het
+// echte OAuth-token heeft z'n eigen (kortere) levensduur. Bij store-time gelezen
+// (niet bij import) zodat de TTL overschrijfbaar/testbaar is via env.
+function ttlMs(): number {
+  const v = Number(process.env.HUDDLE_TOKEN_PLACEHOLDER_TTL_MS);
+  return Number.isFinite(v) && process.env.HUDDLE_TOKEN_PLACEHOLDER_TTL_MS ? v : 12 * 60 * 60 * 1000;
+}
+
 interface TokenMapping {
   realToken: string;
   containerId: string;
+  expiresAt: number;
 }
 
 const tokenMap = new Map<string, TokenMapping>();
 const containerLatest = new Map<string, string>();
 
-export function storeTokenExchange(containerId: string, realToken: string): string {
-  const prev = containerLatest.get(containerId);
-  if (prev) tokenMap.delete(prev);
+// Constant-tijd vergelijking van twee containerId-strings (voorkomt dat de
+// binding-check via timing te omzeilen is).
+function safeEqual(a: string, b: string): boolean {
+  const ha = crypto.createHash('sha256').update(a).digest();
+  const hb = crypto.createHash('sha256').update(b).digest();
+  return crypto.timingSafeEqual(ha, hb);
+}
+
+// Sla het echte token op achter een placeholder, GEBONDEN aan de container die
+// het aanvroeg (finding #12). Een null container-id levert een placeholder op
+// die nooit inwisselbaar is (fail-closed) i.p.v. de oude gedeelde 'unknown'-
+// bucket waarmee elke onbekende caller andermans token kon inwisselen.
+export function storeTokenExchange(containerId: string | null, realToken: string): string {
+  if (containerId) {
+    const prev = containerLatest.get(containerId);
+    if (prev) tokenMap.delete(prev);
+  }
   const placeholder = PREFIX + crypto.randomBytes(32).toString('hex');
-  tokenMap.set(placeholder, { realToken, containerId });
-  containerLatest.set(containerId, placeholder);
+  // containerId '' bij null → matcht nooit een echte (niet-lege) caller-id.
+  tokenMap.set(placeholder, { realToken, containerId: containerId ?? '', expiresAt: Date.now() + ttlMs() });
+  if (containerId) containerLatest.set(containerId, placeholder);
   return placeholder;
 }
 
-export function resolveToken(placeholder: string): string | null {
-  return tokenMap.get(placeholder)?.realToken ?? null;
+// Wissel een placeholder in voor het echte token — alleen wanneer de caller
+// dezelfde container is die de placeholder kreeg, en de TTL niet verlopen is.
+export function resolveToken(placeholder: string, callerContainerId: string | null): string | null {
+  const entry = tokenMap.get(placeholder);
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) {
+    tokenMap.delete(placeholder);
+    return null;
+  }
+  // Ongebonden (leeg opgeslagen) of ongeïdentificeerde caller → nooit inwisselen.
+  if (!entry.containerId || !callerContainerId) return null;
+  if (!safeEqual(entry.containerId, callerContainerId)) return null;
+  return entry.realToken;
 }
 
 export function isPlaceholderToken(token: string): boolean {

--- a/gateway/test/e2e/boundary.e2e.ts
+++ b/gateway/test/e2e/boundary.e2e.ts
@@ -201,10 +201,13 @@ describe.skipIf(!E2E_ENABLED)('live security boundary', () => {
       await createRule('*.github.com', 'allow');
       await createRule('gist.github.com', 'deny');
       await sleep(1000);
-      // Exact (lowercase) → geblokkeerd.
-      expect(curlStatusIn(E2E_NAME, 'https://gist.github.com')).toBe('403');
-      // Zelfde host, ge-kapitaliseerd → mag NIET ineens door de wildcard-allow.
-      expect(curlStatusIn(E2E_NAME, 'https://GIST.GITHUB.COM')).toBe('403');
+      // Een host-level HTTPS-deny weigert de CONNECT-tunnel: curl krijgt géén
+      // HTTP-status (http_code '000'; de 403 zit in de CONNECT-respons, niet in
+      // http_code — anders dan het plain-HTTP-pad hierboven). Zou casing de deny
+      // omzeilen, dan matchte de host de wildcard-allow en wérd de CONNECT
+      // geaccepteerd (geen '000'). Zowel exact als ge-kapitaliseerd moet dus '000'.
+      expect(curlStatusIn(E2E_NAME, 'https://gist.github.com')).toBe('000');
+      expect(curlStatusIn(E2E_NAME, 'https://GIST.GITHUB.COM')).toBe('000');
     });
 
     // Finding #7 (MEDIUM) — pad-allowlist bypass via traversal. `--path-as-is`

--- a/gateway/test/e2e/boundary.e2e.ts
+++ b/gateway/test/e2e/boundary.e2e.ts
@@ -3,8 +3,9 @@ import {
   E2E_ENABLED, E2E_NAME, E2E_IMAGE,
   dockerAvailable, assertHuddleReachable,
   spawnDevcontainer, removeDevcontainer,
-  execIn, curlStatusIn,
-  clearRulesForDomain, allowDomain, setGrant, revokeGrant, setActionPolicy, sleep,
+  execIn, curlStatusIn, run,
+  clearRulesForDomain, allowDomain, createRule, enablePathMode,
+  setGrant, revokeGrant, setActionPolicy, sleep,
 } from './helpers';
 
 // ── LIVE security-boundary suite (T1–T11 stijl) ─────────────────────────────
@@ -143,6 +144,82 @@ describe.skipIf(!E2E_ENABLED)('live security boundary', () => {
         expect(r.status).not.toBe(0);
         expect(`${r.stdout}${r.stderr}`).toMatch(/not owned|not permitted/i);
       });
+
+      // Finding #1 (CRITICAL) — VolumesFrom erft huddle's echte docker.sock +
+      // CA-key + DB → host/daemon-takeover. Moet nu door de allowlist sneuvelen.
+      it('weigert HostConfig.VolumesFrom (finding #1)', async () => {
+        const r = execIn(E2E_NAME, `docker create --name e2e-pwned --volumes-from huddle ${E2E_IMAGE} true`);
+        expect(r.status).not.toBe(0);
+        expect(`${r.stdout}${r.stderr}`).toMatch(/volumesfrom not permitted/i);
+        execIn(E2E_NAME, 'docker rm -f e2e-pwned 2>/dev/null || true');
+      });
+
+      // Finding #2 (HIGH) — DeviceCgroupRules whitelist't host block-devices;
+      // met default CAP_MKNOD → raw-disk toegang. --privileged wordt al geweigerd;
+      // deze variant mag óók niet meer door.
+      it('weigert HostConfig.DeviceCgroupRules (finding #2)', async () => {
+        const r = execIn(E2E_NAME, `docker create --name e2e-dcr --device-cgroup-rule "b 8:0 rwm" ${E2E_IMAGE} true`);
+        expect(r.status).not.toBe(0);
+        expect(`${r.stdout}${r.stderr}`).toMatch(/devicecgrouprules not permitted/i);
+        execIn(E2E_NAME, 'docker rm -f e2e-dcr 2>/dev/null || true');
+      });
+
+      // Finding #8 (MEDIUM) — cross-container volume-diefstal: een volume dat aan
+      // een ANDERE devcontainer toebehoort mag niet gemount worden.
+      it('weigert het mounten van andermans named volume (finding #8)', async () => {
+        // Operator/host maakt een volume dat aan een peer-devcontainer toebehoort.
+        run('docker', ['volume', 'rm', '-f', 'e2e-victimvol']);
+        run('docker', ['volume', 'create', '--label', 'huddle.parent=devcontainer-victim', 'e2e-victimvol']);
+        run('docker', ['run', '--rm', '-v', 'e2e-victimvol:/v', E2E_IMAGE, 'sh', '-c', 'echo victim-secret-XYZ > /v/s.txt']);
+        try {
+          const r = execIn(E2E_NAME, `docker create --name e2e-steal -v e2e-victimvol:/loot ${E2E_IMAGE} cat /loot/s.txt`);
+          expect(r.status).not.toBe(0);
+          expect(`${r.stdout}${r.stderr}`).toMatch(/owned by another devcontainer/i);
+          execIn(E2E_NAME, 'docker rm -f e2e-steal 2>/dev/null || true');
+        } finally {
+          run('docker', ['volume', 'rm', '-f', 'e2e-victimvol']);
+        }
+      });
+    });
+  });
+
+  // ── Firewall parser-differential regressies (#3, #7) ──────────────────────
+  // Eigen domeinen (github.com / example.org) zodat deze concurrent naast de
+  // example.com-firewalltest kan draaien zonder state-botsing.
+  describe('firewall parser-differential', () => {
+    afterAll(async () => {
+      await clearRulesForDomain('*.github.com');
+      await clearRulesForDomain('gist.github.com');
+      await clearRulesForDomain('example.org');
+    });
+
+    // Finding #3 (HIGH) — de broad-allow/specific-deny vorm mag niet met casing
+    // te omzeilen zijn.
+    it('CONNECT casing omzeilt een exacte deny niet (finding #3)', async () => {
+      await clearRulesForDomain('*.github.com');
+      await clearRulesForDomain('gist.github.com');
+      await createRule('*.github.com', 'allow');
+      await createRule('gist.github.com', 'deny');
+      await sleep(1000);
+      // Exact (lowercase) → geblokkeerd.
+      expect(curlStatusIn(E2E_NAME, 'https://gist.github.com')).toBe('403');
+      // Zelfde host, ge-kapitaliseerd → mag NIET ineens door de wildcard-allow.
+      expect(curlStatusIn(E2E_NAME, 'https://GIST.GITHUB.COM')).toBe('403');
+    });
+
+    // Finding #7 (MEDIUM) — pad-allowlist bypass via traversal. `--path-as-is`
+    // bootst een aanvaller-client na die het pad niet client-side normaliseert.
+    it('pad-traversal glipt niet door een /foo/* allowlist (finding #7)', async () => {
+      await clearRulesForDomain('example.org');
+      const denyId = await createRule('example.org', 'deny');
+      await enablePathMode(denyId);
+      await createRule('example.org', 'allow', { path_pattern: '/foo/*' });
+      await sleep(1000);
+      // Legitiem subpad mag (bereikt upstream — 2xx/3xx/4xx, in elk geval geen 403).
+      expect(curlStatusIn(E2E_NAME, 'https://example.org/foo/', '--path-as-is')).not.toBe('403');
+      // Traversal buiten /foo/ → door Huddle geblokkeerd (403), niet doorgestuurd.
+      expect(curlStatusIn(E2E_NAME, 'https://example.org/foo/../secret', '--path-as-is')).toBe('403');
+      expect(curlStatusIn(E2E_NAME, 'https://example.org/foo/..%2f..%2fadmin', '--path-as-is')).toBe('403');
     });
   });
 

--- a/gateway/test/e2e/helpers.ts
+++ b/gateway/test/e2e/helpers.ts
@@ -117,6 +117,26 @@ export async function allowDomain(domain: string, container: string): Promise<vo
   }
 }
 
+// Maak een verse rule aan (globaal tenzij container gegeven) en geef het id terug.
+export async function createRule(
+  domain: string,
+  status: 'allow' | 'deny' | 'requested',
+  opts: { container?: string | null; path_pattern?: string | null } = {},
+): Promise<number> {
+  const r = await api('POST', '/api/rules', {
+    domain, status,
+    container_id: opts.container ?? null,
+    path_pattern: opts.path_pattern ?? null,
+  });
+  return r.id as number;
+}
+
+// Zet een host-only regel in pad-allowlist modus (kaal domein dicht, subpaden
+// afzonderlijk goed te keuren).
+export async function enablePathMode(ruleId: number): Promise<void> {
+  await api('POST', `/api/rules/${ruleId}/path-mode`, { enabled: true });
+}
+
 export async function setGrant(container: string, minutes: number): Promise<void> {
   await api('PUT', `/api/authz/grants/${encodeURIComponent(container)}`, { minutes });
 }

--- a/gateway/test/extension-integrity.test.ts
+++ b/gateway/test/extension-integrity.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { bundleSha256, checkExtensionIntegrity } from '../src/extensions/loader';
+
+// Extensie-integriteitscheck (finding #11). loader.ts importeert better-sqlite3
+// alleen als type (erased op runtime) en instantieert geen DB, dus dit draait
+// zonder de native binding.
+
+const bundle = Buffer.from('fake-extension-zip-bytes');
+const hash = bundleSha256(bundle);
+
+afterEach(() => { delete process.env.HUDDLE_EXTENSION_SHA256_ALLOWLIST; });
+
+describe('checkExtensionIntegrity', () => {
+  it('log-only zonder allowlist → toegestaan (null)', () => {
+    expect(checkExtensionIntegrity(bundle)).toBeNull();
+  });
+
+  it('bundel op de allowlist → toegestaan', () => {
+    process.env.HUDDLE_EXTENSION_SHA256_ALLOWLIST = hash;
+    expect(checkExtensionIntegrity(bundle)).toBeNull();
+  });
+
+  it('allowlist gezet maar bundel-hash ontbreekt → geweigerd', () => {
+    process.env.HUDDLE_EXTENSION_SHA256_ALLOWLIST = 'deadbeef';
+    expect(checkExtensionIntegrity(bundle)).toMatch(/not on HUDDLE_EXTENSION_SHA256_ALLOWLIST/);
+  });
+
+  it('allowlist is hoofdletter-ongevoelig en tolereert spaties', () => {
+    process.env.HUDDLE_EXTENSION_SHA256_ALLOWLIST = ` OTHER , ${hash.toUpperCase()} `;
+    expect(checkExtensionIntegrity(bundle)).toBeNull();
+  });
+});

--- a/gateway/test/host-config.test.ts
+++ b/gateway/test/host-config.test.ts
@@ -40,6 +40,64 @@ describe('validateHostConfig', () => {
     });
     expect(denial).toMatch(/driverconfig not permitted/i);
   });
+
+  // ── Findings #1 / #2 — bevestigde escape-vectoren (hard-deny) ──────────────
+  it('weigert HostConfig.VolumesFrom (finding #1 — erven van huddle-mounts)', () => {
+    expect(validateHostConfig({ VolumesFrom: ['huddle'] })).toMatch(/volumesfrom not permitted/i);
+    // Lege VolumesFrom (wat de CLI standaard meestuurt) is ONSCHULDIG.
+    expect(validateHostConfig({ VolumesFrom: [] })).toBeNull();
+  });
+  it('weigert HostConfig.DeviceCgroupRules (finding #2 — host raw-disk)', () => {
+    expect(validateHostConfig({ DeviceCgroupRules: ['b 8:0 rwm'] })).toMatch(/devicecgrouprules not permitted/i);
+    expect(validateHostConfig({ DeviceCgroupRules: [] })).toBeNull();
+  });
+  it('weigert de rest van de device-familie (DeviceRequests, Blkio device-limieten)', () => {
+    expect(validateHostConfig({ DeviceRequests: [{ Driver: 'nvidia', Count: -1 }] })).toMatch(/devicerequests not permitted/i);
+    expect(validateHostConfig({ BlkioDeviceReadBps: [{ Path: '/dev/sda', Rate: 1 }] })).toMatch(/blkiodevicereadbps not permitted/i);
+    expect(validateHostConfig({ BlkioDeviceWriteIOps: [{ Path: '/dev/sda', Rate: 1 }] })).toMatch(/blkiodevicewriteiops not permitted/i);
+  });
+
+  // ── Generieke allowlist-sweep over onbekende velden ────────────────────────
+  it('staat de nul-/lege waarden toe die de Docker-CLI standaard meestuurt', () => {
+    // Een representatieve `docker run`-achtige HostConfig met veel default-velden.
+    const denial = validateHostConfig({
+      NetworkMode: 'bridge',
+      Memory: 0, CpuShares: 0, NanoCpus: 0,
+      RestartPolicy: { Name: 'no', MaximumRetryCount: 0 },
+      LogConfig: { Type: 'json-file', Config: {} },
+      Binds: null, VolumesFrom: [], CapAdd: [], CapDrop: [], Devices: [],
+      DeviceCgroupRules: [], Privileged: false, IpcMode: 'private',
+      MaskedPaths: ['/proc/kcore'], ReadonlyPaths: ['/proc/sysrq-trigger'],
+      Ulimits: [{ Name: 'nofile', Soft: 1024, Hard: 2048 }],
+      AutoRemove: true,
+    });
+    expect(denial).toBeNull();
+  });
+  it('log-only default: een onbekend niet-leeg veld wordt NIET geweigerd', () => {
+    delete process.env.HUDDLE_HOSTCONFIG_ENFORCE;
+    expect(validateHostConfig({ SomeFutureField: { danger: true } })).toBeNull();
+  });
+  it('enforce-mode: een onbekend niet-leeg veld wordt geweigerd', () => {
+    process.env.HUDDLE_HOSTCONFIG_ENFORCE = '1';
+    try {
+      expect(validateHostConfig({ SomeFutureField: { danger: true } })).toMatch(/not permitted: SomeFutureField/);
+      // Een onbekend veld met een lege waarde blijft toegestaan, ook in enforce.
+      expect(validateHostConfig({ SomeFutureField: [] })).toBeNull();
+    } finally {
+      delete process.env.HUDDLE_HOSTCONFIG_ENFORCE;
+    }
+  });
+  it('enforce-mode breekt de legitieme create-body niet', () => {
+    process.env.HUDDLE_HOSTCONFIG_ENFORCE = '1';
+    try {
+      expect(validateHostConfig({
+        NetworkMode: 'bridge', Memory: 536870912, CpuQuota: 200000, CpuPeriod: 100000,
+        RestartPolicy: { Name: 'unless-stopped' }, Mounts: [{ Type: 'volume', Source: 'data', Target: '/data' }],
+      })).toBeNull();
+    } finally {
+      delete process.env.HUDDLE_HOSTCONFIG_ENFORCE;
+    }
+  });
 });
 
 describe('validateVolumeCreate', () => {

--- a/gateway/test/pty-join-audit.test.ts
+++ b/gateway/test/pty-join-audit.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// PTY-join audit (finding #13): meerdere clients delen één shell per container.
+// Een tweede client die aanhaakt op een bestaande sessie MOET als 'attach:join'
+// in de audit-log verschijnen — in het gedeelde-token-model kunnen we een join
+// niet verbieden, maar een stille overname mag niet kunnen. We mocken de
+// docker-exec-laag (geen echte container nodig) en vangen logAudit af.
+
+const auditCalls: Array<{ containerId?: string | null; domain?: string; action?: string }> = [];
+vi.mock('../src/db', () => ({
+  logAudit: (e: { containerId?: string | null; domain?: string; action?: string }) => { auditCalls.push(e); },
+}));
+
+// Minimale ReadWriteStream-stub: pty-manager registreert alleen handlers en
+// schrijft; niets hoeft te vuren voor de attach-audit.
+const fakeStream = { on: () => fakeStream, write: () => true, end: () => {} };
+vi.mock('../src/terminal', () => ({
+  dockerExec: async () => 'exec-1',
+  dockerExecStart: async () => fakeStream,
+  dockerExecResize: async () => {},
+}));
+
+vi.mock('../src/docker', () => ({
+  listDevcontainers: async () => [{ name: 'devcontainer-x' }],
+}));
+
+const { ptyManager } = await import('../src/pty-manager');
+
+// WebSocket-stub: attach() registreert message/close/error-handlers en leest
+// readyState; verder is niets nodig.
+function fakeWs(): any {
+  return { readyState: 1, on: () => {}, send: () => {}, close: () => {} };
+}
+
+describe('pty-manager join-audit (finding #13)', () => {
+  beforeEach(() => { auditCalls.length = 0; });
+
+  it('logt de eerste client als attach:owner en de tweede als attach:join', async () => {
+    await ptyManager.attach(fakeWs(), 'devcontainer-x');
+    await ptyManager.attach(fakeWs(), 'devcontainer-x');
+
+    const attachActions = auditCalls
+      .filter(e => e.domain === 'terminal' && String(e.action).startsWith('attach'))
+      .map(e => e.action);
+
+    expect(attachActions[0]).toBe('attach:owner');
+    expect(attachActions[1]).toBe('attach:join(2 clients)');
+  });
+});

--- a/gateway/test/rules.test.ts
+++ b/gateway/test/rules.test.ts
@@ -31,6 +31,8 @@ let matchDomain: typeof import('../src/rules').matchDomain;
 let matchPath: typeof import('../src/rules').matchPath;
 let firstSegmentPattern: typeof import('../src/rules').firstSegmentPattern;
 let isPathMode: typeof import('../src/rules').isPathMode;
+let canonicalizeHost: typeof import('../src/rules').canonicalizeHost;
+let normalizePathname: typeof import('../src/rules').normalizePathname;
 
 const CID = 'container-abc';
 
@@ -58,6 +60,8 @@ describe.skipIf(!sqliteAvailable)('checkRule', () => {
     matchPath = rulesMod.matchPath;
     firstSegmentPattern = rulesMod.firstSegmentPattern;
     isPathMode = rulesMod.isPathMode;
+    canonicalizeHost = rulesMod.canonicalizeHost;
+    normalizePathname = rulesMod.normalizePathname;
     dbMod.initDb();
   });
   beforeEach(() => { db.exec('DELETE FROM rules'); db.exec('DELETE FROM containers'); });
@@ -292,6 +296,116 @@ describe.skipIf(!sqliteAvailable)('checkRule', () => {
     it('host-only allow matcht ongeacht het pad', () => {
       setRule('hostonly.test', CID, 'allow');
       expect(checkRule('hostonly.test', CID, '/any/path').status).toBe('allow');
+    });
+  });
+
+  // ── Finding #3 — hoofdletter-bypass van exacte deny-regels ─────────────────
+  // De klassieke broad-allow/specific-deny vorm: `*.github.com` allow +
+  // `gist.github.com` deny. Een ge-kapitaliseerde host mocht de deny NIET
+  // omzeilen (was een reliable firewall-bypass via CONNECT GIST.GITHUB.COM).
+  describe('regressie #3: casing omzeilt geen exacte deny', () => {
+    it('exacte deny wint van wildcard allow, ongeacht de host-casing', () => {
+      setRule('*.github.com', null, 'allow');
+      setRule('gist.github.com', null, 'deny');
+      expect(checkRule('gist.github.com', CID).status).toBe('deny');
+      // Zelfde host, ge-kapitaliseerd — checkRule lowercase't het domein-argument
+      // en de exacte SQL-lookup is COLLATE NOCASE.
+      expect(checkRule('GIST.GITHUB.COM', CID).status).toBe('deny');
+      expect(checkRule('Gist.GitHub.Com', CID).status).toBe('deny');
+    });
+    it('een deny-regel die zelf ge-kapitaliseerd is opgeslagen matcht ook', () => {
+      // Simuleer een oude, niet-gemigreerde rij (mixed case) — COLLATE NOCASE
+      // op de index/lookup vangt hem alsnog.
+      db.prepare(`INSERT INTO rules (domain, container_id, status) VALUES ('EVIL.TEST', NULL, 'deny')`).run();
+      expect(checkRule('evil.test', CID).status).toBe('deny');
+    });
+  });
+
+  // ── Finding #7 — pad-traversal door een pad-allowlist ──────────────────────
+  describe('regressie #7: pad-normalisatie blokkeert traversal', () => {
+    it('`/foo/../secret` matcht niet langer een `/foo/*` allow', () => {
+      setRule('example.com', CID, 'deny', null, null, 1);          // path-mode marker
+      setRule('example.com', CID, 'allow', null, '/foo/*');        // alleen /foo/* toegestaan
+      expect(checkRule('example.com', CID, '/foo/bar').status).toBe('allow');
+      // Traversal → normaliseert weg van /foo/ → niet meer 'allow'.
+      expect(checkRule('example.com', CID, '/foo/../secret').status).not.toBe('allow');
+      expect(checkRule('example.com', CID, '/foo/..%2f..%2fadmin').status).not.toBe('allow');
+      expect(checkRule('example.com', CID, '/foo/../').status).not.toBe('allow');
+    });
+  });
+
+  describe('canonicalizeHost (pure helper)', () => {
+    it('lowercase + trailing dot strippen', () => {
+      expect(canonicalizeHost('GIST.GITHUB.COM')).toBe('gist.github.com');
+      expect(canonicalizeHost('example.com.')).toBe('example.com');
+      expect(canonicalizeHost('Example.COM.')).toBe('example.com');
+    });
+    it('IDN → punycode (de vorm die DNS/SNI zien)', () => {
+      // bücher.example → xn--bcher-kva.example
+      expect(canonicalizeHost('bücher.example')).toBe('xn--bcher-kva.example');
+    });
+    it('weigert control chars, whitespace en lege host', () => {
+      expect(canonicalizeHost('')).toBeNull();
+      expect(canonicalizeHost('  ')).toBeNull();
+      expect(canonicalizeHost('evil.com\r\nHost: x')).toBeNull();
+      expect(canonicalizeHost('a b.com')).toBeNull();
+    });
+    it('is idempotent op een al-canonieke host', () => {
+      expect(canonicalizeHost('gist.github.com')).toBe('gist.github.com');
+    });
+  });
+
+  describe('normalizePathname (pure helper)', () => {
+    it('laat een normaal pad ongemoeid (incl. trailing slash)', () => {
+      expect(normalizePathname('/api/v1/foo')).toBe('/api/v1/foo');
+      expect(normalizePathname('/api/v1/')).toBe('/api/v1/');
+      expect(normalizePathname('/')).toBe('/');
+    });
+    it('strip query en fragment', () => {
+      expect(normalizePathname('/foo?x=1')).toBe('/foo');
+      expect(normalizePathname('/foo#frag')).toBe('/foo');
+    });
+    it('vouwt `.`-segmenten weg', () => {
+      expect(normalizePathname('/foo/./bar')).toBe('/foo/bar');
+    });
+    it('fail-closed op `..`-traversal (plain, %-encoded, dubbel-slash)', () => {
+      expect(normalizePathname('/foo/../secret')).toBeNull();
+      expect(normalizePathname('/foo/..%2f..%2fadmin')).toBeNull();
+      expect(normalizePathname('/foo/../')).toBeNull();
+      expect(normalizePathname('/..')).toBeNull();
+    });
+    it('fail-closed op kapotte percent-encoding', () => {
+      expect(normalizePathname('/foo/%zz')).toBeNull();
+      expect(normalizePathname('/foo/%2')).toBeNull();
+    });
+    it('behandelt dubbel-encoded `..` als een letterlijk segment (single decode)', () => {
+      // %252e%252e → één decode → %2e%2e (geen `..`-segment) → géén traversal.
+      expect(normalizePathname('/foo/%252e%252e/x')).toBe('/foo/%2e%2e/x');
+    });
+    it('behoudt legitieme %-encoded tekens (geen verminking van de beslissing)', () => {
+      // %2e%2e = `..` → traversal → fail closed.
+      expect(normalizePathname('/foo/%2e%2e/x')).toBeNull();
+      // een gewoon encoded teken (spatie) in een segment blijft een geldig pad.
+      expect(normalizePathname('/a%20b/c')).toBe('/a b/c');
+    });
+  });
+
+  describe('matchPath: segment-grens (regressie #7 tail)', () => {
+    it('`*`-suffix matcht alleen op een segment-grens', () => {
+      expect(matchPath('/safe*', '/safe')).toBe(true);
+      expect(matchPath('/safe*', '/safe/x')).toBe(true);
+      expect(matchPath('/safe*', '/safe-danger')).toBe(false);
+    });
+    it('`/foo/*` matcht subpaden maar niet na traversal', () => {
+      expect(matchPath('/foo/*', '/foo/bar')).toBe(true);
+      expect(matchPath('/foo/*', '/foo/../secret')).toBe(false);
+      expect(matchPath('/foo/*', '/foo/..%2fsecret')).toBe(false);
+    });
+    it('null/leeg patroon (host-only) matcht elk pad, ook traversal', () => {
+      // Host-only regels handhaven geen pad; traversal-bescherming zit in de
+      // pad-regels zelf.
+      expect(matchPath(null, '/foo/../secret')).toBe(true);
+      expect(matchPath('', '/whatever')).toBe(true);
     });
   });
 });

--- a/gateway/test/token-exchange.test.ts
+++ b/gateway/test/token-exchange.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { storeTokenExchange, resolveToken, isPlaceholderToken } from '../src/token-exchange';
+
+// Token-exchange containerId-binding (finding #12). Puur (alleen crypto).
+
+describe('token-exchange containerId binding', () => {
+  it('de container die het token kreeg kan het inwisselen', () => {
+    const ph = storeTokenExchange('container-a', 'REAL-TOKEN');
+    expect(isPlaceholderToken(ph)).toBe(true);
+    expect(resolveToken(ph, 'container-a')).toBe('REAL-TOKEN');
+  });
+
+  it('een ANDERE container kan het niet inwisselen (geen cross-container bearer)', () => {
+    const ph = storeTokenExchange('container-a', 'REAL-TOKEN');
+    expect(resolveToken(ph, 'container-b')).toBeNull();
+  });
+
+  it('een ongeïdentificeerde caller (null) kan niets inwisselen', () => {
+    const ph = storeTokenExchange('container-a', 'REAL-TOKEN');
+    expect(resolveToken(ph, null)).toBeNull();
+  });
+
+  it('een null-container placeholder is nooit inwisselbaar (geen "unknown"-bucket)', () => {
+    const ph = storeTokenExchange(null, 'REAL-TOKEN');
+    expect(resolveToken(ph, '')).toBeNull();
+    expect(resolveToken(ph, 'anything')).toBeNull();
+  });
+
+  it('onbekende placeholder → null', () => {
+    expect(resolveToken('huddle_tok_deadbeef', 'container-a')).toBeNull();
+  });
+
+  describe('TTL', () => {
+    beforeEach(() => { delete process.env.HUDDLE_TOKEN_PLACEHOLDER_TTL_MS; });
+
+    it('een verlopen placeholder wordt niet meer ingewisseld', async () => {
+      process.env.HUDDLE_TOKEN_PLACEHOLDER_TTL_MS = '5'; // 5ms
+      const ph = storeTokenExchange('container-a', 'REAL-TOKEN');
+      await new Promise(r => setTimeout(r, 15));
+      delete process.env.HUDDLE_TOKEN_PLACEHOLDER_TTL_MS;
+      expect(resolveToken(ph, 'container-a')).toBeNull();
+    });
+  });
+});

--- a/gateway/test/vscode-ide-hardening.test.ts
+++ b/gateway/test/vscode-ide-hardening.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+
+// VS Code Remote IDE-kanaal hardening (finding #15). buildVscodeMachineSettings
+// leeft in docker.ts, dat bij import de native better-sqlite3-binding laadt
+// (listFolderMappings); die ontbreekt in een verse DMZ-devcontainer. Probe en
+// sla anders over — draait volledig in CI / de huddle-image.
+let sqliteAvailable = true;
+try {
+  const mod = await import('better-sqlite3');
+  new mod.default(':memory:').close();
+} catch (e) {
+  sqliteAvailable = false;
+  console.warn(`[vscode-ide-hardening.test] SKIPPED — better-sqlite3 binding niet bruikbaar: ${(e as Error).message}`);
+}
+
+const d = sqliteAvailable ? describe : describe.skip;
+const { buildVscodeMachineSettings } = sqliteAvailable
+  ? await import('../src/docker')
+  : ({ buildVscodeMachineSettings: (() => ({})) as any });
+
+d('buildVscodeMachineSettings (#15)', () => {
+  const s = buildVscodeMachineSettings() as Record<string, any>;
+
+  it('dwingt workspace trust af (blokkeert folderOpen auto-run)', () => {
+    expect(s['security.workspace.trust.enabled']).toBe(true);
+    expect(s['security.workspace.trust.emptyWindow']).toBe(false);
+    expect(s['task.allowAutomaticTasks']).toBe('off');
+  });
+
+  it('blokkeert een host-terminal vanuit het remote-venster', () => {
+    expect(s['terminal.integrated.allowLocalTerminal']).toBe(false);
+  });
+
+  it('leegt de doorgestuurde host-credential-env in terminals', () => {
+    const env = s['terminal.integrated.env.linux'];
+    for (const k of ['GIT_ASKPASS', 'VSCODE_GIT_ASKPASS_NODE', 'VSCODE_GIT_ASKPASS_MAIN',
+                     'VSCODE_GIT_IPC_HANDLE', 'SSH_AUTH_SOCK', 'GPG_AGENT_INFO', 'GPG_TTY']) {
+      expect(env[k]).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
<!--
Thanks for contributing to Huddle! Please fill in this template.
See CONTRIBUTING.md for the full workflow, coding standards, and commit conventions.
-->

## Summary

Squashed security-hardening work on top of `main` (operator-auth + source-IP-gate
removal already landed via #47). The finding numbers below refer to the internal
security review, not GitHub issues (none were opened). Internal review/design docs
and the Aikido extension changes (findings 6 and 14) are intentionally left out of
this branch.

- **Socket-proxy HostConfig allowlist (findings 1–2):** reject `VolumesFrom`,
  `DeviceCgroupRules`, `DeviceRequests` and the device family (host/daemon
  takeover, raw-disk access).
- **CONNECT hostname casing (finding 3):** canonicalize the host + `COLLATE NOCASE`
  so casing can't bypass an exact deny carved out of a wildcard allow.
- **Path-allowlist normalization (finding 7):** fail-closed on `../` and `..%2f`,
  segment boundaries; the normalized path is forwarded upstream.
- **Volume ownership (finding 8):** named-volume `huddle.parent` check +
  `GET /volumes` filtered to the caller's own volumes.
- **Folder-mapping SQL injection (finding 9):** column allowlist kills the
  JSON-key injection; route returns 400/404 instead of 500.
- **Extension integrity (finding 11):** SHA-256 check of the bundle before
  extraction (allowlist).
- **Token placeholder scoping (finding 12):** bound to the requesting container
  (timing-safe) + TTL; no shared `unknown` bucket; redacted from the audit body.
- **PTY join visibility (finding 13):** multi-attach logs `attach:owner` vs
  `attach:join(N)` so a join is never silent (regression test added).
- **IDE credential channel (finding 15):** VS Code Machine settings (workspace
  trust, no auto-tasks, no local terminal, null credential env) + a container-side
  guard that strips the forwarded git `credential.helper` from `/etc/gitconfig`
  and `~/.gitconfig`, tears down the forwarded GPG/SSH/askpass sockets, and
  re-applies on inotify events (fallback poll). JetBrains gets the shared
  env/socket scrub. Verified live: `git push` and `git credential fill` no longer
  obtain host creds.
- **e2e:** authenticate with `HUDDLE_OPERATOR_TOKEN`; split devcontainer→API into
  proxy path (403) and direct path (401); targeted pre-flight on auth misconfig.

## How to try it (experiment 48)

Pushing this branch publishes a full experiment build (CLI + gateway/base images)
under the tag `experiment-48`, so reviewers can test end-to-end on their own
Docker/Podman host:

```
# als je al op een ander experiment zit: eerst resetten (anders blijft de CLI
# op de oude versie hangen — die vergelijkt alleen het experimentnummer)
huddle experiment reset

huddle experiment use 48        # installeert CLI + images van experiment 48 en init't
# of, in één keer vanuit een schone stand:
huddle init --experiment 48
```

Terug naar de stabiele versie:

```
huddle experiment reset
```

Snelle rooktest van de finding-15-fix in een verse devcontainer (host-creds mogen
er niet meer in zitten):

```
printf 'protocol=https\nhost=github.com\n\n' | GIT_TERMINAL_PROMPT=0 git credential fill   # geen password=
git push --dry-run origin HEAD:refs/heads/_test                                             # faalt op auth
```

## Related issue

No GitHub issues were opened for these; the finding numbers track the internal
security review (findings 1–15). Addressed here: 1, 2, 3, 7, 8, 9, 11, 12, 13, 15.
Deliberately **not** in this branch (remain open): findings 6 and 14 (Aikido
extension, handled separately).

## Type of change

- [x] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Documentation (`docs`)
- [ ] Refactor / maintenance (`refactor` / `chore`)
- [ ] Other:

## Checklist

- [x] My branch is up to date with `main` and focused on a single change.
- [ ] The project **builds** and **type-checks** locally. <!-- niet lokaal te draaien: npm install wordt door de Huddle-firewall geblokkeerd; leunt op CI -->
- [ ] Tests pass (`npm --prefix gateway test`) and I added/updated tests where relevant. <!-- tests toegevoegd (o.a. pty-join-audit); niet lokaal gedraaid (firewall), draait in CI -->
- [ ] I ran Prettier and did not reformat unrelated code. <!-- controleer/draai vóór merge -->
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] I did not introduce logging of secrets, tokens, or credentials.
- [x] Documentation is updated where needed (README / relevant docs). <!-- interne review/design-docs bewust uit de branch gehouden -->

## Notes for reviewers

- **Bouwt op #47:** operator-token-auth en het verwijderen van de source-IP-gate
  zaten al in `main` via #47; deze branch is de resterende hardening.
- **Finding 15 is containerkant defense-in-depth, niet formeel 100%.** Het
  attach-kanaal wordt door de host-IDE gedreven; de guard maakt het *gebruik* van
  doorgestuurde credentials onmogelijk (helper-strip + socket-teardown via
  inotify). Live geverifieerd in een herstarte devcontainer: `git push` faalt op
  auth en `git credential fill` geeft geen token meer. De structureel-airtight
  route (server-side IDE achter de proxy) is Phase 1.
- **Neveneffect van de guard:** binnen de devcontainer werkt push met de
  doorgestuurde host-credentials niet meer — dat is het beoogde gedrag. Pushen
  vanuit de container vergt nu een bewust eigen token/deploy-key.
- **Findings 6 en 14 (Aikido) blijven open** — bewust uit deze branch gehouden;
  beleg ze bij de Aikido-revisie zodat ze niet tussen wal en schip vallen.
  Finding 6 is een High (langlevend OAuth-secret + globale API-key in de untrusted
  container).
- **Lokale build/test niet gedraaid:** `npm install` voor de gateway wordt door de
  Huddle-firewall geblokkeerd; typecheck/vitest/e2e leunen op CI. Wel gedaan:
  POSIX-syntaxchecks van de gegenereerde config-shell en functionele checks van de
  guard-logica.
- **Testen (na build in CI / lokaal met engine):**
  ```
  # in een verse devcontainer
  printf 'protocol=https\nhost=github.com\n\n' | GIT_TERMINAL_PROMPT=0 git credential fill   # geen password=
  ls -la ~/.gnupg/S.gpg-agent*                                                                # bestaat niet
  git push --dry-run origin HEAD:refs/heads/_test                                             # faalt op auth
  ```
