### PR TITLE
fix(experiment): trigger reusable npm publish on workflow_call

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -137,7 +137,11 @@ jobs:
   # `experiment`-job hierboven, maar de key komt uit de input i.p.v. de
   # branchnaam en de checkout gebeurt op de expliciet geresolvede head-SHA.
   dispatch:
-    if: ${{ github.event_name == 'workflow_call' }}
+    # Bij een reusable workflow is de github-context die van de caller, dus
+    # github.event_name is hier 'workflow_dispatch' (van experiment-publish.yml)
+    # en NOOIT 'workflow_call'. Detecteer de reusable-call daarom via de
+    # verplichte workflow_call-input: bij een push is inputs.key leeg/null.
+    if: ${{ inputs.key != '' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
The dispatch job in publish-npm.yml gated on
`github.event_name == 'workflow_call'`, but in a reusable workflow the github context is the caller's. When experiment-publish.yml calls publish-npm.yml via `uses:`, github.event_name is the caller's trigger (workflow_dispatch), never 'workflow_call'. The condition never matched, so the dispatch job was skipped and no CLI was published for a maintainer-triggered experiment build.

Detect the reusable call via the required workflow_call input instead: `inputs.key != ''` is true only when called with inputs and false on a push (where inputs.key is null). The stable/experiment push jobs keep their event_name == 'push' gate, which correctly evaluates false under a workflow_call.

<!--
Thanks for contributing to Huddle! Please fill in this template.
See CONTRIBUTING.md for the full workflow, coding standards, and commit conventions.
-->

## Summary

<!-- What does this PR do and why? -->

## Related issue

<!-- e.g. Fixes #123. Open an issue first for large changes. -->
Fixes #

## Type of change

- [ ] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Documentation (`docs`)
- [ ] Refactor / maintenance (`refactor` / `chore`)
- [ ] Other:

## Checklist

- [ ] My branch is up to date with `main` and focused on a single change.
- [ ] The project **builds** and **type-checks** locally.
- [ ] Tests pass (`npm --prefix gateway test`) and I added/updated tests where relevant.
- [ ] I ran Prettier and did not reformat unrelated code.
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/).
- [ ] I did not introduce logging of secrets, tokens, or credentials.
- [ ] Documentation is updated where needed (README / relevant docs).

## Notes for reviewers

<!-- Anything reviewers should pay special attention to, testing instructions, screenshots, etc. -->
