### PR TITLE
Support Aspire in huddle

### DIFF
--- a/gateway/src/api.ts
+++ b/gateway/src/api.ts
@@ -34,6 +34,7 @@ import {
   sessionCookie,
   clearSessionCookie,
 } from './auth';
+import { ensurePortForwarder, isRelayNetworkIp } from './port-relay';
 import { attachTerminal } from './terminal';
 import { ptyManager } from './pty-manager';
 import { getCaCertPem } from './tls-ca';
@@ -525,6 +526,9 @@ export async function createApiServer(): Promise<FastifyInstance> {
       const inspect = await inspectContainer(name);
       if (inspect.State?.Running) return { ok: true };
       await startExistingContainer(inspect.Id);
+      // De forwarder (port-relay.ts) leeft in de devcontainer en sterft met een
+      // stop; na een start opnieuw opzetten.
+      await ensurePortForwarder(name, inspect.Id);
       logAudit({ containerId: name, domain: 'docker', action: 'container:start' });
       notifyStateChanged();
       return { ok: true };
@@ -975,6 +979,20 @@ export async function createApiServer(): Promise<FastifyInstance> {
   getOperatorToken();
 
   const address = await app.listen({ port: API_PORT, host: '0.0.0.0' });
+  // :3000 moet op 0.0.0.0 blijven (de host bereikt het portal via de published
+  // port, die op het container-IP uitkomt — loopback-binden kan dus niet). Maar
+  // netwerken die de gateway alleen voor de port-relay joinde dragen puur
+  // workload-verkeer: verbindingen daarvandaan worden op TCP-niveau geweigerd
+  // (dekt HTTP én WebSocket-upgrades), zodat een netwerk-join geen nieuw
+  // API-oppervlak oplevert. dc-net-verkeer (devcontainers, o.a. de
+  // sudo-audit-ingest) blijft ongemoeid.
+  app.server.on('connection', (sock) => {
+    const ip = sock.remoteAddress ?? '';
+    if (ip && isRelayNetworkIp(ip)) {
+      console.warn(`[api] denied connection from relay-joined network: ${ip}`);
+      sock.destroy();
+    }
+  });
   console.log(`[api] listening on ${address}`);
 
   return app;

--- a/gateway/src/api.ts
+++ b/gateway/src/api.ts
@@ -526,8 +526,8 @@ export async function createApiServer(): Promise<FastifyInstance> {
       const inspect = await inspectContainer(name);
       if (inspect.State?.Running) return { ok: true };
       await startExistingContainer(inspect.Id);
-      // De forwarder (port-relay.ts) leeft in de devcontainer en sterft met een
-      // stop; na een start opnieuw opzetten.
+      // The forwarder (port-relay.ts) lives inside the devcontainer and dies
+      // with a stop; re-install it after a start.
       await ensurePortForwarder(name, inspect.Id);
       logAudit({ containerId: name, domain: 'docker', action: 'container:start' });
       notifyStateChanged();
@@ -979,13 +979,13 @@ export async function createApiServer(): Promise<FastifyInstance> {
   getOperatorToken();
 
   const address = await app.listen({ port: API_PORT, host: '0.0.0.0' });
-  // :3000 moet op 0.0.0.0 blijven (de host bereikt het portal via de published
-  // port, die op het container-IP uitkomt — loopback-binden kan dus niet). Maar
-  // netwerken die de gateway alleen voor de port-relay joinde dragen puur
-  // workload-verkeer: verbindingen daarvandaan worden op TCP-niveau geweigerd
-  // (dekt HTTP én WebSocket-upgrades), zodat een netwerk-join geen nieuw
-  // API-oppervlak oplevert. dc-net-verkeer (devcontainers, o.a. de
-  // sudo-audit-ingest) blijft ongemoeid.
+  // :3000 must stay bound to 0.0.0.0 (the host reaches the portal through the
+  // published port, which lands on the container IP — binding loopback is not
+  // an option). But networks the gateway joined solely for the port-relay carry
+  // pure workload traffic: connections from there are refused at the TCP level
+  // (covers both HTTP and WebSocket upgrades), so a network join never adds new
+  // API surface. dc-net traffic (devcontainers, incl. the sudo-audit ingest)
+  // is left untouched.
   app.server.on('connection', (sock) => {
     const ip = sock.remoteAddress ?? '';
     if (ip && isRelayNetworkIp(ip)) {

--- a/gateway/src/docker.ts
+++ b/gateway/src/docker.ts
@@ -73,9 +73,9 @@ async function fetchContainerMap(): Promise<Map<string, string>> {
   return map;
 }
 
-// Bij een cache-miss maximaal 1×/s een geforceerde refresh: sinds de proxy
-// onbekende bronnen hard weigert (default-deny) mag een net gestarte container
-// binnen de cache-TTL geen onterechte 403 krijgen.
+// On a cache miss, force a refresh at most once per second: now that the proxy
+// hard-refuses unknown sources (default-deny), a freshly started container must
+// not catch an unwarranted 403 within the cache TTL.
 let lastMissRefresh = 0;
 
 export async function resolveContainerByIp(rawIp: string): Promise<string | null> {
@@ -97,8 +97,8 @@ export async function resolveContainerByIp(rawIp: string): Promise<string | null
       ipToName = await fetchContainerMap();
       cacheExpiry = now + CACHE_TTL_MS;
     } catch (err: any) {
-      // Stale map blijft bruikbaar; wel loggen, anders is een 'unknown
-      // source'-denial door een mislukte refresh niet te diagnosticeren.
+      // The stale map stays usable; do log, though — otherwise an 'unknown
+      // source' denial caused by a failed refresh cannot be diagnosed.
       console.warn(`[docker] container-map refresh failed for ${ip}: ${err?.message ?? err}`);
     }
   }
@@ -960,8 +960,8 @@ export async function createAndStartContainer(params: StartParams): Promise<stri
   });
   await dockerRequest('POST', `/exec/${execCreate.Id}/start`, { Detach: true });
 
-  // Port-relay-forwarder: spiegelt gepubliceerde poorten van owned containers
-  // op de loopback van de devcontainer (zie port-relay.ts).
+  // Port-relay forwarder: mirrors published ports of owned containers onto
+  // the devcontainer's loopback (see port-relay.ts).
   await ensurePortForwarder(containerName, id);
 
   saveCredentials(containerName, password);

--- a/gateway/src/docker.ts
+++ b/gateway/src/docker.ts
@@ -96,7 +96,11 @@ export async function resolveContainerByIp(rawIp: string): Promise<string | null
     try {
       ipToName = await fetchContainerMap();
       cacheExpiry = now + CACHE_TTL_MS;
-    } catch {}
+    } catch (err: any) {
+      // Stale map blijft bruikbaar; wel loggen, anders is een 'unknown
+      // source'-denial door een mislukte refresh niet te diagnosticeren.
+      console.warn(`[docker] container-map refresh failed for ${ip}: ${err?.message ?? err}`);
+    }
   }
   return ipToName.get(ip) ?? null;
 }

--- a/gateway/src/docker.ts
+++ b/gateway/src/docker.ts
@@ -2,6 +2,7 @@ import http from 'http';
 import fs from 'fs';
 import crypto from 'crypto';
 import { createContainerProxy } from './socket-proxy';
+import { ensurePortForwarder } from './port-relay';
 import { saveCredentials, getSetting, listFolderMappings } from './db';
 import { getCaCertPem } from './tls-ca';
 import { ensureWorktree } from './worktree';
@@ -72,6 +73,11 @@ async function fetchContainerMap(): Promise<Map<string, string>> {
   return map;
 }
 
+// Bij een cache-miss maximaal 1×/s een geforceerde refresh: sinds de proxy
+// onbekende bronnen hard weigert (default-deny) mag een net gestarte container
+// binnen de cache-TTL geen onterechte 403 krijgen.
+let lastMissRefresh = 0;
+
 export async function resolveContainerByIp(rawIp: string): Promise<string | null> {
   const ip = rawIp.replace(/^::ffff:/, '');
   const now = Date.now();
@@ -82,6 +88,15 @@ export async function resolveContainerByIp(rawIp: string): Promise<string | null
     } catch {
       cacheExpiry = now + 2_000;
     }
+  }
+  const hit = ipToName.get(ip);
+  if (hit) return hit;
+  if (now - lastMissRefresh > 1_000) {
+    lastMissRefresh = now;
+    try {
+      ipToName = await fetchContainerMap();
+      cacheExpiry = now + CACHE_TTL_MS;
+    } catch {}
   }
   return ipToName.get(ip) ?? null;
 }
@@ -940,6 +955,10 @@ export async function createAndStartContainer(params: StartParams): Promise<stri
     Cmd: ['sh', '-c', script],
   });
   await dockerRequest('POST', `/exec/${execCreate.Id}/start`, { Detach: true });
+
+  // Port-relay-forwarder: spiegelt gepubliceerde poorten van owned containers
+  // op de loopback van de devcontainer (zie port-relay.ts).
+  await ensurePortForwarder(containerName, id);
 
   saveCredentials(containerName, password);
 

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -3,6 +3,7 @@ import { createProxyServer } from './proxy';
 import { createApiServer } from './api';
 import { listDevcontainers, networkExists, connectNetwork, refreshContainerIptables } from './docker';
 import { createContainerProxy } from './socket-proxy';
+import { initPortRelays } from './port-relay';
 import { initCa } from './tls-ca';
 import { sanitizeResolvConf, scheduleSettlingSanitize } from './dns-egress';
 
@@ -70,6 +71,8 @@ initContainerProxies();
 // internal-net aardvark-DNS erin); sanitize erna zodat egress-DNS blijft werken,
 // óók als er (nog) geen devcontainers zijn. De settling-runs vangen bovendien de
 // devcontainer-net-connect op die `huddle init` pas ná de start uitvoert.
-initContainerNetworks().finally(() => { void sanitizeResolvConf(); });
+// Port-relays herstellen ná de netwerk-reconnects: de relay bereikt de
+// workload-containers via het dc-net waar huddle (weer) aan moet hangen.
+initContainerNetworks().finally(() => { void sanitizeResolvConf(); void initPortRelays(); });
 scheduleSettlingSanitize();
 initContainerIptables();

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -71,8 +71,8 @@ initContainerProxies();
 // internal-net aardvark-DNS erin); sanitize erna zodat egress-DNS blijft werken,
 // óók als er (nog) geen devcontainers zijn. De settling-runs vangen bovendien de
 // devcontainer-net-connect op die `huddle init` pas ná de start uitvoert.
-// Port-relays herstellen ná de netwerk-reconnects: de relay bereikt de
-// workload-containers via het dc-net waar huddle (weer) aan moet hangen.
+// Restore port-relays AFTER the network reconnects: a relay reaches the
+// workload containers via the dc-net that huddle must be (re)attached to.
 initContainerNetworks().finally(() => { void sanitizeResolvConf(); void initPortRelays(); });
 scheduleSettlingSanitize();
 initContainerIptables();

