### PR TITLE
fix(proxy): forward original encoded request-path instead of decoded …

### DIFF
--- a/gateway/src/proxy.ts
+++ b/gateway/src/proxy.ts
@@ -4,12 +4,12 @@ import net from 'net';
 import tls from 'tls';
 import stream from 'stream';
 import zlib from 'zlib';
-import { URL } from 'url';
-import { checkRule, isPathMode, canonicalizeHost, normalizePathname } from './rules';
-import { resolveContainerByIp } from './docker';
-import { logAudit, updateAuditResponse } from './db';
-import { signLeafCert } from './tls-ca';
-import { storeTokenExchange, resolveToken, isPlaceholderToken } from './token-exchange';
+import {URL} from 'url';
+import {canonicalizeHost, checkRule, isPathMode, normalizePathname} from './rules';
+import {resolveContainerByIp} from './docker';
+import {logAudit, updateAuditResponse} from './db';
+import {signLeafCert} from './tls-ca';
+import {isPlaceholderToken, resolveToken, storeTokenExchange} from './token-exchange';
 
 const PROXY_PORT = 80;
 
@@ -126,8 +126,7 @@ function handleTokenExchangeResponse(
         // Bind de placeholder aan de aanvragende container (finding #12); geen
         // 'unknown'-fallback meer. Een null container levert een niet-inwissel-
         // bare placeholder op (fail-closed).
-        const placeholder = storeTokenExchange(containerId, json.access_token as string);
-        json.access_token = placeholder;
+        json.access_token = storeTokenExchange(containerId, json.access_token as string);
         console.log(`[token-exchange] placeholder issued voor container ${containerId}`);
         outBuf = Buffer.from(JSON.stringify(json));
         delete outHeaders['content-encoding'];
@@ -184,9 +183,14 @@ export function createProxyServer(): http.Server {
       return;
     }
 
-    // Normaliseer het pad naar de vorm die de upstream zal interpreteren en
-    // forward exact dat pad. `new URL` heeft `../` al weggevouwen; normalizePathname
-    // dekt daarnaast `%2f`-getruceerde traversal (finding #7) en weigert fail-closed.
+    // Beslis op de gedecodeerde vorm (normalizePathname, finding #7) maar
+    // forward de originele encoded bytes van de URL-parser. De gedecodeerde
+    // vorm is geen geldige request-target: rauwe spaties/UTF-8 laten
+    // http.request synchroon gooien (ERR_UNESCAPED_CHARACTERS → proces-crash),
+    // en de upstream zou hem een twééde keer decoden (double-decode-
+    // differential; verminkt bovendien legitieme %2F/%20). `new URL` heeft
+    // `../` al weggevouwen; normalizePathname dekt `%2f`-getruceerde traversal
+    // en weigert fail-closed — er bereiken dus nooit `..`-bytes de upstream.
     const normPath = normalizePathname(target.pathname);
     if (normPath === null) {
       logAudit({
@@ -196,7 +200,7 @@ export function createProxyServer(): http.Server {
       send403(res, host, 'deny', containerId);
       return;
     }
-    const forwardPath = `${normPath}${target.search}`;
+    const forwardPath = `${target.pathname}${target.search}`;
 
     let ruleId: number | null;
     if (host === 'huddle') {
@@ -270,7 +274,13 @@ export function createProxyServer(): http.Server {
     // MCP-verkeer naar huddle altijd via de API-poort (3000), niet de proxypoort (80).
     const upstreamPort = target.port || 80;
 
-    const upstream = http.request(
+    // Node valideert request-opties synchroon in de ClientRequest-constructor
+    // (bv. ERR_UNESCAPED_CHARACTERS bij een ongeldige request-target). Zo'n
+    // throw belandt anders in de uncaughtException-handler die het hele proces
+    // — en dus élke huddle — neerhaalt. Fail per request, niet per proces.
+    let upstream: http.ClientRequest;
+    try {
+      upstream = http.request(
       {
         hostname: host,
         port: upstreamPort,
@@ -293,7 +303,14 @@ export function createProxyServer(): http.Server {
           complete(0, upstreamRes.headers);
         });
       }
-    );
+      );
+    } catch (err: any) {
+      const body = JSON.stringify({ error: 'bad_request', message: `cannot forward request: ${err.message}` });
+      res.writeHead(400, { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) });
+      res.end(body);
+      complete(400);
+      return;
+    }
 
     upstream.on('error', (err) => {
       if (!res.headersSent) send502(res, err.message);
@@ -435,20 +452,24 @@ export function createProxyServer(): http.Server {
       // De CONNECT stond de host al toe (pad was toen versleuteld). Nu de TLS
       // getermineerd is kennen we het pad: pas padbeleid alsnog toe per request.
       //
-      // Normaliseer het pad één keer naar de vorm die de upstream zal
-      // interpreteren en forward EXACT dat pad — zo kunnen de gecontroleerde en
-      // de verstuurde bytes niet divergeren (finding #7). Traversal (`../`,
-      // `..%2f`) of kapotte encoding → fail closed (403), nooit doorsturen.
+      // Beslis op de gedecodeerde vorm (finding #7): traversal (`../`, `..%2f`)
+      // of kapotte encoding → fail closed (403), nooit doorsturen. Geforward
+      // worden daarna de originele encoded bytes (zie rules.ts): de gedecodeerde
+      // vorm is geen geldige request-target — rauwe spaties/UTF-8 (bv. een
+      // `%20` in een Azure DevOps-projectnaam) laten https.request synchroon
+      // gooien (ERR_UNESCAPED_CHARACTERS → proces-crash) — en de upstream zou
+      // hem een twééde keer decoden, waarmee `%252e%252e` alsnog tot `..`
+      // vervalt en legitieme %2F/%20 verminkt raken.
       const rawUrl = innerReq.url ?? '/';
       const qi = rawUrl.indexOf('?');
       const rawPathPart = qi === -1 ? rawUrl : rawUrl.slice(0, qi);
       const query = qi === -1 ? '' : rawUrl.slice(qi);
       const normPath = normalizePathname(rawPathPart);
-      const forwardUrl = normPath === null ? null : `${normPath}${query}`;
+      const checkUrl = normPath === null ? null : `${normPath}${query}`;
 
       const pathResult = normPath === null
         ? { status: 'deny' as const, ruleId: null }
-        : checkRule(hostname, containerId, forwardUrl);
+        : checkRule(hostname, containerId, checkUrl);
       // Alles behalve 'allow' blokkeren: een 'deny'-padregel, maar ook een nog
       // niet beoordeeld subpad ('requested') van een pad-allowlist-domein —
       // fail-closed tot de operator het pad expliciet toestaat.
@@ -543,14 +564,18 @@ export function createProxyServer(): http.Server {
         });
       };
 
-      const upstreamReq = https.request(
+      // Zelfde vangnet als het plain-HTTP-pad: een synchrone constructor-throw
+      // mag nooit via de uncaughtException-handler het hele proces neerhalen.
+      let upstreamReq: http.ClientRequest;
+      try {
+        upstreamReq = https.request(
         {
           hostname,
           port,
           method: innerReq.method,
-          // Forward het genormaliseerde pad dat we ook gecontroleerd hebben, niet
-          // de rauwe (mogelijk traversal-getruceerde) innerReq.url (finding #7).
-          path: forwardUrl ?? innerReq.url,
+          // De originele encoded bytes; de gedecodeerde checkUrl is alleen de
+          // beslisvorm. Traversal is hierboven al fail-closed geweigerd.
+          path: rawUrl,
           headers: upstreamHeaders,
           servername: hostname,
         },
@@ -573,7 +598,14 @@ export function createProxyServer(): http.Server {
             });
           }
         },
-      );
+        );
+      } catch (err: any) {
+        const body = JSON.stringify({ error: 'bad_request', message: `cannot forward request: ${err.message}` });
+        innerRes.writeHead(400, { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) });
+        innerRes.end(body);
+        complete(400);
+        return;
+      }
 
       upstreamReq.on('error', (err) => {
         if (!innerRes.headersSent) {

--- a/gateway/src/proxy.ts
+++ b/gateway/src/proxy.ts
@@ -4,12 +4,12 @@ import net from 'net';
 import tls from 'tls';
 import stream from 'stream';
 import zlib from 'zlib';
-import {URL} from 'url';
-import {canonicalizeHost, checkRule, isPathMode, normalizePathname} from './rules';
-import {resolveContainerByIp} from './docker';
-import {logAudit, updateAuditResponse} from './db';
-import {signLeafCert} from './tls-ca';
-import {isPlaceholderToken, resolveToken, storeTokenExchange} from './token-exchange';
+import { URL } from 'url';
+import { checkRule, isPathMode, canonicalizeHost, normalizePathname } from './rules';
+import { resolveContainerByIp } from './docker';
+import { logAudit, updateAuditResponse } from './db';
+import { signLeafCert } from './tls-ca';
+import { storeTokenExchange, resolveToken, isPlaceholderToken } from './token-exchange';
 
 const PROXY_PORT = 80;
 
@@ -175,7 +175,9 @@ function handleTokenExchangeResponse(
   });
 }
 
-export function createProxyServer(): http.Server {
+// `port` is standaard de vaste proxypoort; tests binden op 0 (een vrije
+// efemere poort) zodat het pad-forwardgedrag hermetisch getest kan worden.
+export function createProxyServer(port: number = PROXY_PORT): http.Server {
   const server = http.createServer();
 
   server.on('request', async (req, res) => {
@@ -629,8 +631,8 @@ export function createProxyServer(): http.Server {
     clientSocket.on('close', () => { try { innerTls.destroy(); } catch {} });
   });
 
-  server.listen(PROXY_PORT, () => {
-    console.log(`[proxy] listening on :${PROXY_PORT}`);
+  server.listen(port, () => {
+    console.log(`[proxy] listening on :${port}`);
   });
 
   return server;

--- a/gateway/src/proxy.ts
+++ b/gateway/src/proxy.ts
@@ -103,6 +103,26 @@ function rejectSocket(socket: stream.Duplex, status: number, blockStatus: string
   socket.end();
 }
 
+// Node valideert request-opties synchroon in de ClientRequest-constructor
+// (bv. ERR_UNESCAPED_CHARACTERS bij een ongeldige request-target). Zo'n throw
+// belandt anders in de uncaughtException-handler die het hele proces — en dus
+// élke huddle — neerhaalt. Fail per request (400), niet per proces.
+function tryCreateUpstreamRequest(
+  create: () => http.ClientRequest,
+  res: http.ServerResponse,
+  complete: (resStatus: number | null) => void,
+): http.ClientRequest | null {
+  try {
+    return create();
+  } catch (err: any) {
+    const body = JSON.stringify({ error: 'bad_request', message: `cannot forward request: ${err.message}` });
+    res.writeHead(400, { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) });
+    res.end(body);
+    complete(400);
+    return null;
+  }
+}
+
 // Buffers en scrubt de OAuth token-exchange response zodat het echte access_token
 // nooit in de audit-log terechtkomt. Stuurt de gescrubde response naar innerRes
 // en roept complete aan met de veilige audit-body als derde argument.
@@ -274,13 +294,7 @@ export function createProxyServer(): http.Server {
     // MCP-verkeer naar huddle altijd via de API-poort (3000), niet de proxypoort (80).
     const upstreamPort = target.port || 80;
 
-    // Node valideert request-opties synchroon in de ClientRequest-constructor
-    // (bv. ERR_UNESCAPED_CHARACTERS bij een ongeldige request-target). Zo'n
-    // throw belandt anders in de uncaughtException-handler die het hele proces
-    // — en dus élke huddle — neerhaalt. Fail per request, niet per proces.
-    let upstream: http.ClientRequest;
-    try {
-      upstream = http.request(
+    const upstream = tryCreateUpstreamRequest(() => http.request(
       {
         hostname: host,
         port: upstreamPort,
@@ -303,14 +317,8 @@ export function createProxyServer(): http.Server {
           complete(0, upstreamRes.headers);
         });
       }
-      );
-    } catch (err: any) {
-      const body = JSON.stringify({ error: 'bad_request', message: `cannot forward request: ${err.message}` });
-      res.writeHead(400, { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) });
-      res.end(body);
-      complete(400);
-      return;
-    }
+    ), res, complete);
+    if (!upstream) return;
 
     upstream.on('error', (err) => {
       if (!res.headersSent) send502(res, err.message);
@@ -564,11 +572,7 @@ export function createProxyServer(): http.Server {
         });
       };
 
-      // Zelfde vangnet als het plain-HTTP-pad: een synchrone constructor-throw
-      // mag nooit via de uncaughtException-handler het hele proces neerhalen.
-      let upstreamReq: http.ClientRequest;
-      try {
-        upstreamReq = https.request(
+      const upstreamReq = tryCreateUpstreamRequest(() => https.request(
         {
           hostname,
           port,
@@ -598,14 +602,8 @@ export function createProxyServer(): http.Server {
             });
           }
         },
-        );
-      } catch (err: any) {
-        const body = JSON.stringify({ error: 'bad_request', message: `cannot forward request: ${err.message}` });
-        innerRes.writeHead(400, { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) });
-        innerRes.end(body);
-        complete(400);
-        return;
-      }
+      ), innerRes, complete);
+      if (!upstreamReq) return;
 
       upstreamReq.on('error', (err) => {
         if (!innerRes.headersSent) {

--- a/gateway/test/e2e/boundary.e2e.ts
+++ b/gateway/test/e2e/boundary.e2e.ts
@@ -224,6 +224,30 @@ describe.skipIf(!E2E_ENABLED)('live security boundary', () => {
       expect(curlStatusIn(E2E_NAME, 'https://example.org/foo/../secret', '--path-as-is')).toBe('403');
       expect(curlStatusIn(E2E_NAME, 'https://example.org/foo/..%2f..%2fadmin', '--path-as-is')).toBe('403');
     });
+
+    // Regressie op de finding #7-fix: de beslissing valt op de gedecodeerde
+    // vorm, maar geforward worden de originele encoded bytes. Werd de
+    // gedecodeerde vorm geforward, dan gooide http(s).request synchroon
+    // ERR_UNESCAPED_CHARACTERS op de rauwe spatie (bv. een Azure DevOps-
+    // projectnaam met %20) en ging het hele gateway-proces neer.
+    it('%-encoded pad (%20) wordt geforward en crasht de gateway niet', async () => {
+      await clearRulesForDomain('example.org');
+      const denyId = await createRule('example.org', 'deny');
+      await enablePathMode(denyId);
+      await createRule('example.org', 'allow', { path_pattern: '/foo/*' });
+      await sleep(1000);
+      // MITM-pad (https): matcht /foo/* op de gedecodeerde vorm, bereikt
+      // upstream ('000' zou een neergegane gateway of geweigerde CONNECT zijn).
+      const mitm = curlStatusIn(E2E_NAME, 'https://example.org/foo/a%20b', '--path-as-is');
+      expect(mitm).not.toBe('403');
+      expect(mitm).not.toBe('000');
+      // Plain-HTTP-pad: zelfde invariant.
+      const plain = curlStatusIn(E2E_NAME, 'http://example.org/foo/a%20b', '--path-as-is');
+      expect(plain).not.toBe('403');
+      expect(plain).not.toBe('000');
+      // De gateway leeft nog na beide requests.
+      expect(curlStatusIn(E2E_NAME, 'https://example.org/foo/', '--path-as-is')).not.toBe('000');
+    });
   });
 
   // ── Huddle self-traffic via de proxy ──────────────────────────────────────

--- a/gateway/test/e2e/boundary.e2e.ts
+++ b/gateway/test/e2e/boundary.e2e.ts
@@ -229,24 +229,35 @@ describe.skipIf(!E2E_ENABLED)('live security boundary', () => {
     // vorm, maar geforward worden de originele encoded bytes. Werd de
     // gedecodeerde vorm geforward, dan gooide http(s).request synchroon
     // ERR_UNESCAPED_CHARACTERS op de rauwe spatie (bv. een Azure DevOps-
-    // projectnaam met %20) en ging het hele gateway-proces neer.
+    // projectnaam met %20). De fix heeft een herkenbare handtekening: een
+    // wélgevormde upstream-status die géén '000', '403' of '400' is —
+    //   • '000'  = de gateway ging neer óf de CONNECT werd geweigerd (pre-fix
+    //              crash, vóór de 400-guard bestond),
+    //   • '403'  = door Huddle's pad-policy geblokkeerd (mag hier niet: /foo/*
+    //              matcht op de gedecodeerde vorm),
+    //   • '400'  = de bad_request-guard vuurt — precies wat er gebeurt als de
+    //              gedecodeerde (rauwe-spatie) vorm wél geforward zou worden en
+    //              http(s).request synchroon gooit.
+    // Zo pinnen we de fix vast zonder afhankelijk te zijn van de exacte
+    // upstream-status van example.org (die mag 2xx/3xx/4xx zijn).
+    const forwardedOk = (status: string) => {
+      expect(status).toMatch(/^[1-5]\d\d$/); // een echte upstream-HTTP-status, geen '000'
+      expect(status).not.toBe('403'); // niet door Huddle geblokkeerd
+      expect(status).not.toBe('400'); // niet de forward-guard: encoded bytes gooien nooit
+    };
     it('%-encoded pad (%20) wordt geforward en crasht de gateway niet', async () => {
       await clearRulesForDomain('example.org');
       const denyId = await createRule('example.org', 'deny');
       await enablePathMode(denyId);
       await createRule('example.org', 'allow', { path_pattern: '/foo/*' });
       await sleep(1000);
-      // MITM-pad (https): matcht /foo/* op de gedecodeerde vorm, bereikt
-      // upstream ('000' zou een neergegane gateway of geweigerde CONNECT zijn).
-      const mitm = curlStatusIn(E2E_NAME, 'https://example.org/foo/a%20b', '--path-as-is');
-      expect(mitm).not.toBe('403');
-      expect(mitm).not.toBe('000');
+      // MITM-pad (https): matcht /foo/* op de gedecodeerde vorm, bereikt upstream.
+      forwardedOk(curlStatusIn(E2E_NAME, 'https://example.org/foo/a%20b', '--path-as-is'));
       // Plain-HTTP-pad: zelfde invariant.
-      const plain = curlStatusIn(E2E_NAME, 'http://example.org/foo/a%20b', '--path-as-is');
-      expect(plain).not.toBe('403');
-      expect(plain).not.toBe('000');
-      // De gateway leeft nog na beide requests.
-      expect(curlStatusIn(E2E_NAME, 'https://example.org/foo/', '--path-as-is')).not.toBe('000');
+      forwardedOk(curlStatusIn(E2E_NAME, 'http://example.org/foo/a%20b', '--path-as-is'));
+      // De gateway leeft nog: een gewoon toegestaan subpad krijgt weer een
+      // wélgevormde upstream-status (geen '000').
+      expect(curlStatusIn(E2E_NAME, 'https://example.org/foo/', '--path-as-is')).toMatch(/^[1-5]\d\d$/);
     });
   });
 

--- a/gateway/test/proxy-forward-path.test.ts
+++ b/gateway/test/proxy-forward-path.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import http from 'http';
+import type { AddressInfo } from 'net';
+
+// ── Regressie op de finding #7-fix (#67) ─────────────────────────────────────
+// De proxy BESLIST op de gedecodeerde vorm (normalizePathname), maar FORWARDT de
+// originele encoded bytes. Werd de gedecodeerde vorm geforward, dan zag de
+// upstream '/foo/a b' i.p.v. '/foo/a%20b' — en http.request gooide op de rauwe
+// spatie synchroon ERR_UNESCAPED_CHARACTERS, wat vóór de 400-guard het hele
+// gateway-proces neerhaalde. Deze suite pint het contract vast zónder Docker of
+// een live container: een echte lokale upstream noteert de request-target die
+// hij daadwerkelijk terugkrijgt.
+//
+// better-sqlite3 is een native module; in een DMZ-devcontainer zonder gebouwde
+// binding slaan we de suite over (zie rules.test.ts). Probe vóór de db-import.
+let sqliteAvailable = true;
+try {
+  const mod = await import('better-sqlite3');
+  new mod.default(':memory:').close();
+} catch (e) {
+  sqliteAvailable = false;
+  console.warn(
+    `[proxy-forward-path.test] SKIPPED — better-sqlite3 binding niet bruikbaar: ${(e as Error).message}`
+  );
+}
+
+let db: typeof import('../src/db').db;
+
+let upstream: http.Server;
+let upstreamPort = 0;
+let lastUpstreamUrl: string | null = null;
+
+let proxy: http.Server;
+let proxyPort = 0;
+
+// Stuur één request door de proxy als forward-proxy-client: over plain HTTP is
+// de request-target absoluut (`GET http://host/pad`). Resolvet met de status die
+// de CLIENT ziet — een antwoord bewijst dat de gateway nog leeft.
+function proxyGet(pathAndQuery: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: '127.0.0.1',
+        port: proxyPort,
+        method: 'GET',
+        path: `http://127.0.0.1:${upstreamPort}${pathAndQuery}`,
+        headers: { host: `127.0.0.1:${upstreamPort}` },
+      },
+      (res) => {
+        res.resume();
+        res.on('end', () => resolve(res.statusCode ?? 0));
+      }
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe.skipIf(!sqliteAvailable)('proxy forwards the original encoded request-path', () => {
+  beforeAll(async () => {
+    const dbMod = await import('../src/db');
+    db = dbMod.db;
+    dbMod.initDb();
+
+    // Geen Docker in de unit-omgeving: de client-IP hoeft niet naar een
+    // container te resolven — een globale allow-regel volstaat.
+    const dockerMod = await import('../src/docker');
+    vi.spyOn(dockerMod, 'resolveContainerByIp').mockResolvedValue(null);
+
+    upstream = http.createServer((req, res) => {
+      lastUpstreamUrl = req.url ?? null;
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end('ok');
+    });
+    await new Promise<void>((r) => upstream.listen(0, '127.0.0.1', () => r()));
+    upstreamPort = (upstream.address() as AddressInfo).port;
+
+    // createProxyServer bindt zelf (poort 0 = vrije efemere poort); wacht op
+    // 'listening' i.p.v. zelf nog eens listen() aan te roepen.
+    const { createProxyServer } = await import('../src/proxy');
+    proxy = createProxyServer(0);
+    await new Promise<void>((r) => proxy.once('listening', () => r()));
+    proxyPort = (proxy.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((r) => (proxy ? proxy.close(() => r()) : r()));
+    await new Promise<void>((r) => (upstream ? upstream.close(() => r()) : r()));
+  });
+
+  beforeEach(() => {
+    db.exec('DELETE FROM rules');
+    lastUpstreamUrl = null;
+    // Host-only allow voor de upstream-host: matcht elk pad, zodat de test het
+    // pad-forwardgedrag isoleert (niet de rule-matching).
+    db.prepare(`INSERT INTO rules (domain, container_id, status) VALUES ('127.0.0.1', NULL, 'allow')`).run();
+  });
+
+  it('%20 blijft encoded richting upstream (geen rauwe spatie, geen crash)', async () => {
+    const status = await proxyGet('/foo/a%20b');
+    expect(status).toBe(200);
+    // Cruciaal: de encoded bytes, NIET de gedecodeerde '/foo/a b'.
+    expect(lastUpstreamUrl).toBe('/foo/a%20b');
+  });
+
+  it('non-ASCII UTF-8 (%E2%9C%93) blijft encoded richting upstream', async () => {
+    const status = await proxyGet('/foo/%E2%9C%93');
+    expect(status).toBe(200);
+    expect(lastUpstreamUrl).toBe('/foo/%E2%9C%93');
+  });
+
+  it('de query-string wordt behouden en niet gedecodeerd', async () => {
+    const status = await proxyGet('/foo/bar?q=a%20b&x=1');
+    expect(status).toBe(200);
+    expect(lastUpstreamUrl).toBe('/foo/bar?q=a%20b&x=1');
+  });
+
+  it('traversal (%2f-getruceerd) wordt fail-closed geweigerd en nooit geforward', async () => {
+    const status = await proxyGet('/foo/..%2f..%2fadmin');
+    expect(status).toBe(403);
+    expect(lastUpstreamUrl).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

One ordinary request through the proxy could crash the entire gateway — and with it every running huddle.

Since the finding #7 hardening (#67), the proxy normalizes request paths with `decodeURIComponent()` for the firewall rule check, but then **forwarded that decoded path** to the upstream. Any percent-encoded character that decodes to something illegal in an HTTP request-target (`%20`, any non-ASCII UTF-8) makes Node's `http(s).request()` throw `ERR_UNESCAPED_CHARACTERS` synchronously; the throw reached the `uncaughtException` handler in `index.ts`, which calls `process.exit(1)`. In practice this was triggered by legitimate traffic: an Azure DevOps project name containing a space (`/org/My%20Project/_git/...`) killed the gateway on every `git fetch`, minutes after each huddle started.

This PR:

1. **Forwards the original encoded bytes** in both the plain-HTTP and MITM handlers, while the rule check keeps deciding on the decoded form (unchanged). This is the design `normalizePathname()`'s documentation in `rules.ts` already describes. It also *strengthens* finding #7: forwarding the decoded form let double-encoded `%252e%252e` reach the upstream half-decoded (whose own decode turns it into `..`, reopening the traversal differential), and silently corrupted legitimate `%2F`/`%20` in forwarded paths.
2. **Wraps the `http(s).request()` construction in try/catch** in both handlers, so any future synchronous validation throw fails that single request with a 400 instead of exiting the process.
3. Adds an e2e regression test (`boundary.e2e.ts`) covering both proxy paths.

Verified end-to-end against a live container: the previously crashing URL now returns the upstream's normal response (302 from dev.azure.com) on both paths, traversal (`/foo/..%2f..%2fadmin`) is still blocked with 403, and the gateway stays up.

## Related issue

Fixes #

## Type of change

- [x] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Documentation (`docs`)
- [ ] Refactor / maintenance (`refactor` / `chore`)
- [ ] Other:
## Related issue

## Checklist

- [x] My branch is up to date with `main` and focused on a single change.
- [x] The project **builds** and **type-checks** locally.
- [x] Tests pass (`npm --prefix gateway test`) and I added/updated tests where relevant.
- [ ] I ran Prettier and did not reformat unrelated code.
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] I did not introduce logging of secrets, tokens, or credentials.
- [x] Documentation is updated where needed (README / relevant docs). *(No docs impact.)*

## Notes for reviewers

- **The security-relevant hunks** are the two `path:` changes (`gateway/src/proxy.ts`). The rule check still receives the decoded form — only the forwarded bytes changed. The existing finding #7 e2e test (traversal → 403) passes unchanged.
- The try/catch blocks are defense-in-depth: with encoded forwarding, Node's server parser already guarantees a valid request-target, so they should never fire — but a synchronous constructor throw must never take down the shared gateway again.
- Note on unit tests when run on Windows: 3 `socket-proxy.test.ts` failures are pre-existing on `main` (Unix-socket `EACCES`); the skip fix (`de51151`) lives on `experiment/58-wslc-support` and hasn't landed on `main`. Linux CI is unaffected.
- Repro of the crash on the current image, if you want to see it fail before the fix:
```sh
  docker run -d --name repro -p 18081:80 -v repro:/data ghcr.io/infosupport/huddle:<current-tag>
  docker exec repro node -e "new (require('better-sqlite3'))('/data/huddle.db').prepare(\"INSERT INTO rules (domain, container_id, status) VALUES ('dev.azure.com', NULL, 'allow')\").run()"
  curl -x http://localhost:18081 -k "https://dev.azure.com/org/My%20Project/_git/My%20Project/info/refs?service=git-upload-pack"
  docker inspect repro --format '{{.State.Status}} exit={{.State.ExitCode}}'   # → exited exit=1
```