### PR TITLE
fix(experiment): publish CLI via workflow_dispatch so trusted publishing matches

### DIFF
--- a/.github/workflows/experiment-publish.yml
+++ b/.github/workflows/experiment-publish.yml
@@ -203,13 +203,25 @@ jobs:
 
   # De npm-publish van de CLI moet uit publish-npm.yml komen (npm trusted
   # publishing staat maar één trusted-publisher-workflowbestand per package
-  # toe). We roepen die daarom aan als reusable workflow.
+  # toe). npm matcht het OIDC-token bovendien op de ENTRY-workflow, dus een
+  # reusable call (uses:) faalt: de entry blijft dan dit bestand en npm wijst de
+  # trusted-publish af (E404). Daarom triggeren we publish-npm.yml via
+  # workflow_dispatch, zodat DÍT niet de entry is maar publish-npm.yml zelf.
+  # GITHUB_TOKEN mag workflow_dispatch triggeren (expliciete uitzondering op de
+  # recursie-preventie); daarvoor is alleen actions: write nodig.
   npm:
     needs: meta
-    uses: ./.github/workflows/publish-npm.yml
+    runs-on: ubuntu-latest
     permissions:
-      contents: read
-      id-token: write
-    with:
-      ref: ${{ needs.meta.outputs.sha }}
-      key: ${{ needs.meta.outputs.key }}
+      actions: write
+    steps:
+      - name: Dispatch publish-npm.yml (CLI publish als eigen entry-workflow)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run publish-npm.yml \
+            --repo "${{ github.repository }}" \
+            -f ref="${{ needs.meta.outputs.sha }}" \
+            -f key="${{ needs.meta.outputs.key }}"
+          echo "publish-npm.yml gedispatcht voor experiment-${{ needs.meta.outputs.key }} (ref ${{ needs.meta.outputs.sha }})."
+          echo "Volg de run: https://github.com/${{ github.repository }}/actions/workflows/publish-npm.yml"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -6,14 +6,17 @@ name: Publish npm
 # publish-image.yml / publish-experiment.yml. Op npmjs.com configureer je als
 # trusted publisher: org infosupport, repo huddle, workflow publish-npm.yml.
 #
-# De `dispatch`-job wordt aangeroepen als reusable workflow vanuit
-# experiment-publish.yml, zodat een maintainer een experiment-build van een
-# willekeurige (fork-)PR kan publiceren zónder de trusted-publisher-regel te
-# breken: de publish blijft uit dít bestand komen.
+# BELANGRIJK: npm matcht het OIDC-token op de ENTRY-workflow (workflow_ref),
+# niet op de workflow die het `npm publish`-commando bevat (job_workflow_ref).
+# Als reusable workflow (uses:) aangeroepen worden, blijft de caller de entry-
+# workflow -> npm ziet dan experiment-publish.yml i.p.v. publish-npm.yml, wijst
+# de trusted-publish af en valt terug op het (lege) token -> E404. Daarom wordt
+# de experiment-publish via workflow_dispatch getriggerd i.p.v. workflow_call:
+# zo is DÍT bestand altijd zelf de entry-workflow en klopt de identiteit.
 on:
   push:
     branches: [main, release/*, experiment/**]
-  workflow_call:
+  workflow_dispatch:
     inputs:
       ref:
         description: Head-SHA of ref om de CLI van te bouwen.
@@ -131,16 +134,16 @@ jobs:
         # @infosupport/huddle-cli@experiment-<nr>; `latest` blijft onaangeroerd.
         run: cd cli && npm publish --provenance --access public --tag ${{ steps.meta.outputs.tag }}
 
-  # Maintainer-getriggerde experiment-publish (reusable, aangeroepen door
-  # experiment-publish.yml). Publiceert de CLI van een willekeurige ref -
-  # inclusief een fork-PR - onder de tag experiment-<key>. Identiek aan de
-  # `experiment`-job hierboven, maar de key komt uit de input i.p.v. de
-  # branchnaam en de checkout gebeurt op de expliciet geresolvede head-SHA.
+  # Maintainer-getriggerde experiment-publish, via workflow_dispatch getriggerd
+  # door experiment-publish.yml (zie de comment bovenaan: als entry-workflow
+  # klopt de OIDC-identiteit voor trusted publishing). Publiceert de CLI van een
+  # willekeurige ref - inclusief een fork-PR - onder de tag experiment-<key>.
+  # Identiek aan de `experiment`-job hierboven, maar de key komt uit de input
+  # i.p.v. de branchnaam en de checkout gebeurt op de geresolvede head-SHA.
   dispatch:
-    # Bij een reusable workflow is de github-context die van de caller, dus
-    # github.event_name is hier 'workflow_dispatch' (van experiment-publish.yml)
-    # en NOOIT 'workflow_call'. Detecteer de reusable-call daarom via de
-    # verplichte workflow_call-input: bij een push is inputs.key leeg/null.
+    # Draait alleen bij een workflow_dispatch met inputs (experiment-publish.yml
+    # geeft altijd een key mee); bij een push is inputs.key leeg/null -> skip,
+    # dan draaien stable/experiment o.b.v. github.event_name == 'push'.
     if: ${{ inputs.key != '' }}
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
<!--
Thanks for contributing to Huddle! Please fill in this template.
See CONTRIBUTING.md for the full workflow, coding standards, and commit conventions.
-->

## Summary

<!-- What does this PR do and why? -->

## Related issue

<!-- e.g. Fixes #123. Open an issue first for large changes. -->
Fixes #

## Type of change

- [ ] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Documentation (`docs`)
- [ ] Refactor / maintenance (`refactor` / `chore`)
- [ ] Other:

## Checklist

- [ ] My branch is up to date with `main` and focused on a single change.
- [ ] The project **builds** and **type-checks** locally.
- [ ] Tests pass (`npm --prefix gateway test`) and I added/updated tests where relevant.
- [ ] I ran Prettier and did not reformat unrelated code.
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/).
- [ ] I did not introduce logging of secrets, tokens, or credentials.
- [ ] Documentation is updated where needed (README / relevant docs).

## Notes for reviewers

<!-- Anything reviewers should pay special attention to, testing instructions, screenshots, etc. -->