--- a/gateway/src/port-relay.ts
+++ b/gateway/src/port-relay.ts
@@ -222,7 +222,9 @@ function resolveSelfRef(): Promise<string> {
   if (!selfRefPromise) {
     selfRefPromise = (async () => {
       const candidates: string[] = [];
-      try { candidates.push(fs.readFileSync('/etc/hostname', 'utf8').trim()); } catch {}
+      try { candidates.push(fs.readFileSync('/etc/hostname', 'utf8').trim()); } catch (err: any) {
+        console.warn(`[port-relay] cannot read /etc/hostname (${err?.message ?? err}); falling back to container name 'huddle'`);
+      }
       candidates.push('huddle');
       for (const c of candidates) {
         if (!c) continue;
@@ -327,7 +329,21 @@ const relaysById = new Map<string, ContainerRelays>();
 // docker-client ook maar in het pad zette.
 const aliasIndex = new Map<string, string>();
 
+// `owner` vloeit in path.join() onder SOCKET_DIR. De naam komt uit huddle's
+// eigen orchestratie of een operator-API-parameter; net als in socket-proxy.ts
+// (assertSafeContainerName — hier gedupliceerd omdat socket-proxy déze module
+// importeert en een cyclus anders snel gemaakt is) dwingen we de Docker-naam-
+// grammatica expliciet af: geen slashes en geen leidende punt, dus onmogelijk
+// om met `..`/`/` buiten de sockets-directory te schrijven of te lezen.
+const OWNER_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/;
+
+export function assertSafeOwner(owner: string): void {
+  if (typeof owner !== 'string' || !OWNER_NAME_RE.test(owner))
+    throw new Error(`unsafe owner name: ${JSON.stringify(owner)}`);
+}
+
 function portsDirFor(owner: string): string {
+  assertSafeOwner(owner);
   return path.join(SOCKET_DIR, owner, 'ports');
 }
 
@@ -473,6 +489,7 @@ async function waitForForwarderReady(dir: string, spec: RelaySpec, owner: string
 // verdediging-in-de-diepte: de socket-proxy heeft al geverifieerd, maar relays
 // van andermans containers mogen ook standalone nooit ontstaan (#82-semantiek).
 export async function syncContainerRelays(owner: string, containerRef: string): Promise<void> {
+  assertSafeOwner(owner);
   const { status, data } = await dockerRequestJson('GET', `/containers/${encodeURIComponent(containerRef)}/json`);
   if (status !== 200 || !data) return;
   if (data.Config?.Labels?.['huddle.parent'] !== owner) return;
@@ -665,6 +682,7 @@ echo $! > "$PIDFILE"
 // Installeer/start de forwarder in een (draaiende) devcontainer. Aangeroepen
 // bij devcontainer-aanmaak, bij een start via het portal en bij gateway-start.
 export async function ensurePortForwarder(owner: string, containerRef?: string): Promise<void> {
+  assertSafeOwner(owner);
   const ref = containerRef ?? owner;
   try {
     fs.mkdirSync(portsDirFor(owner), { recursive: true });

--- a/gateway/src/port-relay.ts
+++ b/gateway/src/port-relay.ts
@@ -1,0 +1,711 @@
+import net from 'net';
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+import { sanitizeResolvConf } from './dns-egress';
+
+// ── Port-relay: gepubliceerde poorten van owned containers de devcontainer in ─
+// Een devcontainer praat met de docker-daemon van de HOST (docker-outside-of-
+// docker). Publiceert een owned container een poort, dan bindt die op de
+// loopback van de host — onbereikbaar vanuit de devcontainer, die geen default
+// route heeft en een eigen loopback (issue: Aspire/DCP, Testcontainers, plain
+// `docker run -p` — TCP connect naar 127.0.0.1:<hostPort> faalt of hangt).
+//
+// De oplossing spiegelt het docker.sock-mechanisme: per gepubliceerde TCP-poort
+// legt de gateway een unix-socket neer in de al gedeelde per-container mount
+// (/tmp/dc-sockets/<owner>/ports/<hostPort>.sock ≙ /var/run/huddle/ports/… in
+// de devcontainer). Een kleine in-devcontainer forwarder (Node, door de gateway
+// via docker exec geïnstalleerd) luistert op 127.0.0.1/::1:<hostPort> en pipe't
+// naar die unix-socket; de gateway pipe't de unix-socket door naar
+// containerIP:containerPort op het dc-net van de eigenaar (waar huddle zelf al
+// aan gekoppeld is). Zo is er nooit een pad via de host-loopback nodig.
+
+const DOCKER_SOCKET = '/var/run/docker.sock';
+const SOCKET_DIR = '/tmp/dc-sockets';
+
+// Hoe lang we op de in-devcontainer forwarder wachten voordat de start-respons
+// alsnog doorgaat. DCP/Testcontainers inspecteren en connecten direct ná de
+// start-respons, dus de loopback-listener moet er vóór die respons zijn.
+const FORWARDER_READY_TIMEOUT_MS = 2000;
+
+// ── Docker helpers ────────────────────────────────────────────────────────────
+// Bewust zelfstandig (geen import uit docker.ts): docker.ts importeert deze
+// module, en een importcyclus met socket-proxy.ts erbij is dan snel gemaakt.
+
+function dockerRequestJson(method: string, urlPath: string, body?: unknown): Promise<{ status: number; data: any }> {
+  return new Promise((resolve, reject) => {
+    const bodyStr = body !== undefined ? JSON.stringify(body) : undefined;
+    const req = http.request(
+      {
+        socketPath: DOCKER_SOCKET,
+        method,
+        path: urlPath,
+        headers: bodyStr ? { 'content-type': 'application/json', 'content-length': Buffer.byteLength(bodyStr) } : {},
+      },
+      (res) => {
+        let raw = '';
+        res.on('data', (d: Buffer) => { raw += d.toString(); });
+        res.on('end', () => {
+          let data: any = null;
+          try { data = raw ? JSON.parse(raw) : null; } catch { data = null; }
+          resolve({ status: res.statusCode ?? 0, data });
+        });
+      }
+    );
+    req.on('error', reject);
+    if (bodyStr) req.write(bodyStr);
+    req.end();
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((res) => setTimeout(res, ms));
+}
+
+// ── Pure helpers (unit-getest) ────────────────────────────────────────────────
+
+export interface RelaySpec {
+  hostPort: number;
+  containerPort: number;
+  proto: string;
+}
+
+// Leid uit een container-inspect de te relayen poorten af. Bron is
+// NetworkSettings.Ports zoals dat er NÁ de start uitziet, dus inclusief
+// dynamisch toegewezen poorten (HostPort:0 → daadwerkelijke poort). Dubbele
+// bindings van dezelfde hostpoort (0.0.0.0 + ::) vallen samen tot één spec.
+export function extractRelaySpecs(inspect: any): RelaySpec[] {
+  const ports = inspect?.NetworkSettings?.Ports;
+  if (!ports || typeof ports !== 'object') return [];
+  const seen = new Map<string, RelaySpec>();
+  for (const [key, bindings] of Object.entries(ports)) {
+    if (!Array.isArray(bindings)) continue; // niet-gepubliceerde poort (null)
+    const [portStr, proto = 'tcp'] = key.split('/');
+    const containerPort = parseInt(portStr, 10);
+    if (!Number.isInteger(containerPort) || containerPort <= 0) continue;
+    for (const b of bindings) {
+      const hostPort = parseInt(String((b as any)?.HostPort ?? ''), 10);
+      if (!Number.isInteger(hostPort) || hostPort <= 0) continue;
+      const k = `${hostPort}/${proto}`;
+      if (!seen.has(k)) seen.set(k, { hostPort, containerPort, proto });
+    }
+  }
+  return [...seen.values()];
+}
+
+export interface RelayTarget {
+  ip: string;
+  network: string;
+}
+
+// Netwerk + IP waarop de gateway de workload-container moet bereiken. Voorkeur:
+// het dc-net van de eigenaar (daar zit huddle standaard al in). Maar een
+// workload kan óók uitsluitend op een eigen netwerk leven — Aspire's DCP maakt
+// z'n session-netwerk via de socket-proxy aan en verhangt containers erheen —
+// en Docker's inter-bridge-isolatie DROP't SYN's stilletjes tussen bridges. De
+// caller moet de gateway dus expliciet aan `network` koppelen vóór de dial
+// (ensure + refcount hieronder); vandaar dat het netwerk hier mee terugkomt.
+export function resolveTarget(inspect: any, owner: string): RelayTarget | null {
+  const nets = inspect?.NetworkSettings?.Networks ?? {};
+  const dcNet = `dc-net-${owner}`;
+  if (nets[dcNet]?.IPAddress) return { ip: nets[dcNet].IPAddress, network: dcNet };
+  for (const [name, n] of Object.entries<any>(nets)) {
+    if (n?.IPAddress) return { ip: n.IPAddress, network: name };
+  }
+  return null;
+}
+
+// ── Gateway-netwerkbeheer (join + refcount) ──────────────────────────────────
+// De gateway koppelt zichzelf on demand aan het netwerk van een workload-
+// container. Refcounted over alle relays heen: pas als de laatste relay op een
+// netwerk verdwijnt, koppelt de gateway zich weer los — een achtergebleven
+// membership blokkeert `docker network rm` wanneer Aspire/DCP z'n session-
+// netwerken opruimt. Netwerken waar de gateway al aan hing vóór de eerste
+// acquire (joinedByUs=false) en permanente netwerken (dc-net-*) worden nooit
+// losgekoppeld.
+
+export type NetworkConnectResult = 'connected' | 'already-connected' | 'missing' | 'error';
+
+export interface GatewayNetworkOps {
+  connect(network: string): Promise<NetworkConnectResult>;
+  disconnect(network: string): Promise<void>;
+  subnets(network: string): Promise<string[]>;
+}
+
+export interface NetworkRefTracker {
+  acquire(network: string, ref: string): Promise<boolean>;
+  release(network: string, ref: string): Promise<void>;
+  isJoined(network: string): boolean;
+  isJoinedNetworkIp(ip: string): boolean;
+}
+
+// Zit `ip` in IPv4-CIDR `subnet`? IPv6-subnetten (zeldzaam voor Docker-bridges)
+// matchen conservatief niet — dan blijft alleen de default-deny van de proxy
+// als laag over. Exported voor unit-tests.
+export function ipInSubnet(rawIp: string, subnet: string): boolean {
+  const ip = rawIp.replace(/^::ffff:/, '');
+  const m = subnet.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)\/(\d+)$/);
+  const i = ip.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+  if (!m || !i) return false;
+  const bits = parseInt(m[5], 10);
+  if (bits < 0 || bits > 32) return false;
+  const toNum = (p: string[]) => ((+p[0] << 24) | (+p[1] << 16) | (+p[2] << 8) | +p[3]) >>> 0;
+  const mask = bits === 0 ? 0 : (~0 << (32 - bits)) >>> 0;
+  return (toNum(m.slice(1, 5)) & mask) === (toNum(i.slice(1, 5)) & mask);
+}
+
+export function createNetworkRefTracker(
+  ops: GatewayNetworkOps,
+  isPermanent: (network: string) => boolean = (n) => n.startsWith('dc-net-'),
+): NetworkRefTracker {
+  interface JoinedNet { joinedByUs: boolean; refs: Set<string>; subnets: string[]; }
+  const nets = new Map<string, JoinedNet>();
+  // Per netwerk geserialiseerd zodat een gelijktijdige acquire/release nooit
+  // een connect en disconnect door elkaar laat lopen.
+  const locks = new Map<string, Promise<unknown>>();
+  function withLock<T>(network: string, fn: () => Promise<T>): Promise<T> {
+    const prev = locks.get(network) ?? Promise.resolve();
+    const p = prev.then(fn, fn);
+    locks.set(network, p.then(() => {}, () => {}));
+    return p;
+  }
+
+  return {
+    acquire(network, ref) {
+      return withLock(network, async () => {
+        const existing = nets.get(network);
+        if (existing) { existing.refs.add(ref); return true; }
+        const res = await ops.connect(network);
+        if (res === 'missing' || res === 'error') return false;
+        const subnets = await ops.subnets(network).catch(() => []);
+        nets.set(network, { joinedByUs: res === 'connected', refs: new Set([ref]), subnets });
+        return true;
+      });
+    },
+    release(network, ref) {
+      return withLock(network, async () => {
+        const entry = nets.get(network);
+        if (!entry) return;
+        entry.refs.delete(ref);
+        if (entry.refs.size > 0) return;
+        nets.delete(network);
+        if (entry.joinedByUs && !isPermanent(network)) {
+          await ops.disconnect(network).catch(() => {});
+        }
+      });
+    },
+    isJoined(network) {
+      return nets.has(network);
+    },
+    // Alleen subnetten van netwerken die WIJ voor de relay joinden: verkeer
+    // daarvandaan is per definitie workload-verkeer en mag de :3000-API nooit
+    // bereiken (zie de connection-guard in api.ts). Bestaande memberships
+    // (dc-net-*, het default-net) blijven buiten schot.
+    isJoinedNetworkIp(ip) {
+      for (const entry of nets.values()) {
+        if (!entry.joinedByUs) continue;
+        for (const s of entry.subnets) {
+          if (ipInSubnet(ip, s)) return true;
+        }
+      }
+      return false;
+    },
+  };
+}
+
+// Eigen container-referentie van de gateway voor connect/disconnect: de
+// container-id uit /etc/hostname (Docker zet de id als hostname), met 'huddle'
+// (de vaste containernaam uit de CLI-init) als fallback. Eénmalig geverifieerd
+// via inspect.
+let selfRefPromise: Promise<string> | null = null;
+function resolveSelfRef(): Promise<string> {
+  if (!selfRefPromise) {
+    selfRefPromise = (async () => {
+      const candidates: string[] = [];
+      try { candidates.push(fs.readFileSync('/etc/hostname', 'utf8').trim()); } catch {}
+      candidates.push('huddle');
+      for (const c of candidates) {
+        if (!c) continue;
+        try {
+          const { status } = await dockerRequestJson('GET', `/containers/${encodeURIComponent(c)}/json`);
+          if (status === 200) return c;
+        } catch {}
+      }
+      return 'huddle';
+    })();
+  }
+  return selfRefPromise;
+}
+
+const realNetworkOps: GatewayNetworkOps = {
+  async connect(network) {
+    const self = await resolveSelfRef();
+    const { status, data } = await dockerRequestJson(
+      'POST', `/networks/${encodeURIComponent(network)}/connect`, { Container: self },
+    );
+    if (status < 300) {
+      // Podman regenereert resolv.conf bij elke connect van de gateway; herstel
+      // hem zodat egress-DNS blijft werken (zelfde reflex als docker.ts).
+      await sanitizeResolvConf().catch(() => {});
+      return 'connected';
+    }
+    const msg = String(data?.message ?? '');
+    // Docker: "…already exists in network…", Podman: "…already connected…".
+    if (msg.includes('already exists in network') || msg.includes('already connected')) return 'already-connected';
+    if (status === 404) return 'missing';
+    console.warn(`[port-relay] connect to network ${network} failed (${status}): ${msg}`);
+    return 'error';
+  },
+  async disconnect(network) {
+    const self = await resolveSelfRef();
+    await dockerRequestJson('POST', `/networks/${encodeURIComponent(network)}/disconnect`, { Container: self });
+    await sanitizeResolvConf().catch(() => {});
+  },
+  async subnets(network) {
+    const { status, data } = await dockerRequestJson('GET', `/networks/${encodeURIComponent(network)}`);
+    if (status !== 200) return [];
+    const cfg = data?.IPAM?.Config;
+    if (!Array.isArray(cfg)) return [];
+    return cfg.map((c: any) => String(c?.Subnet ?? '')).filter(Boolean);
+  },
+};
+
+const gatewayNetworks = createNetworkRefTracker(realNetworkOps);
+
+// Voor de :3000-API-guard (api.ts): komt dit bron-IP uit een netwerk dat de
+// gateway alleen voor de port-relay heeft gejoined?
+export function isRelayNetworkIp(ip: string): boolean {
+  return gatewayNetworks.isJoinedNetworkIp(ip);
+}
+
+// Backend-dial met harde connect-timeout. Docker's inter-bridge-isolatie DROP't
+// SYN's stilletjes (geen RST): zonder timeout hangt een client voor altijd op
+// een accept zonder bytes. Exported voor unit-tests.
+export function dialWithTimeout(host: string, port: number, timeoutMs: number): Promise<net.Socket> {
+  return new Promise((resolve, reject) => {
+    const sock = net.createConnection({ host, port });
+    const timer = setTimeout(() => {
+      sock.destroy();
+      reject(new Error(`connect timeout after ${timeoutMs}ms`));
+    }, timeoutMs);
+    sock.on('connect', () => {
+      clearTimeout(timer);
+      // Vangnet tot de caller z'n eigen error-handlers hangt.
+      sock.on('error', () => {});
+      resolve(sock);
+    });
+    sock.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+const DIAL_TIMEOUT_MS = 5_000;
+
+// ── Relay-registry ────────────────────────────────────────────────────────────
+
+interface ActiveRelay {
+  spec: RelaySpec;
+  server: net.Server;
+  sockPath: string;
+}
+
+interface ContainerRelays {
+  owner: string;
+  containerId: string;
+  containerName: string;
+  aliases: string[];
+  relays: ActiveRelay[];
+  // Netwerk waarover de relays momenteel dialen; draagt één refcount bij het
+  // netwerkbeheer. Kan per verbinding verspringen (herstart op ander netwerk).
+  network: string | null;
+}
+
+const relaysById = new Map<string, ContainerRelays>();
+// name / korte id / volle id → volle id, zodat teardown werkt met wat de
+// docker-client ook maar in het pad zette.
+const aliasIndex = new Map<string, string>();
+
+function portsDirFor(owner: string): string {
+  return path.join(SOCKET_DIR, owner, 'ports');
+}
+
+function unlinkRelayFiles(sockPath: string): void {
+  for (const p of [sockPath, sockPath.replace(/\.sock$/, '.ready'), sockPath.replace(/\.sock$/, '.err')]) {
+    try { fs.unlinkSync(p); } catch {}
+  }
+}
+
+export async function teardownContainerRelays(ref: string): Promise<void> {
+  const id = aliasIndex.get(ref) ?? ref;
+  const entry = relaysById.get(id);
+  if (!entry) return;
+  relaysById.delete(id);
+  for (const a of entry.aliases) {
+    if (aliasIndex.get(a) === id) aliasIndex.delete(a);
+  }
+  for (const r of entry.relays) {
+    // close() stopt met accepteren; lopende verbindingen mogen leeglopen (de
+    // container gaat toch neer, dan resetten ze vanzelf).
+    try { r.server.close(); } catch {}
+    unlinkRelayFiles(r.sockPath);
+  }
+  console.log(`[port-relay] ${entry.owner}: relays down for ${id.slice(0, 12)} (${entry.relays.map(r => r.spec.hostPort).join(', ') || 'none'})`);
+  // Netwerk-ref pas ná het sluiten vrijgeven: was dit de laatste relay op dat
+  // netwerk, dan koppelt de gateway zich los en kan `docker network rm` weer.
+  if (entry.network) await gatewayNetworks.release(entry.network, id);
+}
+
+// Eén inkomende verbinding op de unix-socket doorzetten naar de workload-
+// container. Target (netwerk + IP) wordt per verbinding vers uit een inspect
+// gehaald: zo overleeft de relay een container-herstart met nieuw IP of ander
+// netwerk, en ruimt hij zichzelf op wanneer de container buiten de proxy om
+// verdween (404). Elke faalroute sluit de client hard (fail fast) — de stille
+// oneindige hang van Docker's inter-bridge-DROP mag niet reproduceerbaar zijn.
+async function relayConnection(client: net.Socket, owner: string, containerId: string, spec: RelaySpec): Promise<void> {
+  client.on('error', () => {});
+  const fail = (reason: string): void => {
+    console.error(`[port-relay] ${owner}: backend dial failed for container ${containerId.slice(0, 12)} port ${spec.hostPort}→${spec.containerPort}: ${reason}`);
+    client.destroy();
+  };
+  let inspect: { status: number; data: any };
+  try {
+    inspect = await dockerRequestJson('GET', `/containers/${containerId}/json`);
+  } catch (err: any) {
+    fail(`inspect failed: ${err.message}`);
+    return;
+  }
+  if (inspect.status === 404) {
+    client.destroy();
+    void teardownContainerRelays(containerId);
+    return;
+  }
+  if (inspect.status !== 200 || !inspect.data?.State?.Running) {
+    fail('container is not running');
+    return;
+  }
+  // Ownership her-checken op het verse inspect: een relay mag ook ná een
+  // herstart/re-create nooit naar een container van een ander gaan wijzen
+  // (#82-semantiek — het id kan inmiddels van eigenaar gewisseld zijn).
+  if (inspect.data.Config?.Labels?.['huddle.parent'] !== owner) {
+    fail('container is no longer owned by this devcontainer');
+    void teardownContainerRelays(containerId);
+    return;
+  }
+  const target = resolveTarget(inspect.data, owner);
+  if (!target) {
+    fail('container has no reachable network/IP');
+    return;
+  }
+  // Zorg dat de gateway aan het doelnetwerk hangt vóór de dial; tussen bridges
+  // worden SYN's anders geluidloos gedropt. Idempotent en refcounted; bij een
+  // netwerkwissel (herstart) verhuist de ref van het oude naar het nieuwe net.
+  // Geen entry meer = teardown won de race — dan geen ref meer nemen die
+  // niemand nog vrijgeeft.
+  const entry = relaysById.get(containerId);
+  if (!entry) {
+    client.destroy();
+    return;
+  }
+  if (!(await gatewayNetworks.acquire(target.network, containerId))) {
+    fail(`cannot join network ${target.network}`);
+    return;
+  }
+  if (entry.network !== target.network) {
+    const old = entry.network;
+    entry.network = target.network;
+    if (old) void gatewayNetworks.release(old, containerId);
+  }
+  let backend: net.Socket;
+  try {
+    backend = await dialWithTimeout(target.ip, spec.containerPort, DIAL_TIMEOUT_MS);
+  } catch (err: any) {
+    fail(`network ${target.network}, target ${target.ip}:${spec.containerPort}: ${err.message}`);
+    return;
+  }
+  backend.on('error', () => client.destroy());
+  client.on('error', () => backend.destroy());
+  client.pipe(backend);
+  backend.pipe(client);
+  client.on('close', () => backend.destroy());
+  backend.on('close', () => client.destroy());
+}
+
+function listenRelay(owner: string, containerId: string, spec: RelaySpec, sockPath: string): Promise<net.Server | null> {
+  return new Promise((resolve) => {
+    const server = net.createServer((client) => { void relayConnection(client, owner, containerId, spec); });
+    server.on('error', (err) => {
+      console.warn(`[port-relay] ${owner}: listen on ${sockPath} failed:`, err.message);
+      resolve(null);
+    });
+    server.listen(sockPath, () => {
+      try { fs.chmodSync(sockPath, 0o777); } catch {}
+      resolve(server);
+    });
+  });
+}
+
+// Wacht tot de in-devcontainer forwarder de loopback-listener bevestigt
+// (`<port>.ready`), of een duidelijke fout meldt (`<port>.err`, bv. poort al in
+// gebruik in de devcontainer). Timeout is geen fout: de relay werkt dan alsnog
+// zodra de forwarder bijtrekt, alleen kunnen eerste connecties racen.
+async function waitForForwarderReady(dir: string, spec: RelaySpec, owner: string): Promise<void> {
+  const readyPath = path.join(dir, `${spec.hostPort}.ready`);
+  const errPath = path.join(dir, `${spec.hostPort}.err`);
+  const deadline = Date.now() + FORWARDER_READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(readyPath)) return;
+    if (fs.existsSync(errPath)) {
+      let msg = '';
+      try { msg = fs.readFileSync(errPath, 'utf8').trim(); } catch {}
+      console.warn(`[port-relay] ${owner}: devcontainer listener for port ${spec.hostPort} failed: ${msg || 'unknown error'} (port already in use in the devcontainer?)`);
+      return;
+    }
+    await sleep(50);
+  }
+  console.warn(`[port-relay] ${owner}: devcontainer forwarder did not confirm port ${spec.hostPort} within ${FORWARDER_READY_TIMEOUT_MS}ms; first connections may be refused`);
+}
+
+// (Her)bouw de relays voor één owned container op basis van een verse inspect.
+// Aangeroepen ná een geslaagde start/restart via de socket-proxy, en bij
+// gateway-start voor al draaiende owned containers. De ownership-check hier is
+// verdediging-in-de-diepte: de socket-proxy heeft al geverifieerd, maar relays
+// van andermans containers mogen ook standalone nooit ontstaan (#82-semantiek).
+export async function syncContainerRelays(owner: string, containerRef: string): Promise<void> {
+  const { status, data } = await dockerRequestJson('GET', `/containers/${encodeURIComponent(containerRef)}/json`);
+  if (status !== 200 || !data) return;
+  if (data.Config?.Labels?.['huddle.parent'] !== owner) return;
+  const id: string = data.Id;
+
+  await teardownContainerRelays(id);
+
+  const specs = extractRelaySpecs(data);
+  for (const s of specs) {
+    if (s.proto !== 'tcp') {
+      console.warn(`[port-relay] ${owner}: ${s.proto} binding ${s.hostPort} not relayed (only tcp is supported)`);
+    }
+  }
+  const tcp = specs.filter(s => s.proto === 'tcp');
+  if (tcp.length === 0) return;
+
+  const dir = portsDirFor(owner);
+  fs.mkdirSync(dir, { recursive: true });
+  const name = String(data.Name ?? '').replace(/^\//, '');
+  const entry: ContainerRelays = {
+    owner,
+    containerId: id,
+    containerName: name,
+    aliases: [id, id.slice(0, 12), name].filter(Boolean),
+    relays: [],
+    network: null,
+  };
+
+  // Gateway alvast aan het doelnetwerk koppelen, zodat de eerste dial niet op
+  // de join hoeft te wachten. Faalt dit (netwerk net verwijderd?), dan blijft
+  // de relay bestaan: elke verbinding probeert het opnieuw en faalt anders
+  // luid via de dial-guard in relayConnection.
+  const target = resolveTarget(data, owner);
+  if (target) {
+    if (await gatewayNetworks.acquire(target.network, id)) {
+      entry.network = target.network;
+    } else {
+      console.error(`[port-relay] ${owner}: cannot join network ${target.network} for ${name || id.slice(0, 12)} (target ${target.ip})`);
+    }
+  }
+
+  for (const spec of tcp) {
+    const sockPath = path.join(dir, `${spec.hostPort}.sock`);
+    unlinkRelayFiles(sockPath);
+    const server = await listenRelay(owner, id, spec, sockPath);
+    if (server) entry.relays.push({ spec, server, sockPath });
+  }
+  if (entry.relays.length === 0) {
+    if (entry.network) await gatewayNetworks.release(entry.network, id);
+    return;
+  }
+
+  relaysById.set(id, entry);
+  for (const a of entry.aliases) aliasIndex.set(a, id);
+
+  await Promise.all(entry.relays.map(r => waitForForwarderReady(dir, r.spec, owner)));
+  console.log(`[port-relay] ${owner}: relaying ${entry.relays.map(r => `${r.spec.hostPort}→${r.spec.containerPort}`).join(', ')} for ${name || id.slice(0, 12)}`);
+}
+
+// ── In-devcontainer forwarder ─────────────────────────────────────────────────
+// Draait als root in de devcontainer (Node zit in het base-image). Houdt
+// /var/run/huddle/ports in de gaten en spiegelt elke <port>.sock naar een
+// TCP-listener op 127.0.0.1 (verplicht) en ::1 (best effort — DCP adresseert
+// [::1]). Meldt succes/falen via <port>.ready / <port>.err zodat de gateway de
+// start-respons kan ophouden tot de listener er echt is.
+
+const FORWARDER_JS = `// huddle-port-forwarder: spiegelt gepubliceerde poorten van owned containers
+// op de loopback van deze devcontainer. Beheerd door de huddle-gateway.
+'use strict';
+const fs = require('fs');
+const net = require('net');
+const path = require('path');
+const DIR = '/var/run/huddle/ports';
+function log(msg) {
+  try { fs.appendFileSync('/tmp/huddle-port-forwarder.log', new Date().toISOString() + ' ' + msg + '\\n'); } catch (e) {}
+}
+const active = new Map(); // port -> [servers]
+function ensureReady(port) {
+  const p = path.join(DIR, port + '.ready');
+  try { if (!fs.existsSync(p)) fs.writeFileSync(p, ''); } catch (e) {}
+}
+function open(port) {
+  const sockPath = path.join(DIR, port + '.sock');
+  const servers = [];
+  active.set(port, servers);
+  let pending = 0;
+  let v4ok = false;
+  let v4err = null;
+  const finish = () => {
+    if (pending !== 0) return;
+    if (v4ok) {
+      try { fs.unlinkSync(path.join(DIR, port + '.err')); } catch (e) {}
+      ensureReady(port);
+      log('listening on ' + port);
+    } else {
+      try { fs.writeFileSync(path.join(DIR, port + '.err'), String(v4err || 'listen failed')); } catch (e) {}
+      log('FAILED to listen on 127.0.0.1:' + port + ': ' + v4err);
+      for (const s of servers) { try { s.close(); } catch (e) {} }
+      active.delete(port);
+    }
+  };
+  const listen = (host, required) => {
+    pending++;
+    const srv = net.createServer((client) => {
+      const up = net.createConnection(sockPath);
+      client.on('error', () => up.destroy());
+      up.on('error', () => client.destroy());
+      client.pipe(up);
+      up.pipe(client);
+      client.on('close', () => up.destroy());
+      up.on('close', () => client.destroy());
+    });
+    srv.on('error', (err) => {
+      if (required) v4err = err.message;
+      pending--;
+      finish();
+    });
+    srv.listen(port, host, () => {
+      if (required) v4ok = true;
+      pending--;
+      finish();
+    });
+    servers.push(srv);
+  };
+  // 127.0.0.1 is verplicht; ::1 best effort (IPv6 kan uit staan).
+  listen('127.0.0.1', true);
+  listen('::1', false);
+}
+function sync() {
+  let names = [];
+  try { names = fs.readdirSync(DIR); } catch (e) { names = []; }
+  const want = new Set();
+  for (const n of names) {
+    const m = /^(\\d+)\\.sock$/.exec(n);
+    if (m) want.add(parseInt(m[1], 10));
+  }
+  for (const [port, servers] of active) {
+    if (want.has(port)) continue;
+    for (const s of servers) { try { s.close(); } catch (e) {} }
+    active.delete(port);
+    try { fs.unlinkSync(path.join(DIR, port + '.ready')); } catch (e) {}
+    log('closed ' + port);
+  }
+  for (const port of want) {
+    if (active.has(port)) ensureReady(port); // gateway kan .ready herschreven willen zien na resync
+    else open(port);
+  }
+}
+let watching = false;
+function ensureWatch() {
+  if (watching) return;
+  try {
+    fs.watch(DIR, () => setTimeout(sync, 20));
+    watching = true;
+  } catch (e) {}
+}
+ensureWatch();
+sync();
+// Vangnet voor gemiste inotify-events of een pas later verschenen ports-dir.
+setInterval(() => { ensureWatch(); sync(); }, 2000);
+log('forwarder started');
+`;
+
+// Sh-script dat de forwarder in de devcontainer installeert en (her)start.
+// Idempotent: bij ongewijzigd script en levend pid-bestand gebeurt er niets;
+// een nieuwe forwarder-versie vervangt het bestand en herstart het proces.
+// Zet daarnaast host.docker.internal → 127.0.0.1 in /etc/hosts, zodat de
+// hostnaam-conventie van DCP/Testcontainers op de relays uitkomt.
+export function buildForwarderSetupScript(): string {
+  const b64 = Buffer.from(FORWARDER_JS, 'utf8').toString('base64');
+  return `#!/bin/sh
+TARGET=/usr/local/lib/huddle-port-forwarder.js
+PIDFILE=/tmp/huddle-port-forwarder.pid
+mkdir -p /usr/local/lib /var/run/huddle/ports 2>/dev/null || true
+TMP=$(mktemp /tmp/huddle-pf.XXXXXX)
+echo '${b64}' | base64 -d > "$TMP"
+if ! cmp -s "$TMP" "$TARGET" 2>/dev/null; then
+  mv "$TMP" "$TARGET"
+  [ -f "$PIDFILE" ] && kill "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null || true
+else
+  rm -f "$TMP"
+fi
+grep -q 'host\\.docker\\.internal' /etc/hosts 2>/dev/null || echo '127.0.0.1 host.docker.internal' >> /etc/hosts
+if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; then exit 0; fi
+nohup node "$TARGET" >> /tmp/huddle-port-forwarder.log 2>&1 &
+echo $! > "$PIDFILE"
+`;
+}
+
+// Installeer/start de forwarder in een (draaiende) devcontainer. Aangeroepen
+// bij devcontainer-aanmaak, bij een start via het portal en bij gateway-start.
+export async function ensurePortForwarder(owner: string, containerRef?: string): Promise<void> {
+  const ref = containerRef ?? owner;
+  try {
+    fs.mkdirSync(portsDirFor(owner), { recursive: true });
+    const exec = await dockerRequestJson('POST', `/containers/${encodeURIComponent(ref)}/exec`, {
+      User: 'root',
+      Cmd: ['sh', '-c', buildForwarderSetupScript()],
+      AttachStdout: false,
+      AttachStderr: false,
+    });
+    if (exec.status >= 400 || !exec.data?.Id) throw new Error(`exec create → ${exec.status}`);
+    const started = await dockerRequestJson('POST', `/exec/${exec.data.Id}/start`, { Detach: true });
+    if (started.status >= 400) throw new Error(`exec start → ${started.status}`);
+  } catch (err: any) {
+    console.warn(`[port-relay] ${owner}: could not start in-devcontainer forwarder:`, err.message);
+  }
+}
+
+// Herstel na een gateway-herstart: forwarder in elke draaiende devcontainer
+// (opnieuw) opzetten en relays terugbouwen voor hun al draaiende owned
+// containers (de unix-sockets van vóór de herstart zijn dood).
+export async function initPortRelays(): Promise<void> {
+  try {
+    const filters = encodeURIComponent(JSON.stringify({ label: ['com.intellij.devcontainer.id'] }));
+    const { status, data } = await dockerRequestJson('GET', `/containers/json?filters=${filters}`);
+    if (status !== 200 || !Array.isArray(data)) return;
+    for (const dc of data) {
+      const name = String(dc.Names?.[0] ?? '').replace(/^\//, '');
+      if (!name) continue;
+      await ensurePortForwarder(name, dc.Id);
+      const childFilters = encodeURIComponent(JSON.stringify({ label: [`huddle.parent=${name}`] }));
+      const children = await dockerRequestJson('GET', `/containers/json?filters=${childFilters}`);
+      if (children.status !== 200 || !Array.isArray(children.data)) continue;
+      for (const c of children.data) {
+        try {
+          await syncContainerRelays(name, c.Id);
+        } catch (err: any) {
+          console.warn(`[port-relay] ${name}: resync failed for ${String(c.Id).slice(0, 12)}:`, err.message);
+        }
+      }
+    }
+  } catch (err: any) {
+    console.error('[port-relay] init failed:', err.message);
+  }
+}

--- a/gateway/src/port-relay.ts
+++ b/gateway/src/port-relay.ts
@@ -4,33 +4,34 @@ import fs from 'fs';
 import path from 'path';
 import { sanitizeResolvConf } from './dns-egress';
 
-// ── Port-relay: gepubliceerde poorten van owned containers de devcontainer in ─
-// Een devcontainer praat met de docker-daemon van de HOST (docker-outside-of-
-// docker). Publiceert een owned container een poort, dan bindt die op de
-// loopback van de host — onbereikbaar vanuit de devcontainer, die geen default
-// route heeft en een eigen loopback (issue: Aspire/DCP, Testcontainers, plain
-// `docker run -p` — TCP connect naar 127.0.0.1:<hostPort> faalt of hangt).
+// ── Port-relay: published ports of owned containers into the devcontainer ────
+// A devcontainer talks to the HOST's docker daemon (docker-outside-of-
+// docker). When an owned container publishes a port, it binds on the host's
+// loopback — unreachable from the devcontainer, which has no default route
+// and its own loopback (issue: Aspire/DCP, Testcontainers, plain
+// `docker run -p` — a TCP connect to 127.0.0.1:<hostPort> fails or hangs).
 //
-// De oplossing spiegelt het docker.sock-mechanisme: per gepubliceerde TCP-poort
-// legt de gateway een unix-socket neer in de al gedeelde per-container mount
+// The solution mirrors the docker.sock mechanism: for each published TCP port
+// the gateway drops a unix-socket into the already-shared per-container mount
 // (/tmp/dc-sockets/<owner>/ports/<hostPort>.sock ≙ /var/run/huddle/ports/… in
-// de devcontainer). Een kleine in-devcontainer forwarder (Node, door de gateway
-// via docker exec geïnstalleerd) luistert op 127.0.0.1/::1:<hostPort> en pipe't
-// naar die unix-socket; de gateway pipe't de unix-socket door naar
-// containerIP:containerPort op het dc-net van de eigenaar (waar huddle zelf al
-// aan gekoppeld is). Zo is er nooit een pad via de host-loopback nodig.
+// the devcontainer). A small in-devcontainer forwarder (Node, installed by the
+// gateway via docker exec) listens on 127.0.0.1/::1:<hostPort> and pipes to
+// that unix-socket; the gateway pipes the unix-socket through to
+// containerIP:containerPort on the owner's dc-net (which huddle itself is
+// already attached to). This way no path via the host loopback is ever needed.
 
 const DOCKER_SOCKET = '/var/run/docker.sock';
 const SOCKET_DIR = '/tmp/dc-sockets';
 
-// Hoe lang we op de in-devcontainer forwarder wachten voordat de start-respons
-// alsnog doorgaat. DCP/Testcontainers inspecteren en connecten direct ná de
-// start-respons, dus de loopback-listener moet er vóór die respons zijn.
+// How long we wait for the in-devcontainer forwarder before the start response
+// proceeds anyway. DCP/Testcontainers inspect and connect immediately after the
+// start response, so the loopback listener must be there before that response.
 const FORWARDER_READY_TIMEOUT_MS = 2000;
 
 // ── Docker helpers ────────────────────────────────────────────────────────────
-// Bewust zelfstandig (geen import uit docker.ts): docker.ts importeert deze
-// module, en een importcyclus met socket-proxy.ts erbij is dan snel gemaakt.
+// Deliberately self-contained (no import from docker.ts): docker.ts imports
+// this module, and with socket-proxy.ts in the mix an import cycle is easily
+// created.
 
 function dockerRequestJson(method: string, urlPath: string, body?: unknown): Promise<{ status: number; data: any }> {
   return new Promise((resolve, reject) => {
@@ -62,7 +63,7 @@ function sleep(ms: number): Promise<void> {
   return new Promise((res) => setTimeout(res, ms));
 }
 
-// ── Pure helpers (unit-getest) ────────────────────────────────────────────────
+// ── Pure helpers (unit-tested) ────────────────────────────────────────────────
 
 export interface RelaySpec {
   hostPort: number;
@@ -70,16 +71,16 @@ export interface RelaySpec {
   proto: string;
 }
 
-// Leid uit een container-inspect de te relayen poorten af. Bron is
-// NetworkSettings.Ports zoals dat er NÁ de start uitziet, dus inclusief
-// dynamisch toegewezen poorten (HostPort:0 → daadwerkelijke poort). Dubbele
-// bindings van dezelfde hostpoort (0.0.0.0 + ::) vallen samen tot één spec.
+// Derive the ports to relay from a container inspect. The source is
+// NetworkSettings.Ports as it looks AFTER the start, so including dynamically
+// assigned ports (HostPort:0 → actual port). Duplicate bindings of the same
+// host port (0.0.0.0 + ::) collapse into a single spec.
 export function extractRelaySpecs(inspect: any): RelaySpec[] {
   const ports = inspect?.NetworkSettings?.Ports;
   if (!ports || typeof ports !== 'object') return [];
   const seen = new Map<string, RelaySpec>();
   for (const [key, bindings] of Object.entries(ports)) {
-    if (!Array.isArray(bindings)) continue; // niet-gepubliceerde poort (null)
+    if (!Array.isArray(bindings)) continue; // unpublished port (null)
     const [portStr, proto = 'tcp'] = key.split('/');
     const containerPort = parseInt(portStr, 10);
     if (!Number.isInteger(containerPort) || containerPort <= 0) continue;
@@ -98,13 +99,13 @@ export interface RelayTarget {
   network: string;
 }
 
-// Netwerk + IP waarop de gateway de workload-container moet bereiken. Voorkeur:
-// het dc-net van de eigenaar (daar zit huddle standaard al in). Maar een
-// workload kan óók uitsluitend op een eigen netwerk leven — Aspire's DCP maakt
-// z'n session-netwerk via de socket-proxy aan en verhangt containers erheen —
-// en Docker's inter-bridge-isolatie DROP't SYN's stilletjes tussen bridges. De
-// caller moet de gateway dus expliciet aan `network` koppelen vóór de dial
-// (ensure + refcount hieronder); vandaar dat het netwerk hier mee terugkomt.
+// Network + IP on which the gateway must reach the workload container.
+// Preference: the owner's dc-net (huddle is already in it by default). But a
+// workload can also live exclusively on its own network — Aspire's DCP creates
+// its session network via the socket-proxy and moves containers onto it — and
+// Docker's inter-bridge isolation silently DROPs SYNs between bridges. The
+// caller must therefore explicitly attach the gateway to `network` before the
+// dial (ensure + refcount below); hence the network is returned here as well.
 export function resolveTarget(inspect: any, owner: string): RelayTarget | null {
   const nets = inspect?.NetworkSettings?.Networks ?? {};
   const dcNet = `dc-net-${owner}`;
@@ -115,14 +116,14 @@ export function resolveTarget(inspect: any, owner: string): RelayTarget | null {
   return null;
 }
 
-// ── Gateway-netwerkbeheer (join + refcount) ──────────────────────────────────
-// De gateway koppelt zichzelf on demand aan het netwerk van een workload-
-// container. Refcounted over alle relays heen: pas als de laatste relay op een
-// netwerk verdwijnt, koppelt de gateway zich weer los — een achtergebleven
-// membership blokkeert `docker network rm` wanneer Aspire/DCP z'n session-
-// netwerken opruimt. Netwerken waar de gateway al aan hing vóór de eerste
-// acquire (joinedByUs=false) en permanente netwerken (dc-net-*) worden nooit
-// losgekoppeld.
+// ── Gateway network management (join + refcount) ─────────────────────────────
+// The gateway attaches itself on demand to a workload container's network.
+// Refcounted across all relays: only when the last relay on a network
+// disappears does the gateway detach again — a leftover membership blocks
+// `docker network rm` when Aspire/DCP cleans up its session networks.
+// Networks the gateway was already attached to before the first acquire
+// (joinedByUs=false) and permanent networks (dc-net-*) are never
+// disconnected.
 
 export type NetworkConnectResult = 'connected' | 'already-connected' | 'missing' | 'error';
 
@@ -139,9 +140,9 @@ export interface NetworkRefTracker {
   isJoinedNetworkIp(ip: string): boolean;
 }
 
-// Zit `ip` in IPv4-CIDR `subnet`? IPv6-subnetten (zeldzaam voor Docker-bridges)
-// matchen conservatief niet — dan blijft alleen de default-deny van de proxy
-// als laag over. Exported voor unit-tests.
+// Is `ip` inside IPv4 CIDR `subnet`? IPv6 subnets (rare for Docker bridges)
+// conservatively don't match — in that case only the proxy's default-deny
+// remains as a layer. Exported for unit tests.
 export function ipInSubnet(rawIp: string, subnet: string): boolean {
   const ip = rawIp.replace(/^::ffff:/, '');
   const m = subnet.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)\/(\d+)$/);
@@ -160,8 +161,8 @@ export function createNetworkRefTracker(
 ): NetworkRefTracker {
   interface JoinedNet { joinedByUs: boolean; refs: Set<string>; subnets: string[]; }
   const nets = new Map<string, JoinedNet>();
-  // Per netwerk geserialiseerd zodat een gelijktijdige acquire/release nooit
-  // een connect en disconnect door elkaar laat lopen.
+  // Serialized per network so that a concurrent acquire/release can never
+  // interleave a connect and a disconnect.
   const locks = new Map<string, Promise<unknown>>();
   function withLock<T>(network: string, fn: () => Promise<T>): Promise<T> {
     const prev = locks.get(network) ?? Promise.resolve();
@@ -197,10 +198,10 @@ export function createNetworkRefTracker(
     isJoined(network) {
       return nets.has(network);
     },
-    // Alleen subnetten van netwerken die WIJ voor de relay joinden: verkeer
-    // daarvandaan is per definitie workload-verkeer en mag de :3000-API nooit
-    // bereiken (zie de connection-guard in api.ts). Bestaande memberships
-    // (dc-net-*, het default-net) blijven buiten schot.
+    // Only subnets of networks that WE joined for the relay: traffic from
+    // there is by definition workload traffic and must never reach the :3000
+    // API (see the connection guard in api.ts). Existing memberships
+    // (dc-net-*, the default net) stay out of scope.
     isJoinedNetworkIp(ip) {
       for (const entry of nets.values()) {
         if (!entry.joinedByUs) continue;
@@ -213,10 +214,10 @@ export function createNetworkRefTracker(
   };
 }
 
-// Eigen container-referentie van de gateway voor connect/disconnect: de
-// container-id uit /etc/hostname (Docker zet de id als hostname), met 'huddle'
-// (de vaste containernaam uit de CLI-init) als fallback. Eénmalig geverifieerd
-// via inspect.
+// The gateway's own container reference for connect/disconnect: the container
+// id from /etc/hostname (Docker sets the id as hostname), with 'huddle' (the
+// fixed container name from the CLI init) as fallback. Verified once via
+// inspect.
 let selfRefPromise: Promise<string> | null = null;
 function resolveSelfRef(): Promise<string> {
   if (!selfRefPromise) {
@@ -246,8 +247,8 @@ const realNetworkOps: GatewayNetworkOps = {
       'POST', `/networks/${encodeURIComponent(network)}/connect`, { Container: self },
     );
     if (status < 300) {
-      // Podman regenereert resolv.conf bij elke connect van de gateway; herstel
-      // hem zodat egress-DNS blijft werken (zelfde reflex als docker.ts).
+      // Podman regenerates resolv.conf on every connect of the gateway;
+      // restore it so egress DNS keeps working (same reflex as docker.ts).
       await sanitizeResolvConf().catch(() => {});
       return 'connected';
     }
@@ -274,15 +275,15 @@ const realNetworkOps: GatewayNetworkOps = {
 
 const gatewayNetworks = createNetworkRefTracker(realNetworkOps);
 
-// Voor de :3000-API-guard (api.ts): komt dit bron-IP uit een netwerk dat de
-// gateway alleen voor de port-relay heeft gejoined?
+// For the :3000 API guard (api.ts): does this source IP come from a network
+// that the gateway joined solely for the port-relay?
 export function isRelayNetworkIp(ip: string): boolean {
   return gatewayNetworks.isJoinedNetworkIp(ip);
 }
 
-// Backend-dial met harde connect-timeout. Docker's inter-bridge-isolatie DROP't
-// SYN's stilletjes (geen RST): zonder timeout hangt een client voor altijd op
-// een accept zonder bytes. Exported voor unit-tests.
+// Backend dial with a hard connect timeout. Docker's inter-bridge isolation
+// silently DROPs SYNs (no RST): without a timeout a client hangs forever on
+// an accept with no bytes. Exported for unit tests.
 export function dialWithTimeout(host: string, port: number, timeoutMs: number): Promise<net.Socket> {
   return new Promise((resolve, reject) => {
     const sock = net.createConnection({ host, port });
@@ -292,7 +293,7 @@ export function dialWithTimeout(host: string, port: number, timeoutMs: number): 
     }, timeoutMs);
     sock.on('connect', () => {
       clearTimeout(timer);
-      // Vangnet tot de caller z'n eigen error-handlers hangt.
+      // Safety net until the caller attaches its own error handlers.
       sock.on('error', () => {});
       resolve(sock);
     });
@@ -319,22 +320,23 @@ interface ContainerRelays {
   containerName: string;
   aliases: string[];
   relays: ActiveRelay[];
-  // Netwerk waarover de relays momenteel dialen; draagt één refcount bij het
-  // netwerkbeheer. Kan per verbinding verspringen (herstart op ander netwerk).
+  // Network the relays currently dial over; carries one refcount with the
+  // network management. Can shift per connection (restart on another network).
   network: string | null;
 }
 
 const relaysById = new Map<string, ContainerRelays>();
-// name / korte id / volle id → volle id, zodat teardown werkt met wat de
-// docker-client ook maar in het pad zette.
+// name / short id / full id → full id, so that teardown works with whatever
+// the docker client happened to put in the path.
 const aliasIndex = new Map<string, string>();
 
-// `owner` vloeit in path.join() onder SOCKET_DIR. De naam komt uit huddle's
-// eigen orchestratie of een operator-API-parameter; net als in socket-proxy.ts
-// (assertSafeContainerName — hier gedupliceerd omdat socket-proxy déze module
-// importeert en een cyclus anders snel gemaakt is) dwingen we de Docker-naam-
-// grammatica expliciet af: geen slashes en geen leidende punt, dus onmogelijk
-// om met `..`/`/` buiten de sockets-directory te schrijven of te lezen.
+// `owner` flows into path.join() under SOCKET_DIR. The name comes from
+// huddle's own orchestration or an operator API parameter; just like in
+// socket-proxy.ts (assertSafeContainerName — duplicated here because
+// socket-proxy imports this very module and a cycle is otherwise easily
+// created) we explicitly enforce the Docker name grammar: no slashes and no
+// leading dot, so it is impossible to write or read outside the sockets
+// directory using `..`/`/`.
 const OWNER_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/;
 
 export function assertSafeOwner(owner: string): void {
@@ -362,23 +364,24 @@ export async function teardownContainerRelays(ref: string): Promise<void> {
     if (aliasIndex.get(a) === id) aliasIndex.delete(a);
   }
   for (const r of entry.relays) {
-    // close() stopt met accepteren; lopende verbindingen mogen leeglopen (de
-    // container gaat toch neer, dan resetten ze vanzelf).
+    // close() stops accepting; in-flight connections may drain (the
+    // container is going down anyway, so they reset on their own).
     try { r.server.close(); } catch {}
     unlinkRelayFiles(r.sockPath);
   }
   console.log(`[port-relay] ${entry.owner}: relays down for ${id.slice(0, 12)} (${entry.relays.map(r => r.spec.hostPort).join(', ') || 'none'})`);
-  // Netwerk-ref pas ná het sluiten vrijgeven: was dit de laatste relay op dat
-  // netwerk, dan koppelt de gateway zich los en kan `docker network rm` weer.
+  // Release the network ref only after closing: if this was the last relay on
+  // that network, the gateway detaches and `docker network rm` works again.
   if (entry.network) await gatewayNetworks.release(entry.network, id);
 }
 
-// Eén inkomende verbinding op de unix-socket doorzetten naar de workload-
-// container. Target (netwerk + IP) wordt per verbinding vers uit een inspect
-// gehaald: zo overleeft de relay een container-herstart met nieuw IP of ander
-// netwerk, en ruimt hij zichzelf op wanneer de container buiten de proxy om
-// verdween (404). Elke faalroute sluit de client hard (fail fast) — de stille
-// oneindige hang van Docker's inter-bridge-DROP mag niet reproduceerbaar zijn.
+// Forward one incoming connection on the unix-socket to the workload
+// container. The target (network + IP) is fetched fresh from an inspect per
+// connection: that way the relay survives a container restart with a new IP or
+// a different network, and it cleans itself up when the container disappeared
+// outside the proxy (404). Every failure path closes the client hard (fail
+// fast) — the silent infinite hang of Docker's inter-bridge DROP must not be
+// reproducible.
 async function relayConnection(client: net.Socket, owner: string, containerId: string, spec: RelaySpec): Promise<void> {
   client.on('error', () => {});
   const fail = (reason: string): void => {
@@ -401,9 +404,9 @@ async function relayConnection(client: net.Socket, owner: string, containerId: s
     fail('container is not running');
     return;
   }
-  // Ownership her-checken op het verse inspect: een relay mag ook ná een
-  // herstart/re-create nooit naar een container van een ander gaan wijzen
-  // (#82-semantiek — het id kan inmiddels van eigenaar gewisseld zijn).
+  // Re-check ownership on the fresh inspect: even after a restart/re-create a
+  // relay must never end up pointing at someone else's container
+  // (#82 semantics — the id may have changed owner in the meantime).
   if (inspect.data.Config?.Labels?.['huddle.parent'] !== owner) {
     fail('container is no longer owned by this devcontainer');
     void teardownContainerRelays(containerId);
@@ -414,11 +417,11 @@ async function relayConnection(client: net.Socket, owner: string, containerId: s
     fail('container has no reachable network/IP');
     return;
   }
-  // Zorg dat de gateway aan het doelnetwerk hangt vóór de dial; tussen bridges
-  // worden SYN's anders geluidloos gedropt. Idempotent en refcounted; bij een
-  // netwerkwissel (herstart) verhuist de ref van het oude naar het nieuwe net.
-  // Geen entry meer = teardown won de race — dan geen ref meer nemen die
-  // niemand nog vrijgeeft.
+  // Make sure the gateway is attached to the target network before the dial;
+  // otherwise SYNs between bridges are dropped silently. Idempotent and
+  // refcounted; on a network switch (restart) the ref moves from the old to
+  // the new net. No entry left = teardown won the race — in that case don't
+  // take a ref that nobody will release anymore.
   const entry = relaysById.get(containerId);
   if (!entry) {
     client.destroy();
@@ -462,10 +465,10 @@ function listenRelay(owner: string, containerId: string, spec: RelaySpec, sockPa
   });
 }
 
-// Wacht tot de in-devcontainer forwarder de loopback-listener bevestigt
-// (`<port>.ready`), of een duidelijke fout meldt (`<port>.err`, bv. poort al in
-// gebruik in de devcontainer). Timeout is geen fout: de relay werkt dan alsnog
-// zodra de forwarder bijtrekt, alleen kunnen eerste connecties racen.
+// Wait until the in-devcontainer forwarder confirms the loopback listener
+// (`<port>.ready`), or reports a clear error (`<port>.err`, e.g. port already
+// in use in the devcontainer). A timeout is not an error: the relay still
+// works once the forwarder catches up, only the first connections may race.
 async function waitForForwarderReady(dir: string, spec: RelaySpec, owner: string): Promise<void> {
   const readyPath = path.join(dir, `${spec.hostPort}.ready`);
   const errPath = path.join(dir, `${spec.hostPort}.err`);
@@ -483,11 +486,12 @@ async function waitForForwarderReady(dir: string, spec: RelaySpec, owner: string
   console.warn(`[port-relay] ${owner}: devcontainer forwarder did not confirm port ${spec.hostPort} within ${FORWARDER_READY_TIMEOUT_MS}ms; first connections may be refused`);
 }
 
-// (Her)bouw de relays voor één owned container op basis van een verse inspect.
-// Aangeroepen ná een geslaagde start/restart via de socket-proxy, en bij
-// gateway-start voor al draaiende owned containers. De ownership-check hier is
-// verdediging-in-de-diepte: de socket-proxy heeft al geverifieerd, maar relays
-// van andermans containers mogen ook standalone nooit ontstaan (#82-semantiek).
+// (Re)build the relays for one owned container based on a fresh inspect.
+// Called after a successful start/restart via the socket-proxy, and at
+// gateway startup for already-running owned containers. The ownership check
+// here is defence-in-depth: the socket-proxy has already verified, but relays
+// for someone else's containers must never come into existence standalone
+// either (#82 semantics).
 export async function syncContainerRelays(owner: string, containerRef: string): Promise<void> {
   assertSafeOwner(owner);
   const { status, data } = await dockerRequestJson('GET', `/containers/${encodeURIComponent(containerRef)}/json`);
@@ -518,10 +522,10 @@ export async function syncContainerRelays(owner: string, containerRef: string): 
     network: null,
   };
 
-  // Gateway alvast aan het doelnetwerk koppelen, zodat de eerste dial niet op
-  // de join hoeft te wachten. Faalt dit (netwerk net verwijderd?), dan blijft
-  // de relay bestaan: elke verbinding probeert het opnieuw en faalt anders
-  // luid via de dial-guard in relayConnection.
+  // Attach the gateway to the target network up front, so the first dial
+  // doesn't have to wait for the join. If this fails (network just removed?),
+  // the relay stays in place: every connection retries it and otherwise fails
+  // loudly via the dial guard in relayConnection.
   const target = resolveTarget(data, owner);
   if (target) {
     if (await gatewayNetworks.acquire(target.network, id)) {
@@ -550,14 +554,14 @@ export async function syncContainerRelays(owner: string, containerRef: string): 
 }
 
 // ── In-devcontainer forwarder ─────────────────────────────────────────────────
-// Draait als root in de devcontainer (Node zit in het base-image). Houdt
-// /var/run/huddle/ports in de gaten en spiegelt elke <port>.sock naar een
-// TCP-listener op 127.0.0.1 (verplicht) en ::1 (best effort — DCP adresseert
-// [::1]). Meldt succes/falen via <port>.ready / <port>.err zodat de gateway de
-// start-respons kan ophouden tot de listener er echt is.
+// Runs as root in the devcontainer (Node is in the base image). Watches
+// /var/run/huddle/ports and mirrors every <port>.sock to a TCP listener on
+// 127.0.0.1 (required) and ::1 (best effort — DCP addresses [::1]). Reports
+// success/failure via <port>.ready / <port>.err so the gateway can hold the
+// start response until the listener really exists.
 
-const FORWARDER_JS = `// huddle-port-forwarder: spiegelt gepubliceerde poorten van owned containers
-// op de loopback van deze devcontainer. Beheerd door de huddle-gateway.
+const FORWARDER_JS = `// huddle-port-forwarder: mirrors published ports of owned containers
+// onto this devcontainer's loopback. Managed by the huddle gateway.
 'use strict';
 const fs = require('fs');
 const net = require('net');
@@ -614,7 +618,7 @@ function open(port) {
     });
     servers.push(srv);
   };
-  // 127.0.0.1 is verplicht; ::1 best effort (IPv6 kan uit staan).
+  // 127.0.0.1 is required; ::1 best effort (IPv6 may be disabled).
   listen('127.0.0.1', true);
   listen('::1', false);
 }
@@ -634,7 +638,7 @@ function sync() {
     log('closed ' + port);
   }
   for (const port of want) {
-    if (active.has(port)) ensureReady(port); // gateway kan .ready herschreven willen zien na resync
+    if (active.has(port)) ensureReady(port); // gateway may want to see .ready rewritten after a resync
     else open(port);
   }
 }
@@ -648,16 +652,16 @@ function ensureWatch() {
 }
 ensureWatch();
 sync();
-// Vangnet voor gemiste inotify-events of een pas later verschenen ports-dir.
+// Safety net for missed inotify events or a ports dir that appears only later.
 setInterval(() => { ensureWatch(); sync(); }, 2000);
 log('forwarder started');
 `;
 
-// Sh-script dat de forwarder in de devcontainer installeert en (her)start.
-// Idempotent: bij ongewijzigd script en levend pid-bestand gebeurt er niets;
-// een nieuwe forwarder-versie vervangt het bestand en herstart het proces.
-// Zet daarnaast host.docker.internal → 127.0.0.1 in /etc/hosts, zodat de
-// hostnaam-conventie van DCP/Testcontainers op de relays uitkomt.
+// Sh script that installs and (re)starts the forwarder in the devcontainer.
+// Idempotent: with an unchanged script and a live pid file nothing happens;
+// a new forwarder version replaces the file and restarts the process.
+// Additionally sets host.docker.internal → 127.0.0.1 in /etc/hosts, so that
+// the hostname convention of DCP/Testcontainers ends up on the relays.
 export function buildForwarderSetupScript(): string {
   const b64 = Buffer.from(FORWARDER_JS, 'utf8').toString('base64');
   return `#!/bin/sh
@@ -679,8 +683,8 @@ echo $! > "$PIDFILE"
 `;
 }
 
-// Installeer/start de forwarder in een (draaiende) devcontainer. Aangeroepen
-// bij devcontainer-aanmaak, bij een start via het portal en bij gateway-start.
+// Install/start the forwarder in a (running) devcontainer. Called on
+// devcontainer creation, on a start via the portal, and at gateway startup.
 export async function ensurePortForwarder(owner: string, containerRef?: string): Promise<void> {
   assertSafeOwner(owner);
   const ref = containerRef ?? owner;
@@ -700,9 +704,9 @@ export async function ensurePortForwarder(owner: string, containerRef?: string):
   }
 }
 
-// Herstel na een gateway-herstart: forwarder in elke draaiende devcontainer
-// (opnieuw) opzetten en relays terugbouwen voor hun al draaiende owned
-// containers (de unix-sockets van vóór de herstart zijn dood).
+// Recovery after a gateway restart: set up the forwarder (again) in every
+// running devcontainer and rebuild relays for their already-running owned
+// containers (the unix-sockets from before the restart are dead).
 export async function initPortRelays(): Promise<void> {
   try {
     const filters = encodeURIComponent(JSON.stringify({ label: ['com.intellij.devcontainer.id'] }));

--- a/gateway/src/proxy.ts
+++ b/gateway/src/proxy.ts
@@ -205,6 +205,24 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
       return;
     }
 
+    // Default-deny voor onbekende bronnen. Client-identiteit is bron-IP →
+    // containermap (kinderen erven hun parent-devcontainer, zie docker.ts); een
+    // IP dat na een geforceerde refresh nog steeds niet naar een huddle-beheerde
+    // container herleidt (host-verkeer, een vreemde container op een netwerk
+    // waar de gateway voor de port-relay bij zit) krijgt GEEN globale-regel-
+    // fallback en maakt ook geen requested-regel aan. Zonder deze guard was elke
+    // globale allow-regel bruikbaar voor iedereen die de proxy kan bereiken —
+    // een stille bypass van "no direct internet".
+    if (!extHeader && containerId === null) {
+      console.warn(`[proxy] denied request from unknown source ${req.socket.remoteAddress ?? '?'} for ${host}`);
+      logAudit({
+        containerId: null, domain: host, action: 'deny', ruleId: null,
+        method: req.method ?? null, path: `${target.pathname}${target.search}`, resStatus: 403,
+      });
+      send403(res, host, 'deny', null);
+      return;
+    }
+
     // Beslis op de gedecodeerde vorm (normalizePathname, finding #7) maar
     // forward de originele encoded bytes van de URL-parser. De gedecodeerde
     // vorm is geen geldige request-target: rauwe spaties/UTF-8 laten
@@ -350,6 +368,18 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
     const hostname = canonicalizeHost(rawHostname);
     if (!hostname) {
       rejectSocket(clientSocket, 400, 'deny', '', null);
+      return;
+    }
+
+    // Default-deny voor onbekende bronnen — zelfde guard en rationale als op
+    // het plain-HTTP-pad hierboven.
+    if (containerId === null) {
+      console.warn(`[proxy] denied CONNECT from unknown source ${(clientSocket as net.Socket).remoteAddress ?? '?'} for ${hostname}`);
+      logAudit({
+        containerId: null, domain: hostname, port, action: 'deny', ruleId: null,
+        method: 'CONNECT', resStatus: 403,
+      });
+      rejectSocket(clientSocket, 403, 'deny', hostname, null);
       return;
     }
 

--- a/gateway/src/proxy.ts
+++ b/gateway/src/proxy.ts
@@ -205,14 +205,14 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
       return;
     }
 
-    // Default-deny voor onbekende bronnen. Client-identiteit is bron-IP →
-    // containermap (kinderen erven hun parent-devcontainer, zie docker.ts); een
-    // IP dat na een geforceerde refresh nog steeds niet naar een huddle-beheerde
-    // container herleidt (host-verkeer, een vreemde container op een netwerk
-    // waar de gateway voor de port-relay bij zit) krijgt GEEN globale-regel-
-    // fallback en maakt ook geen requested-regel aan. Zonder deze guard was elke
-    // globale allow-regel bruikbaar voor iedereen die de proxy kan bereiken —
-    // een stille bypass van "no direct internet".
+    // Default-deny for unknown sources. Client identity is source IP →
+    // container map (children inherit their parent devcontainer, see docker.ts);
+    // an IP that still does not resolve to a huddle-managed container after a
+    // forced refresh (host traffic, a foreign container on a network the
+    // gateway joined for the port-relay) gets NO global-rule fallback and does
+    // not create a requested-rule either. Without this guard every global allow
+    // rule would be usable by anyone able to reach the proxy — a silent bypass
+    // of "no direct internet".
     if (!extHeader && containerId === null) {
       console.warn(`[proxy] denied request from unknown source ${req.socket.remoteAddress ?? '?'} for ${host}`);
       logAudit({
@@ -371,8 +371,8 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
       return;
     }
 
-    // Default-deny voor onbekende bronnen — zelfde guard en rationale als op
-    // het plain-HTTP-pad hierboven.
+    // Default-deny for unknown sources — same guard and rationale as on the
+    // plain-HTTP path above.
     if (containerId === null) {
       console.warn(`[proxy] denied CONNECT from unknown source ${(clientSocket as net.Socket).remoteAddress ?? '?'} for ${hostname}`);
       logAudit({

--- a/gateway/src/socket-proxy.ts
+++ b/gateway/src/socket-proxy.ts
@@ -43,6 +43,50 @@ function dockerGet(urlPath: string): Promise<any> {
   });
 }
 
+// Zoals dockerGet, maar geeft óók de HTTP-status terug. dockerGet parse't het
+// body ongeacht de status, zodat een 404 (`{"message":"No such container"}`) niet
+// van een echte 200-inspect te onderscheiden is. Voor de ownership-check moeten we
+// "bestaat niet" (404) juist wél kunnen scheiden van "bestaat, maar niet van mij".
+function dockerGetStatus(urlPath: string): Promise<{ status: number; data: any }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { socketPath: DOCKER_SOCKET, path: urlPath, method: 'GET' },
+      (res) => {
+        let body = '';
+        res.on('data', (d: Buffer) => { body += d.toString(); });
+        res.on('end', () => {
+          let data: any = null;
+          try { data = body ? JSON.parse(body) : null; } catch { data = null; }
+          resolve({ status: res.statusCode ?? 0, data });
+        });
+      }
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+export type ContainerOwnership = 'own' | 'foreign' | 'missing';
+
+// Classificeer een container-inspect-respons: van ons (huddle.parent-label komt
+// overeen), van een andere devcontainer, of niet-bestaand (404). Puur zodat de
+// beslissing zonder live Docker-socket te unit-testen valt.
+export function ownershipFromInspect(status: number, data: any, containerName: string): ContainerOwnership {
+  if (status === 404) return 'missing';
+  // Onbekende/onverwachte fout of onleesbaar body → veilig als 'foreign' behandelen
+  // (weigeren), nooit per ongeluk als 'missing' doorlaten.
+  if (status >= 400 || !data || typeof data !== 'object') return 'foreign';
+  const labels: Record<string, string> = data.Config?.Labels ?? {};
+  return labels['huddle.parent'] === containerName ? 'own' : 'foreign';
+}
+
+async function classifyContainerOwnership(targetId: string, containerName: string): Promise<ContainerOwnership> {
+  try {
+    const { status, data } = await dockerGetStatus(`/containers/${encodeURIComponent(targetId)}/json`);
+    return ownershipFromInspect(status, data, containerName);
+  } catch { return 'foreign'; }
+}
+
 async function hasOwnLabel(type: 'container' | 'image', targetId: string, containerName: string): Promise<boolean> {
   try {
     const urlPath = type === 'container'
@@ -342,6 +386,19 @@ function namedVolumeSources(hostConfig: any): string[] {
 function deny403(client: net.Socket, msg: string): void {
   const body = JSON.stringify({ message: msg });
   client.write(`HTTP/1.1 403 Forbidden\r\nContent-Type: application/json\r\nContent-Length: ${body.length}\r\n\r\n${body}`);
+  client.end();
+}
+
+// Synthetiseer Docker's eigen "No such container"-404. Gebruikt op de
+// lees-/inspect-tak voor élke container die deze devcontainer niet bezit, zodat
+// een vreemde en een niet-bestaande container niet te onderscheiden zijn (geen
+// bestaans-oracle) en tools als Aspire's DCP een nog-niet-aangemaakte persistent
+// container als afwezig zien en 'm aanmaken (#61). Body byte-lengte i.p.v.
+// string-lengte: containernamen zijn ASCII, maar zo blijft het correct als daar
+// ooit iets anders in zou vloeien.
+function denyNotFound(client: net.Socket, name: string): void {
+  const body = JSON.stringify({ message: `No such container: ${name}` });
+  client.write(`HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\nContent-Length: ${Buffer.byteLength(body)}\r\n\r\n${body}`);
   client.end();
 }
 
@@ -707,16 +764,30 @@ export async function createContainerProxy(containerName: string, socketDir: str
           // containers labeled by this devcontainer
           const inspectCt = p.match(/^\/containers\/([^/]+)\/(json|logs|top|archive|stats)$/)?.[1];
           if (inspectCt) {
-            if (devcontainerIds.has(inspectCt)) {
-              deny403(client, 'inspect of devcontainer not permitted');
-              return;
-            }
             client.pause();
-            hasOwnLabel('container', inspectCt, containerName).then(ok => {
-              if (ok) {
+            classifyContainerOwnership(inspectCt, containerName).then(ownership => {
+              if (ownership === 'own') {
                 openUpstream(Buffer.concat([Buffer.from(headerPart + '\r\n\r\n'), remainder]));
               } else {
-                deny403(client, 'container not owned by this devcontainer');
+                // Alles wat deze devcontainer NIET zelf heeft aangemaakt — een
+                // vreemde container, een peer-devcontainer, of iets dat niet
+                // bestaat — krijgt Docker's eigen 404. Zo:
+                //  1. lijkt de sandbox leeg van andermans containers: 'foreign'
+                //     en 'missing' zijn niet te onderscheiden, dus geen
+                //     bestaans-oracle waarmee je containernamen kunt aftasten;
+                //  2. behandelt Aspire's DCP een nog-niet-bestaande persistent
+                //     container als afwezig en maakt 'm aan (#61);
+                //  3. forwarden we niets door na de check → geen TOCTOU-venster
+                //     waarin een net-aangemaakte vreemde container alsnog
+                //     geïnspecteerd zou kunnen worden.
+                // Een devcontainer heeft geen huddle.parent-label en valt dus
+                // vanzelf onder 'foreign'; de expliciete devcontainer-guard is
+                // daarom overbodig op deze lees-tak (en 404 verraadt ook niet
+                // langer dát het een devcontainer is).
+                if (ownership === 'foreign') {
+                  console.warn(`[socket-proxy] denied inspect of foreign container ${inspectCt} (container: ${containerName})`);
+                }
+                denyNotFound(client, inspectCt);
               }
               client.resume();
             });

--- a/gateway/src/socket-proxy.ts
+++ b/gateway/src/socket-proxy.ts
@@ -44,10 +44,10 @@ function dockerGet(urlPath: string): Promise<any> {
   });
 }
 
-// Zoals dockerGet, maar geeft óók de HTTP-status terug. dockerGet parse't het
-// body ongeacht de status, zodat een 404 (`{"message":"No such container"}`) niet
-// van een echte 200-inspect te onderscheiden is. Voor de ownership-check moeten we
-// "bestaat niet" (404) juist wél kunnen scheiden van "bestaat, maar niet van mij".
+// Like dockerGet, but also returns the HTTP status. dockerGet parses the body
+// regardless of the status, so a 404 (`{"message":"No such container"}`) cannot
+// be told apart from a genuine 200 inspect. For the ownership check we need to
+// distinguish "does not exist" (404) from "exists, but is not mine".
 function dockerGetStatus(urlPath: string): Promise<{ status: number; data: any }> {
   return new Promise((resolve, reject) => {
     const req = http.request(
@@ -69,13 +69,13 @@ function dockerGetStatus(urlPath: string): Promise<{ status: number; data: any }
 
 export type ContainerOwnership = 'own' | 'foreign' | 'missing';
 
-// Classificeer een container-inspect-respons: van ons (huddle.parent-label komt
-// overeen), van een andere devcontainer, of niet-bestaand (404). Puur zodat de
-// beslissing zonder live Docker-socket te unit-testen valt.
+// Classify a container-inspect response: ours (huddle.parent label matches),
+// another devcontainer's, or non-existent (404). Pure so the decision can be
+// unit-tested without a live Docker socket.
 export function ownershipFromInspect(status: number, data: any, containerName: string): ContainerOwnership {
   if (status === 404) return 'missing';
-  // Onbekende/onverwachte fout of onleesbaar body → veilig als 'foreign' behandelen
-  // (weigeren), nooit per ongeluk als 'missing' doorlaten.
+  // Unknown/unexpected error or unreadable body → treat safely as 'foreign'
+  // (refuse), never accidentally let it pass as 'missing'.
   if (status >= 400 || !data || typeof data !== 'object') return 'foreign';
   const labels: Record<string, string> = data.Config?.Labels ?? {};
   return labels['huddle.parent'] === containerName ? 'own' : 'foreign';
@@ -145,8 +145,8 @@ export function withLabelFilter(rawUrl: string, label: string): string {
   return `${base}?${params.toString()}`;
 }
 
-// Statuscode uit een gebufferde HTTP-respons ("HTTP/1.1 204 …"). 0 bij een
-// onherkenbaar antwoord, zodat post-response hooks dan niets doen.
+// Status code from a buffered HTTP response ("HTTP/1.1 204 …"). 0 for an
+// unrecognizable reply, so post-response hooks then do nothing.
 export function parseHttpStatus(resp: Buffer): number {
   const m = /^HTTP\/1\.[01] (\d{3})/.exec(resp.toString('latin1', 0, 16));
   return m ? parseInt(m[1], 10) : 0;
@@ -397,13 +397,12 @@ function deny403(client: net.Socket, msg: string): void {
   client.end();
 }
 
-// Synthetiseer Docker's eigen "No such container"-404. Gebruikt op de
-// lees-/inspect-tak voor élke container die deze devcontainer niet bezit, zodat
-// een vreemde en een niet-bestaande container niet te onderscheiden zijn (geen
-// bestaans-oracle) en tools als Aspire's DCP een nog-niet-aangemaakte persistent
-// container als afwezig zien en 'm aanmaken (#61). Body byte-lengte i.p.v.
-// string-lengte: containernamen zijn ASCII, maar zo blijft het correct als daar
-// ooit iets anders in zou vloeien.
+// Synthesize Docker's own "No such container" 404. Used on the read/inspect
+// branch for every container this devcontainer does not own, so that a foreign
+// and a non-existent container are indistinguishable (no existence oracle) and
+// tools like Aspire's DCP see a not-yet-created persistent container as absent
+// and create it (#61). Body byte length instead of string length: container
+// names are ASCII, but this stays correct should anything else ever flow in.
 function denyNotFound(client: net.Socket, name: string): void {
   const body = JSON.stringify({ message: `No such container: ${name}` });
   client.write(`HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\nContent-Length: ${Buffer.byteLength(body)}\r\n\r\n${body}`);
@@ -494,14 +493,14 @@ export async function createContainerProxy(containerName: string, socketDir: str
         writeRequestConnectionClose(upstream, firstData);
       }
 
-      // Als openUpstream, maar buffert de volledige upstream-respons en stelt
-      // het terugschrijven naar de client uit tot `onDone` klaar is. Nodig voor
-      // de port-relays: DCP/Testcontainers doen direct ná een geslaagde start
-      // een inspect + connect naar de gepubliceerde poort, dus de relay moet er
-      // ZIJN voordat de start-respons de client bereikt (anders racen eerste
-      // connecties op een dynamische poort in "connection refused"). Docker's
-      // respons op start/stop/kill/remove is klein (204/304 of een JSON-fout),
-      // dus bufferen is veilig.
+      // Like openUpstream, but buffers the full upstream response and defers
+      // writing it back to the client until `onDone` has finished. Needed for
+      // the port-relays: DCP/Testcontainers inspect + connect to the published
+      // port immediately after a successful start, so the relay must EXIST
+      // before the start response reaches the client (otherwise first
+      // connections on a dynamic port race into "connection refused"). Docker's
+      // response to start/stop/kill/remove is small (204/304 or a JSON error),
+      // so buffering is safe.
       function openUpstreamBuffered(firstData: Buffer, onDone: (status: number) => Promise<void>): void {
         phase = 'tunnel';
         upstream = net.createConnection(DOCKER_SOCKET);
@@ -744,9 +743,9 @@ export async function createContainerProxy(containerName: string, socketDir: str
             if (!ok) {
               deny403(client, `cannot delete ${type} not created by this container`);
             } else if (type === 'container') {
-              // Ruim de port-relays op zodra de remove slaagde (of de container
-              // al weg bleek). Een 409 (nog draaiend, zonder force) laat de
-              // relays juist staan.
+              // Tear down the port-relays once the remove succeeded (or the
+              // container turned out to be gone already). A 409 (still running,
+              // without force) deliberately leaves the relays in place.
               openUpstreamBuffered(Buffer.concat([Buffer.from(headerPart + '\r\n\r\n'), remainder]), async (status) => {
                 if ((status > 0 && status < 400) || status === 404) await teardownContainerRelays(targetId);
               });
@@ -809,10 +808,10 @@ export async function createContainerProxy(containerName: string, socketDir: str
           // containers labeled by this devcontainer
           const inspectCt = p.match(/^\/containers\/([^/]+)\/(json|logs|top|archive|stats)$/)?.[1];
           if (inspectCt) {
-            // Fast-path: een devcontainer is per definitie nooit 'own', dus de
-            // Docker-inspect van de ownership-check kan overgeslagen worden.
-            // Exact dezelfde 404 als de langzame route hieronder, zodat het
-            // antwoord niet verraadt dát dit een (bestaande) devcontainer is.
+            // Fast-path: a devcontainer is by definition never 'own', so the
+            // ownership check's Docker inspect can be skipped. Exactly the same
+            // 404 as the slow route below, so the answer does not betray that
+            // this is an (existing) devcontainer.
             if (devcontainerIds.has(inspectCt)) {
               console.warn(`[socket-proxy] denied inspect of foreign container ${inspectCt} (container: ${containerName})`);
               denyNotFound(client, inspectCt);
@@ -823,21 +822,22 @@ export async function createContainerProxy(containerName: string, socketDir: str
               if (ownership === 'own') {
                 openUpstream(Buffer.concat([Buffer.from(headerPart + '\r\n\r\n'), remainder]));
               } else {
-                // Alles wat deze devcontainer NIET zelf heeft aangemaakt — een
-                // vreemde container, een peer-devcontainer, of iets dat niet
-                // bestaat — krijgt Docker's eigen 404. Zo:
-                //  1. lijkt de sandbox leeg van andermans containers: 'foreign'
-                //     en 'missing' zijn niet te onderscheiden, dus geen
-                //     bestaans-oracle waarmee je containernamen kunt aftasten;
-                //  2. behandelt Aspire's DCP een nog-niet-bestaande persistent
-                //     container als afwezig en maakt 'm aan (#61);
-                //  3. forwarden we niets door na de check → geen TOCTOU-venster
-                //     waarin een net-aangemaakte vreemde container alsnog
-                //     geïnspecteerd zou kunnen worden.
-                // Een devcontainer heeft geen huddle.parent-label en valt dus
-                // vanzelf onder 'foreign' — het devcontainer-fast-path hierboven
-                // is puur een optimalisatie, geen aparte security-beslissing, en
-                // de 404 verraadt niet dát het een devcontainer is.
+                // Everything this devcontainer did NOT create itself — a
+                // foreign container, a peer devcontainer, or something that
+                // does not exist — gets Docker's own 404. This way:
+                //  1. the sandbox looks empty of other people's containers:
+                //     'foreign' and 'missing' are indistinguishable, so there is
+                //     no existence oracle to probe container names with;
+                //  2. Aspire's DCP treats a not-yet-existing persistent
+                //     container as absent and creates it (#61);
+                //  3. we forward nothing after the check → no TOCTOU window in
+                //     which a just-created foreign container could still be
+                //     inspected.
+                // A devcontainer carries no huddle.parent label and thus falls
+                // under 'foreign' automatically — the devcontainer fast-path
+                // above is purely an optimization, not a separate security
+                // decision, and the 404 does not betray that it is a
+                // devcontainer.
                 if (ownership === 'foreign') {
                   console.warn(`[socket-proxy] denied inspect of foreign container ${inspectCt} (container: ${containerName})`);
                 }
@@ -928,17 +928,18 @@ export async function createContainerProxy(containerName: string, socketDir: str
               }
               const reqBuf = Buffer.concat([Buffer.from(headerPart + '\r\n\r\n'), remainder]);
               if (ctVerb === 'start' || ctVerb === 'restart') {
-                // Relays opzetten vóórdat de respons teruggaat: clients
-                // inspecteren en connecten direct na een geslaagde start.
-                // 304 (already started) telt ook — de relay kan na een
-                // gateway-herstart ontbreken terwijl de container al draait.
+                // Set up the relays before the response goes back: clients
+                // inspect and connect immediately after a successful start.
+                // 304 (already started) counts too — the relay can be missing
+                // after a gateway restart while the container is already
+                // running.
                 openUpstreamBuffered(reqBuf, async (status) => {
                   if (status > 0 && status < 400) await syncContainerRelays(containerName, ctId);
                 });
               } else if (ctVerb === 'stop' || ctVerb === 'kill') {
                 openUpstreamBuffered(reqBuf, async (status) => {
-                  // 304 = al gestopt, 404 = weg (bv. AutoRemove) — in alle
-                  // gevallen is de relay stale.
+                  // 304 = already stopped, 404 = gone (e.g. AutoRemove) — in
+                  // all cases the relay is stale.
                   if ((status > 0 && status < 400) || status === 404) await teardownContainerRelays(ctId);
                 });
               } else {

--- a/gateway/src/socket-proxy.ts
+++ b/gateway/src/socket-proxy.ts
@@ -809,6 +809,15 @@ export async function createContainerProxy(containerName: string, socketDir: str
           // containers labeled by this devcontainer
           const inspectCt = p.match(/^\/containers\/([^/]+)\/(json|logs|top|archive|stats)$/)?.[1];
           if (inspectCt) {
+            // Fast-path: een devcontainer is per definitie nooit 'own', dus de
+            // Docker-inspect van de ownership-check kan overgeslagen worden.
+            // Exact dezelfde 404 als de langzame route hieronder, zodat het
+            // antwoord niet verraadt dát dit een (bestaande) devcontainer is.
+            if (devcontainerIds.has(inspectCt)) {
+              console.warn(`[socket-proxy] denied inspect of foreign container ${inspectCt} (container: ${containerName})`);
+              denyNotFound(client, inspectCt);
+              return;
+            }
             client.pause();
             classifyContainerOwnership(inspectCt, containerName).then(ownership => {
               if (ownership === 'own') {
@@ -826,9 +835,9 @@ export async function createContainerProxy(containerName: string, socketDir: str
                 //     waarin een net-aangemaakte vreemde container alsnog
                 //     geïnspecteerd zou kunnen worden.
                 // Een devcontainer heeft geen huddle.parent-label en valt dus
-                // vanzelf onder 'foreign'; de expliciete devcontainer-guard is
-                // daarom overbodig op deze lees-tak (en 404 verraadt ook niet
-                // langer dát het een devcontainer is).
+                // vanzelf onder 'foreign' — het devcontainer-fast-path hierboven
+                // is puur een optimalisatie, geen aparte security-beslissing, en
+                // de 404 verraadt niet dát het een devcontainer is.
                 if (ownership === 'foreign') {
                   console.warn(`[socket-proxy] denied inspect of foreign container ${inspectCt} (container: ${containerName})`);
                 }

--- a/gateway/src/socket-proxy.ts
+++ b/gateway/src/socket-proxy.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import { isHostPortApproved } from './db';
 import { authorizeAction, classifyRequest, getMountPermissions, MountPermissions } from './docker-actions';
+import { syncContainerRelays, teardownContainerRelays } from './port-relay';
 
 // Default mount policy when no per-container perms are supplied (e.g. unit
 // tests): all mount kinds denied. Mirrors the secure-by-default catalog in
@@ -142,6 +143,13 @@ export function withLabelFilter(rawUrl: string, label: string): string {
   filters.label = [...(filters.label ?? []), label];
   params.set('filters', JSON.stringify(filters));
   return `${base}?${params.toString()}`;
+}
+
+// Statuscode uit een gebufferde HTTP-respons ("HTTP/1.1 204 …"). 0 bij een
+// onherkenbaar antwoord, zodat post-response hooks dan niets doen.
+export function parseHttpStatus(resp: Buffer): number {
+  const m = /^HTTP\/1\.[01] (\d{3})/.exec(resp.toString('latin1', 0, 16));
+  return m ? parseInt(m[1], 10) : 0;
 }
 
 function rewriteFirstLine(headerPart: string, newUrl: string): string {
@@ -455,6 +463,24 @@ export async function createContainerProxy(containerName: string, socketDir: str
       client.on('error', () => upstream?.destroy());
       client.on('end', () => upstream?.end());
 
+      // Force Connection: close so docker CLI cannot reuse this TCP socket
+      // for a second request — every request must reopen and re-enter our
+      // header parser (otherwise we'd tunnel subsequent requests raw and
+      // bypass /containers/json filtering).
+      function writeRequestConnectionClose(sock: net.Socket, firstData: Buffer): void {
+        const sep = firstData.indexOf('\r\n\r\n');
+        if (sep === -1) { sock.write(firstData); return; }
+        const headerStr = firstData.slice(0, sep).toString();
+        const tail = firstData.slice(sep + 4);
+        const lines = headerStr.split('\r\n');
+        const fixed = [
+          lines[0],
+          'Connection: close',
+          ...lines.slice(1).filter(l => !/^connection:\s*/i.test(l)),
+        ].join('\r\n');
+        sock.write(Buffer.concat([Buffer.from(fixed + '\r\n\r\n'), tail]));
+      }
+
       function openUpstream(firstData: Buffer): void {
         phase = 'tunnel';
         upstream = net.createConnection(DOCKER_SOCKET);
@@ -465,22 +491,34 @@ export async function createContainerProxy(containerName: string, socketDir: str
         });
         upstream.on('end', () => client.end());
         upstream.pipe(client);
+        writeRequestConnectionClose(upstream, firstData);
+      }
 
-        // Force Connection: close so docker CLI cannot reuse this TCP socket
-        // for a second request — every request must reopen and re-enter our
-        // header parser (otherwise we'd tunnel subsequent requests raw and
-        // bypass /containers/json filtering).
-        const sep = firstData.indexOf('\r\n\r\n');
-        if (sep === -1) { upstream.write(firstData); return; }
-        const headerStr = firstData.slice(0, sep).toString();
-        const tail = firstData.slice(sep + 4);
-        const lines = headerStr.split('\r\n');
-        const fixed = [
-          lines[0],
-          'Connection: close',
-          ...lines.slice(1).filter(l => !/^connection:\s*/i.test(l)),
-        ].join('\r\n');
-        upstream.write(Buffer.concat([Buffer.from(fixed + '\r\n\r\n'), tail]));
+      // Als openUpstream, maar buffert de volledige upstream-respons en stelt
+      // het terugschrijven naar de client uit tot `onDone` klaar is. Nodig voor
+      // de port-relays: DCP/Testcontainers doen direct ná een geslaagde start
+      // een inspect + connect naar de gepubliceerde poort, dus de relay moet er
+      // ZIJN voordat de start-respons de client bereikt (anders racen eerste
+      // connecties op een dynamische poort in "connection refused"). Docker's
+      // respons op start/stop/kill/remove is klein (204/304 of een JSON-fout),
+      // dus bufferen is veilig.
+      function openUpstreamBuffered(firstData: Buffer, onDone: (status: number) => Promise<void>): void {
+        phase = 'tunnel';
+        upstream = net.createConnection(DOCKER_SOCKET);
+        const chunks: Buffer[] = [];
+        upstream.on('error', (err) => {
+          if ((err as NodeJS.ErrnoException).code !== 'ECONNRESET')
+            console.error(`[socket-proxy] upstream error for ${containerName}:`, err.message);
+          client.destroy();
+        });
+        upstream.on('data', (d: Buffer) => { chunks.push(d); });
+        upstream.on('end', () => {
+          const resp = Buffer.concat(chunks);
+          onDone(parseHttpStatus(resp))
+            .catch((err: any) => console.warn(`[socket-proxy] post-response hook failed for ${containerName}:`, err?.message ?? err))
+            .then(() => { client.write(resp); client.end(); });
+        });
+        writeRequestConnectionClose(upstream, firstData);
       }
 
       function forwardWithRewrittenUrl(headerPart: string, newUrl: string, remainder: Buffer): void {
@@ -703,10 +741,17 @@ export async function createContainerProxy(containerName: string, socketDir: str
 
           client.pause();
           hasOwnLabel(type, targetId, containerName).then(ok => {
-            if (ok) {
-              openUpstream(Buffer.concat([Buffer.from(headerPart + '\r\n\r\n'), remainder]));
-            } else {
+            if (!ok) {
               deny403(client, `cannot delete ${type} not created by this container`);
+            } else if (type === 'container') {
+              // Ruim de port-relays op zodra de remove slaagde (of de container
+              // al weg bleek). Een 409 (nog draaiend, zonder force) laat de
+              // relays juist staan.
+              openUpstreamBuffered(Buffer.concat([Buffer.from(headerPart + '\r\n\r\n'), remainder]), async (status) => {
+                if ((status > 0 && status < 400) || status === 404) await teardownContainerRelays(targetId);
+              });
+            } else {
+              openUpstream(Buffer.concat([Buffer.from(headerPart + '\r\n\r\n'), remainder]));
             }
             client.resume();
           });
@@ -857,18 +902,38 @@ export async function createContainerProxy(containerName: string, socketDir: str
           }
 
           // Container management: only for own spawned containers, never devcontainers
-          const ctId = p.match(/^\/containers\/([^/]+)\/(exec|start|stop|restart|kill|wait|update)$/)?.[1];
+          const ctVerbMatch = p.match(/^\/containers\/([^/]+)\/(exec|start|stop|restart|kill|wait|update)$/);
+          const ctId = ctVerbMatch?.[1];
           if (ctId) {
+            const ctVerb = ctVerbMatch![2];
             if (devcontainerIds.has(ctId)) {
               deny403(client, 'operation on devcontainer not permitted');
               return;
             }
             client.pause();
             hasOwnLabel('container', ctId, containerName).then(ok => {
-              if (ok) {
-                openUpstream(Buffer.concat([Buffer.from(headerPart + '\r\n\r\n'), remainder]));
-              } else {
+              if (!ok) {
                 deny403(client, 'container was not created by this devcontainer');
+                client.resume();
+                return;
+              }
+              const reqBuf = Buffer.concat([Buffer.from(headerPart + '\r\n\r\n'), remainder]);
+              if (ctVerb === 'start' || ctVerb === 'restart') {
+                // Relays opzetten vóórdat de respons teruggaat: clients
+                // inspecteren en connecten direct na een geslaagde start.
+                // 304 (already started) telt ook — de relay kan na een
+                // gateway-herstart ontbreken terwijl de container al draait.
+                openUpstreamBuffered(reqBuf, async (status) => {
+                  if (status > 0 && status < 400) await syncContainerRelays(containerName, ctId);
+                });
+              } else if (ctVerb === 'stop' || ctVerb === 'kill') {
+                openUpstreamBuffered(reqBuf, async (status) => {
+                  // 304 = al gestopt, 404 = weg (bv. AutoRemove) — in alle
+                  // gevallen is de relay stale.
+                  if ((status > 0 && status < 400) || status === 404) await teardownContainerRelays(ctId);
+                });
+              } else {
+                openUpstream(reqBuf);
               }
               client.resume();
             });

--- a/gateway/test/container-ownership.test.ts
+++ b/gateway/test/container-ownership.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// socket-proxy importeert db.ts alleen voor de grant-checks; mocken houdt de
+// native better-sqlite3-binding buiten deze test (die ontbreekt in een verse
+// DMZ-devcontainer, zie rules.test.ts / grants.test.ts). ownershipFromInspect is
+// puur en raakt de db niet.
+vi.mock('../src/db', () => ({
+  getGrant: () => null,
+  isHostPortApproved: () => false,
+}));
+
+const { ownershipFromInspect } = await import('../src/socket-proxy');
+
+// ── Container-ownership classificatie (issue #61) ────────────────────────────
+// De inspect-policy classificeert een container als 'own', 'foreign' of
+// 'missing'. Alleen 'own' wordt naar Docker doorgezet; 'foreign' én 'missing'
+// krijgen beide een gesynthetiseerde 404 (zie de inspect-tak in socket-proxy.ts).
+// Dat 'foreign' óók een 404 geeft is bewust: zo is een vreemde container niet van
+// een niet-bestaande te onderscheiden (geen bestaans-oracle) en ziet Aspire's DCP
+// een nog-niet-aangemaakte persistent container als afwezig → maakt 'm aan. Het
+// onderscheid 'foreign' vs 'missing' blijft bestaan zodat een probe op een écht
+// bestaande vreemde container als verdacht gelogd kan worden. Deze pure functie
+// is het beslispunt.
+describe('ownershipFromInspect', () => {
+  const own = { Config: { Labels: { 'huddle.parent': 'dc-a' } } };
+
+  it('markeert een eigen container als "own"', () => {
+    expect(ownershipFromInspect(200, own, 'dc-a')).toBe('own');
+  });
+
+  it('markeert een container van een andere devcontainer als "foreign"', () => {
+    expect(ownershipFromInspect(200, own, 'dc-b')).toBe('foreign');
+  });
+
+  it('markeert een ongelabelde container als "foreign"', () => {
+    expect(ownershipFromInspect(200, { Config: { Labels: {} } }, 'dc-a')).toBe('foreign');
+    expect(ownershipFromInspect(200, { Config: {} }, 'dc-a')).toBe('foreign');
+  });
+
+  it('markeert een 404 (No such container) als "missing"', () => {
+    // Dít is de kern van issue #61: een niet-bestaande container mag geen 403
+    // "not owned" opleveren, maar als "missing" worden doorgelaten zodat Docker
+    // z'n eigen 404 teruggeeft en DCP de persistent container alsnog aanmaakt.
+    expect(ownershipFromInspect(404, { message: 'No such container: sqlserver-x' }, 'dc-a')).toBe('missing');
+  });
+
+  it('behandelt een onverwachte fout (5xx) veilig als "foreign", niet als "missing"', () => {
+    expect(ownershipFromInspect(500, { message: 'boom' }, 'dc-a')).toBe('foreign');
+    expect(ownershipFromInspect(500, null, 'dc-a')).toBe('foreign');
+  });
+
+  it('behandelt onleesbaar/leeg body op een 200 veilig als "foreign"', () => {
+    expect(ownershipFromInspect(200, null, 'dc-a')).toBe('foreign');
+  });
+});

--- a/gateway/test/container-ownership.test.ts
+++ b/gateway/test/container-ownership.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
 
-// socket-proxy importeert db.ts alleen voor de grant-checks; mocken houdt de
-// native better-sqlite3-binding buiten deze test (die ontbreekt in een verse
-// DMZ-devcontainer, zie rules.test.ts / grants.test.ts). ownershipFromInspect is
-// puur en raakt de db niet.
+// socket-proxy imports db.ts only for the grant checks; mocking it keeps the
+// native better-sqlite3 binding out of this test (it is absent in a fresh
+// DMZ devcontainer, see rules.test.ts / grants.test.ts). ownershipFromInspect
+// is pure and never touches the db.
 vi.mock('../src/db', () => ({
   getGrant: () => null,
   isHostPortApproved: () => false,
@@ -11,45 +11,45 @@ vi.mock('../src/db', () => ({
 
 const { ownershipFromInspect } = await import('../src/socket-proxy');
 
-// ── Container-ownership classificatie (issue #61) ────────────────────────────
-// De inspect-policy classificeert een container als 'own', 'foreign' of
-// 'missing'. Alleen 'own' wordt naar Docker doorgezet; 'foreign' én 'missing'
-// krijgen beide een gesynthetiseerde 404 (zie de inspect-tak in socket-proxy.ts).
-// Dat 'foreign' óók een 404 geeft is bewust: zo is een vreemde container niet van
-// een niet-bestaande te onderscheiden (geen bestaans-oracle) en ziet Aspire's DCP
-// een nog-niet-aangemaakte persistent container als afwezig → maakt 'm aan. Het
-// onderscheid 'foreign' vs 'missing' blijft bestaan zodat een probe op een écht
-// bestaande vreemde container als verdacht gelogd kan worden. Deze pure functie
-// is het beslispunt.
+// ── Container-ownership classification (issue #61) ───────────────────────────
+// The inspect policy classifies a container as 'own', 'foreign' or 'missing'.
+// Only 'own' is passed through to Docker; 'foreign' and 'missing' both get a
+// synthesized 404 (see the inspect branch in socket-proxy.ts). That 'foreign'
+// also yields a 404 is deliberate: it makes a foreign container
+// indistinguishable from a nonexistent one (no existence oracle), and Aspire's
+// DCP sees a not-yet-created persistent container as absent → creates it. The
+// distinction 'foreign' vs 'missing' is kept so a probe against a genuinely
+// existing foreign container can be logged as suspicious. This pure function
+// is the decision point.
 describe('ownershipFromInspect', () => {
   const own = { Config: { Labels: { 'huddle.parent': 'dc-a' } } };
 
-  it('markeert een eigen container als "own"', () => {
+  it('classifies our own container as "own"', () => {
     expect(ownershipFromInspect(200, own, 'dc-a')).toBe('own');
   });
 
-  it('markeert een container van een andere devcontainer als "foreign"', () => {
+  it('classifies a container of another devcontainer as "foreign"', () => {
     expect(ownershipFromInspect(200, own, 'dc-b')).toBe('foreign');
   });
 
-  it('markeert een ongelabelde container als "foreign"', () => {
+  it('classifies an unlabeled container as "foreign"', () => {
     expect(ownershipFromInspect(200, { Config: { Labels: {} } }, 'dc-a')).toBe('foreign');
     expect(ownershipFromInspect(200, { Config: {} }, 'dc-a')).toBe('foreign');
   });
 
-  it('markeert een 404 (No such container) als "missing"', () => {
-    // Dít is de kern van issue #61: een niet-bestaande container mag geen 403
-    // "not owned" opleveren, maar als "missing" worden doorgelaten zodat Docker
-    // z'n eigen 404 teruggeeft en DCP de persistent container alsnog aanmaakt.
+  it('classifies a 404 (No such container) as "missing"', () => {
+    // THIS is the core of issue #61: a nonexistent container must not yield a
+    // 403 "not owned" but be passed through as "missing", so Docker returns
+    // its own 404 and DCP still creates the persistent container.
     expect(ownershipFromInspect(404, { message: 'No such container: sqlserver-x' }, 'dc-a')).toBe('missing');
   });
 
-  it('behandelt een onverwachte fout (5xx) veilig als "foreign", niet als "missing"', () => {
+  it('safely treats an unexpected error (5xx) as "foreign", not "missing"', () => {
     expect(ownershipFromInspect(500, { message: 'boom' }, 'dc-a')).toBe('foreign');
     expect(ownershipFromInspect(500, null, 'dc-a')).toBe('foreign');
   });
 
-  it('behandelt onleesbaar/leeg body op een 200 veilig als "foreign"', () => {
+  it('safely treats an unreadable/empty body on a 200 as "foreign"', () => {
     expect(ownershipFromInspect(200, null, 'dc-a')).toBe('foreign');
   });
 });

--- a/gateway/test/e2e/README.md
+++ b/gateway/test/e2e/README.md
@@ -47,6 +47,6 @@ The suite cleans up the container + test rules afterwards (`afterAll`).
 | mutation with toggle and grant → exit 0 | timer + toggle opens mutations; own-volume delete proves label injection |
 | `-v /:/host` → `not permitted` (T11) | HostConfig escape (host-path bind) rejected |
 | `--privileged` → `not permitted` (T11) | privileged spawn rejected |
-| `docker inspect huddle` → rejected (T3) | inspecting a foreign container rejected |
+| `docker inspect huddle` → "No such object" (T3) | a foreign container reads as absent (synthesized 404, no existence oracle) |
 | `GET huddle:3000/api/rules` → 403 (T4) | management API unreachable from the container |
 | `POST huddle:3000/api/audit/sudo` → 200 (T5) | sudo-audit ingest is reachable |

--- a/gateway/test/e2e/boundary.e2e.ts
+++ b/gateway/test/e2e/boundary.e2e.ts
@@ -142,10 +142,29 @@ describe.skipIf(!E2E_ENABLED)('live security boundary', () => {
         expect(`${r.stdout}${r.stderr}`).toMatch(/privileged.*not permitted/i);
       });
 
-      it('weigert inspect van een vreemde container (huddle)', async () => {
-        const r = execIn(E2E_NAME, 'docker inspect huddle');
+      // Sinds #61 leest een vreemde container als afwezig (gesynthetiseerde
+      // 404) in plaats van een 403 "not owned": 'foreign' en 'missing' zijn
+      // bewust niet te onderscheiden (geen bestaans-oracle). `--type container`
+      // voorkomt dat de CLI na de 404 terugvalt op image-inspect — dat pad
+      // heeft z'n eigen actietoggle en is hier niet wat we testen.
+      it('vreemde container (huddle) leest als niet-bestaand', async () => {
+        const r = execIn(E2E_NAME, 'docker inspect --type container huddle');
         expect(r.status).not.toBe(0);
-        expect(`${r.stdout}${r.stderr}`).toMatch(/not owned|not permitted/i);
+        const out = `${r.stdout}${r.stderr}`;
+        expect(out).toMatch(/no such container/i);
+        // Het antwoord mag niet verraden dát de container bestaat.
+        expect(out).not.toMatch(/not owned|not permitted/i);
+      });
+
+      // Zelfde 404, maar dan via het devcontainer-fast-path (de naam staat in
+      // devcontainerIds, dus de proxy antwoordt zonder Docker-round-trip). Het
+      // antwoord moet identiek zijn aan de trage route hierboven.
+      it('devcontainer zelf leest óók als niet-bestaand (fast-path)', async () => {
+        const r = execIn(E2E_NAME, `docker inspect --type container ${E2E_NAME}`);
+        expect(r.status).not.toBe(0);
+        const out = `${r.stdout}${r.stderr}`;
+        expect(out).toMatch(/no such container/i);
+        expect(out).not.toMatch(/not owned|not permitted/i);
       });
 
       // Finding #1 (CRITICAL) — VolumesFrom erft huddle's echte docker.sock +

--- a/gateway/test/e2e/boundary.e2e.ts
+++ b/gateway/test/e2e/boundary.e2e.ts
@@ -142,24 +142,24 @@ describe.skipIf(!E2E_ENABLED)('live security boundary', () => {
         expect(`${r.stdout}${r.stderr}`).toMatch(/privileged.*not permitted/i);
       });
 
-      // Sinds #61 leest een vreemde container als afwezig (gesynthetiseerde
-      // 404) in plaats van een 403 "not owned": 'foreign' en 'missing' zijn
-      // bewust niet te onderscheiden (geen bestaans-oracle). `--type container`
-      // voorkomt dat de CLI na de 404 terugvalt op image-inspect — dat pad
-      // heeft z'n eigen actietoggle en is hier niet wat we testen.
-      it('vreemde container (huddle) leest als niet-bestaand', async () => {
+      // Since #61 a foreign container reads as absent (synthesized 404)
+      // instead of a 403 "not owned": 'foreign' and 'missing' are deliberately
+      // indistinguishable (no existence oracle). `--type container` prevents
+      // the CLI from falling back to image-inspect after the 404 — that path
+      // has its own action toggle and is not what we test here.
+      it('foreign container (huddle) reads as non-existent', async () => {
         const r = execIn(E2E_NAME, 'docker inspect --type container huddle');
         expect(r.status).not.toBe(0);
         const out = `${r.stdout}${r.stderr}`;
         expect(out).toMatch(/no such container/i);
-        // Het antwoord mag niet verraden dát de container bestaat.
+        // The answer must not betray that the container exists.
         expect(out).not.toMatch(/not owned|not permitted/i);
       });
 
-      // Zelfde 404, maar dan via het devcontainer-fast-path (de naam staat in
-      // devcontainerIds, dus de proxy antwoordt zonder Docker-round-trip). Het
-      // antwoord moet identiek zijn aan de trage route hierboven.
-      it('devcontainer zelf leest óók als niet-bestaand (fast-path)', async () => {
+      // Same 404, but via the devcontainer fast-path (the name is in
+      // devcontainerIds, so the proxy answers without a Docker round-trip).
+      // The answer must be identical to the slow route above.
+      it('the devcontainer itself also reads as non-existent (fast-path)', async () => {
         const r = execIn(E2E_NAME, `docker inspect --type container ${E2E_NAME}`);
         expect(r.status).not.toBe(0);
         const out = `${r.stdout}${r.stderr}`;

--- a/gateway/test/port-relay.test.ts
+++ b/gateway/test/port-relay.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi } from 'vitest';
+import net from 'net';
+import type { AddressInfo } from 'net';
+import { EventEmitter } from 'events';
+
+// socket-proxy importeert db.ts alleen voor de grant-checks; mocken houdt de
+// native better-sqlite3-binding buiten deze test (zie container-ownership.test.ts).
+vi.mock('../src/db', () => ({
+  getGrant: () => null,
+  isHostPortApproved: () => false,
+}));
+
+const {
+  extractRelaySpecs, resolveTarget, buildForwarderSetupScript,
+  createNetworkRefTracker, ipInSubnet, dialWithTimeout,
+} = await import('../src/port-relay');
+const { parseHttpStatus } = await import('../src/socket-proxy');
+
+// ── Relay-specs uit een container-inspect ────────────────────────────────────
+// De relay spiegelt de poorten die de docker-daemon op de HOST bond naar de
+// loopback van de devcontainer. Bron is NetworkSettings.Ports ná start, zodat
+// ook dynamisch toegewezen poorten (HostPort:0 in de create) meegenomen worden.
+describe('extractRelaySpecs', () => {
+  it('leest een gepubliceerde tcp-binding uit', () => {
+    const inspect = {
+      NetworkSettings: {
+        Ports: { '1433/tcp': [{ HostIp: '127.0.0.1', HostPort: '32769' }] },
+      },
+    };
+    expect(extractRelaySpecs(inspect)).toEqual([{ hostPort: 32769, containerPort: 1433, proto: 'tcp' }]);
+  });
+
+  it('voegt dubbele v4/v6-bindings van dezelfde hostpoort samen', () => {
+    const inspect = {
+      NetworkSettings: {
+        Ports: {
+          '80/tcp': [
+            { HostIp: '0.0.0.0', HostPort: '8080' },
+            { HostIp: '::', HostPort: '8080' },
+          ],
+        },
+      },
+    };
+    expect(extractRelaySpecs(inspect)).toEqual([{ hostPort: 8080, containerPort: 80, proto: 'tcp' }]);
+  });
+
+  it('slaat niet-gepubliceerde (null) poorten over', () => {
+    const inspect = { NetworkSettings: { Ports: { '1433/tcp': null } } };
+    expect(extractRelaySpecs(inspect)).toEqual([]);
+  });
+
+  it('slaat bindings zonder bruikbare HostPort over', () => {
+    const inspect = {
+      NetworkSettings: {
+        Ports: { '1433/tcp': [{ HostIp: '', HostPort: '' }, { HostPort: '0' }] },
+      },
+    };
+    expect(extractRelaySpecs(inspect)).toEqual([]);
+  });
+
+  it('geeft udp-bindings terug mét proto zodat de caller ze kan loggen', () => {
+    const inspect = {
+      NetworkSettings: {
+        Ports: { '53/udp': [{ HostIp: '0.0.0.0', HostPort: '5353' }] },
+      },
+    };
+    expect(extractRelaySpecs(inspect)).toEqual([{ hostPort: 5353, containerPort: 53, proto: 'udp' }]);
+  });
+
+  it('verdraagt een inspect zonder poortsectie', () => {
+    expect(extractRelaySpecs({})).toEqual([]);
+    expect(extractRelaySpecs(null)).toEqual([]);
+    expect(extractRelaySpecs({ NetworkSettings: {} })).toEqual([]);
+  });
+});
+
+// ── Doel (netwerk + IP) van de workload-container ────────────────────────────
+// De gateway bereikt de workload via het dc-net van de eigenaar als dat kan;
+// leeft de workload alleen op een eigen netwerk (Aspire session-net), dan komt
+// dát netwerk terug zodat de caller de gateway er eerst aan koppelt — tussen
+// niet-gedeelde bridges DROP't Docker SYN's geluidloos.
+describe('resolveTarget', () => {
+  it('kiest het dc-net van de eigenaar als de workload daarop zit', () => {
+    const inspect = {
+      NetworkSettings: {
+        Networks: {
+          'ander-net': { IPAddress: '10.0.0.2' },
+          'dc-net-dc-a': { IPAddress: '192.168.16.2' },
+        },
+      },
+    };
+    expect(resolveTarget(inspect, 'dc-a')).toEqual({ ip: '192.168.16.2', network: 'dc-net-dc-a' });
+  });
+
+  it('geeft anders het workload-netwerk terug (join vereist)', () => {
+    const inspect = {
+      NetworkSettings: { Networks: { 'aspire-session-net': { IPAddress: '10.0.0.2' } } },
+    };
+    expect(resolveTarget(inspect, 'dc-a')).toEqual({ ip: '10.0.0.2', network: 'aspire-session-net' });
+  });
+
+  it('geeft null zonder bruikbaar netwerk', () => {
+    expect(resolveTarget({}, 'dc-a')).toBeNull();
+    expect(resolveTarget({ NetworkSettings: { Networks: { x: { IPAddress: '' } } } }, 'dc-a')).toBeNull();
+  });
+});
+
+// ── Forwarder-setupscript ────────────────────────────────────────────────────
+describe('buildForwarderSetupScript', () => {
+  const script = buildForwarderSetupScript();
+
+  it('installeert de forwarder en maakt host.docker.internal loopback', () => {
+    expect(script).toContain('/usr/local/lib/huddle-port-forwarder.js');
+    expect(script).toContain("echo '127.0.0.1 host.docker.internal' >> /etc/hosts");
+  });
+
+  it('levert de forwarder als geldige base64 met de loopback-listeners', () => {
+    const b64 = script.match(/echo '([A-Za-z0-9+/=]+)' \| base64 -d/)?.[1] ?? '';
+    const js = Buffer.from(b64, 'base64').toString('utf8');
+    expect(js).toContain('/var/run/huddle/ports');
+    expect(js).toContain("'127.0.0.1'");
+    expect(js).toContain("'::1'");
+    // De ready-/err-bestanden zijn het handshake-kanaal met de gateway
+    // (waitForForwarderReady); zonder die markers racet een dynamic-port start.
+    expect(js).toContain(".ready'");
+    expect(js).toContain(".err'");
+  });
+
+  it('is idempotent: herstart alleen bij een gewijzigd script of dode pid', () => {
+    expect(script).toContain('cmp -s');
+    expect(script).toContain('kill -0');
+  });
+});
+
+// ── Netwerk-join + refcount ──────────────────────────────────────────────────
+// De gateway joint workload-netwerken on demand en moet zich weer loskoppelen
+// zodra de laatste relay op dat netwerk verdwijnt — anders blokkeert hij
+// `docker network rm` bij Aspire's cleanup. Netwerken waar hij al aan hing
+// (already-connected) en permanente (dc-net-*) worden nooit losgekoppeld.
+describe('createNetworkRefTracker', () => {
+  function fakeOps(connectResult: () => 'connected' | 'already-connected' | 'missing' | 'error') {
+    const calls = { connect: 0, disconnect: 0 };
+    const ops = {
+      connect: async () => { calls.connect++; return connectResult(); },
+      disconnect: async () => { calls.disconnect++; },
+      subnets: async () => ['10.10.0.0/24'],
+    };
+    return { ops, calls };
+  }
+
+  it('verse join: connect één keer, disconnect pas bij de laatste release', async () => {
+    const { ops, calls } = fakeOps(() => 'connected' as const);
+    const t = createNetworkRefTracker(ops);
+    expect(await t.acquire('net-a', 'ct-1')).toBe(true);
+    expect(await t.acquire('net-a', 'ct-2')).toBe(true);
+    expect(calls.connect).toBe(1); // tweede acquire is puur een refcount
+    await t.release('net-a', 'ct-1');
+    expect(calls.disconnect).toBe(0); // ct-2 houdt het netwerk nog vast
+    expect(t.isJoined('net-a')).toBe(true);
+    await t.release('net-a', 'ct-2');
+    expect(calls.disconnect).toBe(1);
+    expect(t.isJoined('net-a')).toBe(false);
+  });
+
+  it('already-connected: succes, maar nooit een disconnect (membership was niet van ons)', async () => {
+    const { ops, calls } = fakeOps(() => 'already-connected' as const);
+    const t = createNetworkRefTracker(ops);
+    expect(await t.acquire('net-a', 'ct-1')).toBe(true);
+    await t.release('net-a', 'ct-1');
+    expect(calls.disconnect).toBe(0);
+  });
+
+  it('verdwenen netwerk: acquire faalt zonder te registreren', async () => {
+    const { ops } = fakeOps(() => 'missing' as const);
+    const t = createNetworkRefTracker(ops);
+    expect(await t.acquire('net-gone', 'ct-1')).toBe(false);
+    expect(t.isJoined('net-gone')).toBe(false);
+  });
+
+  it('permanente netwerken (dc-net-*) worden nooit losgekoppeld', async () => {
+    const { ops, calls } = fakeOps(() => 'connected' as const);
+    const t = createNetworkRefTracker(ops);
+    await t.acquire('dc-net-dc-a', 'ct-1');
+    await t.release('dc-net-dc-a', 'ct-1');
+    expect(calls.disconnect).toBe(0);
+  });
+
+  it('isJoinedNetworkIp matcht alleen subnetten van door óns gejoinde netwerken', async () => {
+    const { ops } = fakeOps(() => 'connected' as const);
+    const t = createNetworkRefTracker(ops);
+    await t.acquire('net-a', 'ct-1');
+    expect(t.isJoinedNetworkIp('10.10.0.7')).toBe(true);
+    expect(t.isJoinedNetworkIp('::ffff:10.10.0.7')).toBe(true);
+    expect(t.isJoinedNetworkIp('10.11.0.7')).toBe(false);
+
+    // already-connected (pre-existing membership, bv. het default-net) mag de
+    // :3000-guard níet triggeren.
+    const pre = fakeOps(() => 'already-connected' as const);
+    const t2 = createNetworkRefTracker(pre.ops);
+    await t2.acquire('net-b', 'ct-1');
+    expect(t2.isJoinedNetworkIp('10.10.0.7')).toBe(false);
+  });
+});
+
+describe('ipInSubnet', () => {
+  it('matcht IPv4 CIDR-grenzen correct', () => {
+    expect(ipInSubnet('192.168.16.2', '192.168.16.0/20')).toBe(true);
+    expect(ipInSubnet('192.168.31.255', '192.168.16.0/20')).toBe(true);
+    expect(ipInSubnet('192.168.32.1', '192.168.16.0/20')).toBe(false);
+    expect(ipInSubnet('::ffff:192.168.16.2', '192.168.16.0/20')).toBe(true);
+  });
+
+  it('matcht conservatief niet op onbruikbare invoer (IPv6, rommel)', () => {
+    expect(ipInSubnet('fd00::2', 'fd00::/64')).toBe(false);
+    expect(ipInSubnet('not-an-ip', '10.0.0.0/8')).toBe(false);
+    expect(ipInSubnet('10.0.0.1', 'garbage')).toBe(false);
+  });
+});
+
+// ── Backend-dial met timeout ─────────────────────────────────────────────────
+// Docker's inter-bridge-isolatie dropt SYN's zonder RST: zonder harde timeout
+// hangt een relay-client voor eeuwig op accept-zonder-bytes.
+describe('dialWithTimeout', () => {
+  it('verbindt naar een luisterende poort', async () => {
+    const srv = net.createServer(c => c.end());
+    await new Promise<void>((res) => srv.listen(0, '127.0.0.1', () => res()));
+    const port = (srv.address() as AddressInfo).port;
+    const sock = await dialWithTimeout('127.0.0.1', port, 1000);
+    sock.destroy();
+    srv.close();
+  });
+
+  it('reject (geen hang) op een gesloten poort', async () => {
+    // Poort reserveren en weer sluiten → gegarandeerd dicht.
+    const srv = net.createServer();
+    await new Promise<void>((res) => srv.listen(0, '127.0.0.1', () => res()));
+    const port = (srv.address() as AddressInfo).port;
+    await new Promise<void>((res) => srv.close(() => res()));
+    await expect(dialWithTimeout('127.0.0.1', port, 1000)).rejects.toThrow();
+  });
+
+  it('timeout: een dial die nooit connect geeft reject + destroy (het inter-bridge-DROP-scenario)', async () => {
+    // Gemockte socket die nooit 'connect' emit — deterministisch equivalent van
+    // Docker's stille SYN-drop tussen bridges (een echt blackhole-adres is in
+    // een sandbox/CI-netwerk niet betrouwbaar).
+    const fake = new EventEmitter() as any;
+    fake.destroy = vi.fn();
+    const spy = vi.spyOn(net, 'createConnection').mockReturnValue(fake);
+    try {
+      await expect(dialWithTimeout('10.255.0.1', 1433, 50)).rejects.toThrow(/timeout/);
+      expect(fake.destroy).toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+// ── HTTP-statusparser voor gebufferde responsen ──────────────────────────────
+// openUpstreamBuffered (socket-proxy.ts) beslist op deze status of relays
+// opgezet/afgebroken worden voordat de respons naar de client teruggaat.
+describe('parseHttpStatus', () => {
+  it('leest de statuscode uit een HTTP/1.1-respons', () => {
+    expect(parseHttpStatus(Buffer.from('HTTP/1.1 204 No Content\r\n\r\n'))).toBe(204);
+    expect(parseHttpStatus(Buffer.from('HTTP/1.0 404 Not Found\r\n\r\n'))).toBe(404);
+  });
+
+  it('geeft 0 voor een onherkenbaar antwoord', () => {
+    expect(parseHttpStatus(Buffer.from(''))).toBe(0);
+    expect(parseHttpStatus(Buffer.from('garbage'))).toBe(0);
+  });
+});

--- a/gateway/test/port-relay.test.ts
+++ b/gateway/test/port-relay.test.ts
@@ -13,6 +13,7 @@ vi.mock('../src/db', () => ({
 const {
   extractRelaySpecs, resolveTarget, buildForwarderSetupScript,
   createNetworkRefTracker, ipInSubnet, dialWithTimeout,
+  assertSafeOwner, syncContainerRelays, ensurePortForwarder,
 } = await import('../src/port-relay');
 const { parseHttpStatus } = await import('../src/socket-proxy');
 
@@ -267,5 +268,29 @@ describe('parseHttpStatus', () => {
   it('geeft 0 voor een onherkenbaar antwoord', () => {
     expect(parseHttpStatus(Buffer.from(''))).toBe(0);
     expect(parseHttpStatus(Buffer.from('garbage'))).toBe(0);
+  });
+});
+
+// ── Owner-naamguard op de relay-entry-points ─────────────────────────────────
+// `owner` vloeit in path.join() onder de gedeelde sockets-directory. Dezelfde
+// Docker-naamgrammatica als assertSafeContainerName (socket-proxy.ts): een
+// traversal-naam mag nooit tot een pad buiten die directory leiden — ook niet
+// via de operator-API (`/api/docker/containers/:name/start`).
+describe('assertSafeOwner', () => {
+  it('accepteert geldige Docker-containernamen', () => {
+    for (const ok of ['devcontainer-aspire', 'a', 'A1_b.c-d']) {
+      expect(() => assertSafeOwner(ok)).not.toThrow();
+    }
+  });
+
+  it('weigert traversal- en niet-grammatica-namen', () => {
+    for (const bad of ['../evil', 'a/b', '.hidden', '', '..', 'a b']) {
+      expect(() => assertSafeOwner(bad)).toThrow(/unsafe owner name/);
+    }
+  });
+
+  it('vuurt vóór alle I/O op beide publieke entry points', async () => {
+    await expect(syncContainerRelays('../evil', 'x')).rejects.toThrow(/unsafe owner name/);
+    await expect(ensurePortForwarder('../evil')).rejects.toThrow(/unsafe owner name/);
   });
 });

--- a/gateway/test/port-relay.test.ts
+++ b/gateway/test/port-relay.test.ts
@@ -3,8 +3,8 @@ import net from 'net';
 import type { AddressInfo } from 'net';
 import { EventEmitter } from 'events';
 
-// socket-proxy importeert db.ts alleen voor de grant-checks; mocken houdt de
-// native better-sqlite3-binding buiten deze test (zie container-ownership.test.ts).
+// socket-proxy imports db.ts only for the grant checks; mocking it keeps the
+// native better-sqlite3 binding out of this test (see container-ownership.test.ts).
 vi.mock('../src/db', () => ({
   getGrant: () => null,
   isHostPortApproved: () => false,
@@ -17,12 +17,12 @@ const {
 } = await import('../src/port-relay');
 const { parseHttpStatus } = await import('../src/socket-proxy');
 
-// ── Relay-specs uit een container-inspect ────────────────────────────────────
-// De relay spiegelt de poorten die de docker-daemon op de HOST bond naar de
-// loopback van de devcontainer. Bron is NetworkSettings.Ports ná start, zodat
-// ook dynamisch toegewezen poorten (HostPort:0 in de create) meegenomen worden.
+// ── Relay specs from a container inspect ─────────────────────────────────────
+// The relay mirrors the ports the docker daemon bound on the HOST into the
+// devcontainer's loopback. The source is NetworkSettings.Ports after start, so
+// that dynamically assigned ports (HostPort:0 in the create) are picked up too.
 describe('extractRelaySpecs', () => {
-  it('leest een gepubliceerde tcp-binding uit', () => {
+  it('extracts a published tcp binding', () => {
     const inspect = {
       NetworkSettings: {
         Ports: { '1433/tcp': [{ HostIp: '127.0.0.1', HostPort: '32769' }] },
@@ -31,7 +31,7 @@ describe('extractRelaySpecs', () => {
     expect(extractRelaySpecs(inspect)).toEqual([{ hostPort: 32769, containerPort: 1433, proto: 'tcp' }]);
   });
 
-  it('voegt dubbele v4/v6-bindings van dezelfde hostpoort samen', () => {
+  it('deduplicates v4/v6 bindings of the same host port', () => {
     const inspect = {
       NetworkSettings: {
         Ports: {
@@ -45,12 +45,12 @@ describe('extractRelaySpecs', () => {
     expect(extractRelaySpecs(inspect)).toEqual([{ hostPort: 8080, containerPort: 80, proto: 'tcp' }]);
   });
 
-  it('slaat niet-gepubliceerde (null) poorten over', () => {
+  it('skips unpublished (null) ports', () => {
     const inspect = { NetworkSettings: { Ports: { '1433/tcp': null } } };
     expect(extractRelaySpecs(inspect)).toEqual([]);
   });
 
-  it('slaat bindings zonder bruikbare HostPort over', () => {
+  it('skips bindings without a usable HostPort', () => {
     const inspect = {
       NetworkSettings: {
         Ports: { '1433/tcp': [{ HostIp: '', HostPort: '' }, { HostPort: '0' }] },
@@ -59,7 +59,7 @@ describe('extractRelaySpecs', () => {
     expect(extractRelaySpecs(inspect)).toEqual([]);
   });
 
-  it('geeft udp-bindings terug mét proto zodat de caller ze kan loggen', () => {
+  it('returns udp bindings with their proto so the caller can log them', () => {
     const inspect = {
       NetworkSettings: {
         Ports: { '53/udp': [{ HostIp: '0.0.0.0', HostPort: '5353' }] },
@@ -68,20 +68,20 @@ describe('extractRelaySpecs', () => {
     expect(extractRelaySpecs(inspect)).toEqual([{ hostPort: 5353, containerPort: 53, proto: 'udp' }]);
   });
 
-  it('verdraagt een inspect zonder poortsectie', () => {
+  it('tolerates an inspect without a ports section', () => {
     expect(extractRelaySpecs({})).toEqual([]);
     expect(extractRelaySpecs(null)).toEqual([]);
     expect(extractRelaySpecs({ NetworkSettings: {} })).toEqual([]);
   });
 });
 
-// ── Doel (netwerk + IP) van de workload-container ────────────────────────────
-// De gateway bereikt de workload via het dc-net van de eigenaar als dat kan;
-// leeft de workload alleen op een eigen netwerk (Aspire session-net), dan komt
-// dát netwerk terug zodat de caller de gateway er eerst aan koppelt — tussen
-// niet-gedeelde bridges DROP't Docker SYN's geluidloos.
+// ── Target (network + IP) of the workload container ──────────────────────────
+// The gateway reaches the workload via the owner's dc-net when it can; if the
+// workload lives only on a network of its own (Aspire session-net), that
+// network is returned instead so the caller attaches the gateway to it first —
+// between non-shared bridges Docker silently DROPs SYNs.
 describe('resolveTarget', () => {
-  it('kiest het dc-net van de eigenaar als de workload daarop zit', () => {
+  it("picks the owner's dc-net when the workload is on it", () => {
     const inspect = {
       NetworkSettings: {
         Networks: {
@@ -93,51 +93,52 @@ describe('resolveTarget', () => {
     expect(resolveTarget(inspect, 'dc-a')).toEqual({ ip: '192.168.16.2', network: 'dc-net-dc-a' });
   });
 
-  it('geeft anders het workload-netwerk terug (join vereist)', () => {
+  it('otherwise returns the workload network (join required)', () => {
     const inspect = {
       NetworkSettings: { Networks: { 'aspire-session-net': { IPAddress: '10.0.0.2' } } },
     };
     expect(resolveTarget(inspect, 'dc-a')).toEqual({ ip: '10.0.0.2', network: 'aspire-session-net' });
   });
 
-  it('geeft null zonder bruikbaar netwerk', () => {
+  it('returns null without a usable network', () => {
     expect(resolveTarget({}, 'dc-a')).toBeNull();
     expect(resolveTarget({ NetworkSettings: { Networks: { x: { IPAddress: '' } } } }, 'dc-a')).toBeNull();
   });
 });
 
-// ── Forwarder-setupscript ────────────────────────────────────────────────────
+// ── Forwarder setup script ───────────────────────────────────────────────────
 describe('buildForwarderSetupScript', () => {
   const script = buildForwarderSetupScript();
 
-  it('installeert de forwarder en maakt host.docker.internal loopback', () => {
+  it('installs the forwarder and makes host.docker.internal loopback', () => {
     expect(script).toContain('/usr/local/lib/huddle-port-forwarder.js');
     expect(script).toContain("echo '127.0.0.1 host.docker.internal' >> /etc/hosts");
   });
 
-  it('levert de forwarder als geldige base64 met de loopback-listeners', () => {
+  it('ships the forwarder as valid base64 with the loopback listeners', () => {
     const b64 = script.match(/echo '([A-Za-z0-9+/=]+)' \| base64 -d/)?.[1] ?? '';
     const js = Buffer.from(b64, 'base64').toString('utf8');
     expect(js).toContain('/var/run/huddle/ports');
     expect(js).toContain("'127.0.0.1'");
     expect(js).toContain("'::1'");
-    // De ready-/err-bestanden zijn het handshake-kanaal met de gateway
-    // (waitForForwarderReady); zonder die markers racet een dynamic-port start.
+    // The ready/err files are the handshake channel with the gateway
+    // (waitForForwarderReady); without those markers a dynamic-port start races.
     expect(js).toContain(".ready'");
     expect(js).toContain(".err'");
   });
 
-  it('is idempotent: herstart alleen bij een gewijzigd script of dode pid', () => {
+  it('is idempotent: restarts only on a changed script or dead pid', () => {
     expect(script).toContain('cmp -s');
     expect(script).toContain('kill -0');
   });
 });
 
-// ── Netwerk-join + refcount ──────────────────────────────────────────────────
-// De gateway joint workload-netwerken on demand en moet zich weer loskoppelen
-// zodra de laatste relay op dat netwerk verdwijnt — anders blokkeert hij
-// `docker network rm` bij Aspire's cleanup. Netwerken waar hij al aan hing
-// (already-connected) en permanente (dc-net-*) worden nooit losgekoppeld.
+// ── Network join + refcount ──────────────────────────────────────────────────
+// The gateway joins workload networks on demand and must detach again as soon
+// as the last relay on that network disappears — otherwise it blocks
+// `docker network rm` during Aspire's cleanup. Networks it was already
+// attached to (already-connected) and permanent ones (dc-net-*) are never
+// disconnected.
 describe('createNetworkRefTracker', () => {
   function fakeOps(connectResult: () => 'connected' | 'already-connected' | 'missing' | 'error') {
     const calls = { connect: 0, disconnect: 0 };
@@ -149,21 +150,21 @@ describe('createNetworkRefTracker', () => {
     return { ops, calls };
   }
 
-  it('verse join: connect één keer, disconnect pas bij de laatste release', async () => {
+  it('fresh join: connect once, disconnect only on the last release', async () => {
     const { ops, calls } = fakeOps(() => 'connected' as const);
     const t = createNetworkRefTracker(ops);
     expect(await t.acquire('net-a', 'ct-1')).toBe(true);
     expect(await t.acquire('net-a', 'ct-2')).toBe(true);
-    expect(calls.connect).toBe(1); // tweede acquire is puur een refcount
+    expect(calls.connect).toBe(1); // second acquire is purely a refcount
     await t.release('net-a', 'ct-1');
-    expect(calls.disconnect).toBe(0); // ct-2 houdt het netwerk nog vast
+    expect(calls.disconnect).toBe(0); // ct-2 still holds the network
     expect(t.isJoined('net-a')).toBe(true);
     await t.release('net-a', 'ct-2');
     expect(calls.disconnect).toBe(1);
     expect(t.isJoined('net-a')).toBe(false);
   });
 
-  it('already-connected: succes, maar nooit een disconnect (membership was niet van ons)', async () => {
+  it('already-connected: success, but never a disconnect (membership was not ours)', async () => {
     const { ops, calls } = fakeOps(() => 'already-connected' as const);
     const t = createNetworkRefTracker(ops);
     expect(await t.acquire('net-a', 'ct-1')).toBe(true);
@@ -171,14 +172,14 @@ describe('createNetworkRefTracker', () => {
     expect(calls.disconnect).toBe(0);
   });
 
-  it('verdwenen netwerk: acquire faalt zonder te registreren', async () => {
+  it('vanished network: acquire fails without registering', async () => {
     const { ops } = fakeOps(() => 'missing' as const);
     const t = createNetworkRefTracker(ops);
     expect(await t.acquire('net-gone', 'ct-1')).toBe(false);
     expect(t.isJoined('net-gone')).toBe(false);
   });
 
-  it('permanente netwerken (dc-net-*) worden nooit losgekoppeld', async () => {
+  it('permanent networks (dc-net-*) are never disconnected', async () => {
     const { ops, calls } = fakeOps(() => 'connected' as const);
     const t = createNetworkRefTracker(ops);
     await t.acquire('dc-net-dc-a', 'ct-1');
@@ -186,7 +187,7 @@ describe('createNetworkRefTracker', () => {
     expect(calls.disconnect).toBe(0);
   });
 
-  it('isJoinedNetworkIp matcht alleen subnetten van door óns gejoinde netwerken', async () => {
+  it('isJoinedNetworkIp matches only subnets of networks WE joined', async () => {
     const { ops } = fakeOps(() => 'connected' as const);
     const t = createNetworkRefTracker(ops);
     await t.acquire('net-a', 'ct-1');
@@ -194,8 +195,8 @@ describe('createNetworkRefTracker', () => {
     expect(t.isJoinedNetworkIp('::ffff:10.10.0.7')).toBe(true);
     expect(t.isJoinedNetworkIp('10.11.0.7')).toBe(false);
 
-    // already-connected (pre-existing membership, bv. het default-net) mag de
-    // :3000-guard níet triggeren.
+    // already-connected (pre-existing membership, e.g. the default net) must
+    // NOT trigger the :3000 guard.
     const pre = fakeOps(() => 'already-connected' as const);
     const t2 = createNetworkRefTracker(pre.ops);
     await t2.acquire('net-b', 'ct-1');
@@ -204,25 +205,25 @@ describe('createNetworkRefTracker', () => {
 });
 
 describe('ipInSubnet', () => {
-  it('matcht IPv4 CIDR-grenzen correct', () => {
+  it('matches IPv4 CIDR boundaries correctly', () => {
     expect(ipInSubnet('192.168.16.2', '192.168.16.0/20')).toBe(true);
     expect(ipInSubnet('192.168.31.255', '192.168.16.0/20')).toBe(true);
     expect(ipInSubnet('192.168.32.1', '192.168.16.0/20')).toBe(false);
     expect(ipInSubnet('::ffff:192.168.16.2', '192.168.16.0/20')).toBe(true);
   });
 
-  it('matcht conservatief niet op onbruikbare invoer (IPv6, rommel)', () => {
+  it('conservatively does not match unusable input (IPv6, garbage)', () => {
     expect(ipInSubnet('fd00::2', 'fd00::/64')).toBe(false);
     expect(ipInSubnet('not-an-ip', '10.0.0.0/8')).toBe(false);
     expect(ipInSubnet('10.0.0.1', 'garbage')).toBe(false);
   });
 });
 
-// ── Backend-dial met timeout ─────────────────────────────────────────────────
-// Docker's inter-bridge-isolatie dropt SYN's zonder RST: zonder harde timeout
-// hangt een relay-client voor eeuwig op accept-zonder-bytes.
+// ── Backend dial with timeout ────────────────────────────────────────────────
+// Docker's inter-bridge isolation drops SYNs without an RST: without a hard
+// timeout a relay client hangs forever on an accept that never yields bytes.
 describe('dialWithTimeout', () => {
-  it('verbindt naar een luisterende poort', async () => {
+  it('connects to a listening port', async () => {
     const srv = net.createServer(c => c.end());
     await new Promise<void>((res) => srv.listen(0, '127.0.0.1', () => res()));
     const port = (srv.address() as AddressInfo).port;
@@ -231,8 +232,8 @@ describe('dialWithTimeout', () => {
     srv.close();
   });
 
-  it('reject (geen hang) op een gesloten poort', async () => {
-    // Poort reserveren en weer sluiten → gegarandeerd dicht.
+  it('rejects (no hang) on a closed port', async () => {
+    // Reserve a port and close it again → guaranteed closed.
     const srv = net.createServer();
     await new Promise<void>((res) => srv.listen(0, '127.0.0.1', () => res()));
     const port = (srv.address() as AddressInfo).port;
@@ -240,10 +241,10 @@ describe('dialWithTimeout', () => {
     await expect(dialWithTimeout('127.0.0.1', port, 1000)).rejects.toThrow();
   });
 
-  it('timeout: een dial die nooit connect geeft reject + destroy (het inter-bridge-DROP-scenario)', async () => {
-    // Gemockte socket die nooit 'connect' emit — deterministisch equivalent van
-    // Docker's stille SYN-drop tussen bridges (een echt blackhole-adres is in
-    // een sandbox/CI-netwerk niet betrouwbaar).
+  it('timeout: a dial that never connects rejects + destroys (the inter-bridge DROP scenario)', async () => {
+    // Mocked socket that never emits 'connect' — a deterministic equivalent of
+    // Docker's silent SYN drop between bridges (a real blackhole address is
+    // not reliable in a sandbox/CI network).
     const fake = new EventEmitter() as any;
     fake.destroy = vi.fn();
     const spy = vi.spyOn(net, 'createConnection').mockReturnValue(fake);
@@ -256,40 +257,40 @@ describe('dialWithTimeout', () => {
   });
 });
 
-// ── HTTP-statusparser voor gebufferde responsen ──────────────────────────────
-// openUpstreamBuffered (socket-proxy.ts) beslist op deze status of relays
-// opgezet/afgebroken worden voordat de respons naar de client teruggaat.
+// ── HTTP status parser for buffered responses ────────────────────────────────
+// openUpstreamBuffered (socket-proxy.ts) uses this status to decide whether
+// relays are set up or torn down before the response goes back to the client.
 describe('parseHttpStatus', () => {
-  it('leest de statuscode uit een HTTP/1.1-respons', () => {
+  it('reads the status code from an HTTP/1.1 response', () => {
     expect(parseHttpStatus(Buffer.from('HTTP/1.1 204 No Content\r\n\r\n'))).toBe(204);
     expect(parseHttpStatus(Buffer.from('HTTP/1.0 404 Not Found\r\n\r\n'))).toBe(404);
   });
 
-  it('geeft 0 voor een onherkenbaar antwoord', () => {
+  it('returns 0 for an unrecognizable response', () => {
     expect(parseHttpStatus(Buffer.from(''))).toBe(0);
     expect(parseHttpStatus(Buffer.from('garbage'))).toBe(0);
   });
 });
 
-// ── Owner-naamguard op de relay-entry-points ─────────────────────────────────
-// `owner` vloeit in path.join() onder de gedeelde sockets-directory. Dezelfde
-// Docker-naamgrammatica als assertSafeContainerName (socket-proxy.ts): een
-// traversal-naam mag nooit tot een pad buiten die directory leiden — ook niet
-// via de operator-API (`/api/docker/containers/:name/start`).
+// ── Owner-name guard on the relay entry points ───────────────────────────────
+// `owner` flows into path.join() under the shared sockets directory. Same
+// Docker name grammar as assertSafeContainerName (socket-proxy.ts): a
+// traversal name must never lead to a path outside that directory — not even
+// via the operator API (`/api/docker/containers/:name/start`).
 describe('assertSafeOwner', () => {
-  it('accepteert geldige Docker-containernamen', () => {
+  it('accepts valid Docker container names', () => {
     for (const ok of ['devcontainer-aspire', 'a', 'A1_b.c-d']) {
       expect(() => assertSafeOwner(ok)).not.toThrow();
     }
   });
 
-  it('weigert traversal- en niet-grammatica-namen', () => {
+  it('rejects traversal and non-grammar names', () => {
     for (const bad of ['../evil', 'a/b', '.hidden', '', '..', 'a b']) {
       expect(() => assertSafeOwner(bad)).toThrow(/unsafe owner name/);
     }
   });
 
-  it('vuurt vóór alle I/O op beide publieke entry points', async () => {
+  it('fires before any I/O on both public entry points', async () => {
     await expect(syncContainerRelays('../evil', 'x')).rejects.toThrow(/unsafe owner name/);
     await expect(ensurePortForwarder('../evil')).rejects.toThrow(/unsafe owner name/);
   });

--- a/gateway/test/proxy-forward-path.test.ts
+++ b/gateway/test/proxy-forward-path.test.ts
@@ -62,9 +62,10 @@ describe.skipIf(!sqliteAvailable)('proxy forwards the original encoded request-p
     db = dbMod.db;
     dbMod.initDb();
 
-    // Geen Docker in de unit-omgeving: resolve het client-IP naar een vaste
-    // containernaam. (null kan niet meer: onbekende bronnen zijn sinds de
-    // port-relay-netwerkjoins default-deny — zie proxy-unknown-source.test.ts.)
+    // No Docker in the unit environment: resolve the client IP to a fixed
+    // container name. (null is no longer an option: unknown sources are
+    // default-deny since the port-relay network joins — see
+    // proxy-unknown-source.test.ts.)
     const dockerMod = await import('../src/docker');
     vi.spyOn(dockerMod, 'resolveContainerByIp').mockResolvedValue('dc-test');
 

--- a/gateway/test/proxy-forward-path.test.ts
+++ b/gateway/test/proxy-forward-path.test.ts
@@ -62,10 +62,11 @@ describe.skipIf(!sqliteAvailable)('proxy forwards the original encoded request-p
     db = dbMod.db;
     dbMod.initDb();
 
-    // Geen Docker in de unit-omgeving: de client-IP hoeft niet naar een
-    // container te resolven — een globale allow-regel volstaat.
+    // Geen Docker in de unit-omgeving: resolve het client-IP naar een vaste
+    // containernaam. (null kan niet meer: onbekende bronnen zijn sinds de
+    // port-relay-netwerkjoins default-deny — zie proxy-unknown-source.test.ts.)
     const dockerMod = await import('../src/docker');
-    vi.spyOn(dockerMod, 'resolveContainerByIp').mockResolvedValue(null);
+    vi.spyOn(dockerMod, 'resolveContainerByIp').mockResolvedValue('dc-test');
 
     upstream = http.createServer((req, res) => {
       lastUpstreamUrl = req.url ?? null;

--- a/gateway/test/proxy-unknown-source.test.ts
+++ b/gateway/test/proxy-unknown-source.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import http from 'http';
+import type { AddressInfo } from 'net';
+
+// ── Default-deny voor onbekende proxy-bronnen ────────────────────────────────
+// De egress-proxy identificeert clients op bron-IP → containermap (kinderen
+// erven hun parent-devcontainer). Sinds de port-relay de gateway aan workload-
+// netwerken koppelt, kan de proxy in principe bereikt worden door bronnen die
+// niet naar een huddle-beheerde container herleiden. Die mochten voorheen
+// stilletjes meeliften op GLOBALE allow-regels (en vervuilden de rules-tabel
+// met requested-regels) — een bypass van "no direct internet". Deze suite pint
+// het nieuwe contract vast:
+//   1. onbekende bron → 403, óók met een matchende globale allow-regel;
+//   2. onbekende bron maakt géén requested-regel aan;
+//   3. een bekende container blijft de globale-regel-fallback houden.
+//
+// better-sqlite3 is een native module; zonder bruikbare binding slaan we over
+// (zelfde probe als proxy-forward-path.test.ts).
+let sqliteAvailable = true;
+try {
+  const mod = await import('better-sqlite3');
+  new mod.default(':memory:').close();
+} catch (e) {
+  sqliteAvailable = false;
+  console.warn(
+    `[proxy-unknown-source.test] SKIPPED — better-sqlite3 binding niet bruikbaar: ${(e as Error).message}`
+  );
+}
+
+let db: typeof import('../src/db').db;
+let resolveMock: ReturnType<typeof vi.spyOn>;
+
+let upstream: http.Server;
+let upstreamPort = 0;
+
+let proxy: http.Server;
+let proxyPort = 0;
+
+function proxyGet(pathAndQuery: string): Promise<{ status: number; blockedHeader: string | undefined }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: '127.0.0.1',
+        port: proxyPort,
+        method: 'GET',
+        path: `http://127.0.0.1:${upstreamPort}${pathAndQuery}`,
+        headers: { host: `127.0.0.1:${upstreamPort}` },
+      },
+      (res) => {
+        res.resume();
+        res.on('end', () => resolve({
+          status: res.statusCode ?? 0,
+          blockedHeader: res.headers['x-huddle-blocked'] as string | undefined,
+        }));
+      }
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe.skipIf(!sqliteAvailable)('proxy default-deny voor onbekende bronnen', () => {
+  beforeAll(async () => {
+    const dbMod = await import('../src/db');
+    db = dbMod.db;
+    dbMod.initDb();
+
+    const dockerMod = await import('../src/docker');
+    resolveMock = vi.spyOn(dockerMod, 'resolveContainerByIp') as any;
+
+    upstream = http.createServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end('ok');
+    });
+    await new Promise<void>((r) => upstream.listen(0, '127.0.0.1', () => r()));
+    upstreamPort = (upstream.address() as AddressInfo).port;
+
+    const { createProxyServer } = await import('../src/proxy');
+    proxy = createProxyServer(0);
+    await new Promise<void>((r) => proxy.once('listening', () => r()));
+    proxyPort = (proxy.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((r) => (proxy ? proxy.close(() => r()) : r()));
+    await new Promise<void>((r) => (upstream ? upstream.close(() => r()) : r()));
+  });
+
+  beforeEach(() => {
+    db.exec('DELETE FROM rules');
+    db.exec('DELETE FROM audit_log');
+    // Globale allow voor de upstream-host: de verleiding waar een onbekende
+    // bron vroeger op meeliftte.
+    db.prepare(`INSERT INTO rules (domain, container_id, status) VALUES ('127.0.0.1', NULL, 'allow')`).run();
+  });
+
+  it('onbekende bron → 403, ondanks een matchende globale allow-regel', async () => {
+    resolveMock.mockResolvedValue(null);
+    const { status, blockedHeader } = await proxyGet('/data');
+    expect(status).toBe(403);
+    expect(blockedHeader).toBe('1');
+  });
+
+  it('onbekende bron maakt géén requested-regel aan (geen rules-vervuiling)', async () => {
+    resolveMock.mockResolvedValue(null);
+    db.exec('DELETE FROM rules'); // ook geen globale regel: het no-match-pad
+    await proxyGet('/data');
+    const count = (db.prepare('SELECT COUNT(*) AS n FROM rules').get() as { n: number }).n;
+    expect(count).toBe(0);
+  });
+
+  it('bekende container houdt de globale-regel-fallback (regressieguard)', async () => {
+    resolveMock.mockResolvedValue('dc-known');
+    const { status } = await proxyGet('/data');
+    expect(status).toBe(200);
+  });
+});

--- a/gateway/test/proxy-unknown-source.test.ts
+++ b/gateway/test/proxy-unknown-source.test.ts
@@ -2,20 +2,20 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vites
 import http from 'http';
 import type { AddressInfo } from 'net';
 
-// ── Default-deny voor onbekende proxy-bronnen ────────────────────────────────
-// De egress-proxy identificeert clients op bron-IP → containermap (kinderen
-// erven hun parent-devcontainer). Sinds de port-relay de gateway aan workload-
-// netwerken koppelt, kan de proxy in principe bereikt worden door bronnen die
-// niet naar een huddle-beheerde container herleiden. Die mochten voorheen
-// stilletjes meeliften op GLOBALE allow-regels (en vervuilden de rules-tabel
-// met requested-regels) — een bypass van "no direct internet". Deze suite pint
-// het nieuwe contract vast:
-//   1. onbekende bron → 403, óók met een matchende globale allow-regel;
-//   2. onbekende bron maakt géén requested-regel aan;
-//   3. een bekende container blijft de globale-regel-fallback houden.
+// ── Default-deny for unknown proxy sources ───────────────────────────────────
+// The egress proxy identifies clients via source-IP → container mapping
+// (children inherit their parent devcontainer). Since the port relay attaches
+// the gateway to workload networks, the proxy can in principle be reached by
+// sources that do not resolve to a huddle-managed container. Those could
+// previously piggyback silently on GLOBAL allow rules (and polluted the rules
+// table with requested rules) — a bypass of "no direct internet". This suite
+// pins down the new contract:
+//   1. unknown source → 403, even with a matching global allow rule;
+//   2. an unknown source creates no requested rule;
+//   3. a known container keeps the global-rule fallback.
 //
-// better-sqlite3 is een native module; zonder bruikbare binding slaan we over
-// (zelfde probe als proxy-forward-path.test.ts).
+// better-sqlite3 is a native module; without a usable binding we skip
+// (same probe as proxy-forward-path.test.ts).
 let sqliteAvailable = true;
 try {
   const mod = await import('better-sqlite3');
@@ -23,7 +23,7 @@ try {
 } catch (e) {
   sqliteAvailable = false;
   console.warn(
-    `[proxy-unknown-source.test] SKIPPED — better-sqlite3 binding niet bruikbaar: ${(e as Error).message}`
+    `[proxy-unknown-source.test] SKIPPED — better-sqlite3 binding not usable: ${(e as Error).message}`
   );
 }
 
@@ -59,7 +59,7 @@ function proxyGet(pathAndQuery: string): Promise<{ status: number; blockedHeader
   });
 }
 
-describe.skipIf(!sqliteAvailable)('proxy default-deny voor onbekende bronnen', () => {
+describe.skipIf(!sqliteAvailable)('proxy default-deny for unknown sources', () => {
   beforeAll(async () => {
     const dbMod = await import('../src/db');
     db = dbMod.db;
@@ -89,27 +89,27 @@ describe.skipIf(!sqliteAvailable)('proxy default-deny voor onbekende bronnen', (
   beforeEach(() => {
     db.exec('DELETE FROM rules');
     db.exec('DELETE FROM audit_log');
-    // Globale allow voor de upstream-host: de verleiding waar een onbekende
-    // bron vroeger op meeliftte.
+    // Global allow for the upstream host: the temptation an unknown source
+    // used to piggyback on.
     db.prepare(`INSERT INTO rules (domain, container_id, status) VALUES ('127.0.0.1', NULL, 'allow')`).run();
   });
 
-  it('onbekende bron → 403, ondanks een matchende globale allow-regel', async () => {
+  it('unknown source → 403, despite a matching global allow rule', async () => {
     resolveMock.mockResolvedValue(null);
     const { status, blockedHeader } = await proxyGet('/data');
     expect(status).toBe(403);
     expect(blockedHeader).toBe('1');
   });
 
-  it('onbekende bron maakt géén requested-regel aan (geen rules-vervuiling)', async () => {
+  it('unknown source creates no requested rule (no rules pollution)', async () => {
     resolveMock.mockResolvedValue(null);
-    db.exec('DELETE FROM rules'); // ook geen globale regel: het no-match-pad
+    db.exec('DELETE FROM rules'); // no global rule either: the no-match path
     await proxyGet('/data');
     const count = (db.prepare('SELECT COUNT(*) AS n FROM rules').get() as { n: number }).n;
     expect(count).toBe(0);
   });
 
-  it('bekende container houdt de globale-regel-fallback (regressieguard)', async () => {
+  it('known container keeps the global-rule fallback (regression guard)', async () => {
     resolveMock.mockResolvedValue('dc-known');
     const { status } = await proxyGet('/data');
     expect(status).toBe(200);


### PR DESCRIPTION
## Wat & waarom

Fixes #61 — *Aspire SQL server healthcheck does not succeed* (resource blijft op state `Unknown`).

Aspire's DCP inspecteert een **persistent** container (deterministische naam) *vóór* het 'm aanmaakt (inspect-before-create). De socket-proxy behandelde "container bestaat niet" hetzelfde als "van een andere devcontainer" en gaf een `403`. DCP concludeerde daaruit dat de container bestond maar onbereikbaar was, maakte 'm nooit aan, en de resource bleef op `Unknown` staan:

```
docker command 'InspectContainers' returned with non-zero exit code 1
Error response from daemon: container not owned by this devcontainer
only 0 out of 1 containers were successfully inspected
```

## Oplossing

**1. Foreign/missing → 404 op de lees-tak** (`20e7087`, `89adaa2`)

Vanuit een devcontainer bestaat elke container die het **niet zelf heeft aangemaakt** simpelweg niet. De lees-/inspect-tak (`GET .../json|logs|top|archive|stats`) geeft nu Docker's eigen `No such container` **404** terug voor alles wat geen `huddle.parent == <devcontainer>` heeft:

- **Fixt #61**: een nog-niet-aangemaakte persistent container leest als afwezig → DCP maakt 'm aan.
- **Sluit een bestaans-oracle**: `foreign` en `missing` zijn niet meer te onderscheiden (voorheen `foreign→403` vs `missing→404`), dus een devcontainer kan geen containernamen buiten zijn sandbox meer aftasten.
- **Geen TOCTOU**: de 404 wordt *gesynthetiseerd* ná de ownership-check i.p.v. het originele verzoek door te forwarden, dus een in de race aangemaakte vreemde container is niet alsnog te inspecteren.

Een probe op een écht bestaande vreemde container wordt voor de operator gelogd, maar de caller ziet nog steeds `404`. De classificatie zit in een pure `ownershipFromInspect()` met unit-tests. Voor bekende devcontainers zit er een goedkoop fast-path vóór de ownership-check (geen Docker-round-trip; review-opmerking Aikido) dat byte-voor-byte dezelfde 404 teruggeeft.

**2. Port-relay: gepubliceerde poorten van owned containers de devcontainer in** (`d5b3dbe`)

Bij de e2e-repro bleek de healthcheck daarna alsnog niet groen te worden: Docker publiceert de SQL-poort op de loopback van de *engine-host* (`127.0.0.1:<port>`), die binnen de devcontainer niet bestaat. Per gepubliceerde TCP-poort legt de gateway nu een unix-socket neer in de al gedeelde per-container mount; een kleine in-devcontainer forwarder luistert op `127.0.0.1`/`::1:<hostPort>` en pipe't naar die socket, en de gateway pipe't door naar `containerIP:containerPort` op het netwerk van de eigenaar. Relays worden gesynchroniseerd op start/restart en opgeruimd op stop/kill/remove; de start-respons wordt gebufferd tot de relay er staat, zodat DCP/Testcontainers-clients die direct na de start connecten geen "connection refused" racen.

## Security

Netto **strikter** dan het origineel op de lees-tak; er wordt geen nieuwe capability geopend. Mutatie-paden (create/start/exec/archive-upload/delete) zijn ongewijzigd en blijven fail-closed. De relay exposeert uitsluitend poorten die de devcontainer zelf via zijn eigen create-pad heeft gepubliceerd, en alleen ín die devcontainer.

## Tests / verificatie

- `tsc --noEmit` schoon; alle 157 unit-tests groen (o.a. pure classificatie-tests + port-relay-tests).
- Alle 21 live e2e-boundary-tests groen tegen een verse stack (CI-opzet 1-op-1 nagespeeld), incl. twee nieuwe: een vreemde container (`huddle`) leest als niet-bestaand zonder ownership-lek in het antwoord, en het devcontainer-fast-path geeft dezelfde 404.
- Het DCP-scenario uit issue #61 end-to-end nagespeeld in een echte devcontainer: inspect-before-create → schone 404; daarna session-netwerk → create → network connect → start: poort gepubliceerd en via de relay bereikbaar op `127.0.0.1:<hostPort>` én `[::1]:<hostPort>` binnen de devcontainer. Relay verdwijnt bij stop/remove en komt terug bij restart (volgt de nieuwe dynamische poort).
- Eerder al end-to-end geverifieerd met de exacte repro uit de issue (vscode-devcontainer, .NET 10, Aspire 13.4.6, SQL Server 2025, `ContainerLifetime.Persistent`): `sqlserver` wordt aangemaakt met label `huddle.parent`, DCP rapporteert `state=Running`, en een echte TDS-handshake bereikt SQL Server via de DCP-proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
