### PR TITLE
feat(runtime): detect Rancher Desktop docker socket + document support

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,29 @@ After that, you start devcontainers directly from a project directory:
 huddle
 ```
 
+### Rancher Desktop
+
+Huddle works with [Rancher Desktop](https://rancherdesktop.io/) as long as it runs
+in **dockerd (moby)** mode — the `containerd`/`nerdctl` backend is *not* supported,
+because it does not expose a Docker-compatible engine or socket. Switch the container
+engine to `dockerd (moby)` under **Preferences → Container Engine**.
+
+In dockerd mode Rancher Desktop looks like a normal Docker engine, so `huddle init`
+auto-detects it (`--runtime docker`, which is also the default). The one difference
+is the socket location: Rancher Desktop puts its Docker socket at `~/.rd/docker.sock`
+instead of `/var/run/docker.sock`. Huddle reads the active `docker context` and
+mounts that socket automatically — no extra configuration needed. Rancher Desktop
+runs the engine inside a VM on every OS, so Huddle treats it as a remote engine (as
+it does Docker Desktop).
+
+If auto-detection ever fails, make sure the `rancher-desktop` context is active
+(`docker context use rancher-desktop`) and that `docker info` works, then re-run
+`huddle init --runtime docker`.
+
+> Note: Rancher Desktop must share the socket path (and `/tmp/dc-sockets`, used for
+> the per-container proxy sockets) into its VM. The defaults cover this, but if you
+> customized the VM's mounts you may need to add those paths back.
+
 ---
 
 ## Building base images (optional)
@@ -533,6 +556,7 @@ There are two ways an `experiment-<nr>` build gets published:
 |---------|----------|
 | `docker login ghcr.io` or `npm install` fails with **401/403** | Your token expired or lacks the `read:packages` scope. Create a new token and log in again (see [Getting Started](#getting-started)). |
 | `huddle init` finds no runtime | Make sure Docker or Podman is running. Force it explicitly with `huddle init --runtime docker` (or `podman`), or set `HUDDLE_RUNTIME`. |
+| Rancher Desktop not detected | Use **dockerd (moby)** mode (not `containerd`), activate the context with `docker context use rancher-desktop`, verify `docker info` works, then re-run `huddle init --runtime docker`. |
 | Web UI not reachable at `http://localhost:3000` | Check that the Huddle container is running (`docker ps`). The management API binds to `127.0.0.1` by default — reach it locally, not from another host. |
 | Devcontainer can't reach a domain | Expected behavior: all traffic goes through the firewall. Allow the domain via **Firewall** in the UI or `huddle fw list`. |
 | JetBrains Gateway doesn't see the container right away | The JetBrains backend needs a moment to start; the CLI prints the gateway link once it's ready. |
@@ -554,6 +578,11 @@ network infrastructure.
 **Does Huddle work with Podman?**
 Yes. `huddle init` automatically detects Docker or Podman; you can force it with
 `--runtime` or the `HUDDLE_RUNTIME` env var.
+
+**Does Huddle work with Rancher Desktop?**
+Yes, in **dockerd (moby)** mode (not `containerd`/`nerdctl`). Huddle auto-detects it
+as Docker and reads the `~/.rd/docker.sock` socket from the active docker context.
+See [Rancher Desktop](#rancher-desktop) under Getting Started.
 
 **Does Huddle intercept HTTPS traffic?**
 HTTP requests are logged in full. HTTPS is tunneled through `CONNECT`; its

--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -158,7 +158,7 @@ export async function runInit(opts: InitOptions, images: ResolvedImages): Promis
     ` -e HUDDLE_OPERATOR_TOKEN=${operatorToken}` +
     ` -p ${HOST_PORT}:3000` +
     ` -v ${VOLUME}:/data` +
-    ` -v ${runtime.socketPath}:/var/run/docker.sock` +
+    ` -v "${runtime.socketPath}:/var/run/docker.sock"` +
     ` -v "${hostTmpSockets}:/tmp/dc-sockets"` +
     homeMountFlag +
     fwMountFlag +

--- a/cli/src/runtime.ts
+++ b/cli/src/runtime.ts
@@ -66,6 +66,45 @@ function dockerSocketPath(): string {
   return process.platform === 'win32' ? '//var/run/docker.sock' : '/var/run/docker.sock';
 }
 
+/**
+ * Haalt het unix-socketpad uit de JSON van `docker context inspect`. De actieve
+ * context bepaalt naar welke engine het `docker`-commando praat; Rancher Desktop
+ * (dockerd/moby-modus) zet een `rancher-desktop`-context waarvan
+ * `Endpoints.docker.Host` naar `unix:///<home>/.rd/docker.sock` wijst i.p.v. de
+ * standaard `/var/run/docker.sock`.
+ *
+ * Pure functie zodat we het parsen los kunnen testen. Geeft `null` terug bij
+ * niet-parsebare invoer of een niet-unix endpoint (npipe:// op Windows,
+ * tcp:// / ssh:// remote), want die zijn niet als bestandspad te bind-mounten.
+ */
+export function parseDockerContextSocket(json: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  // `docker context inspect` levert een array; één context is één element.
+  const entry = Array.isArray(parsed) ? parsed[0] : parsed;
+  const host = (entry as { Endpoints?: { docker?: { Host?: unknown } } } | null | undefined)
+    ?.Endpoints?.docker?.Host;
+  if (typeof host !== 'string' || !host.startsWith('unix://')) return null;
+  const path = host.slice('unix://'.length);
+  return path.startsWith('/') ? path : null;
+}
+
+/** Herkent het socketpad van Rancher Desktop (dockerd/moby-modus): `~/.rd/docker.sock`. */
+export function isRancherDesktopSocket(socketPath: string | null | undefined): boolean {
+  return typeof socketPath === 'string' && /(^|\/)\.rd\/docker\.sock$/.test(socketPath);
+}
+
+/** Socketpad van de actieve docker-context, of undefined als het niet op te vragen is. */
+function dockerContextSocket(): string | undefined {
+  const json = commandOutput('docker context inspect');
+  if (!json) return undefined;
+  return parseDockerContextSocket(json) ?? undefined;
+}
+
 function podmanIsRemote(): boolean {
   // Op macOS/Windows draait Podman altijd in een `podman machine`-VM; ook op
   // Linux kan de client op een remote socket wijzen. `ServiceIsRemote` is de
@@ -83,12 +122,21 @@ function buildRuntime(name: RuntimeName): ContainerRuntime {
       securityOpts: ['label=disable'],
     };
   }
+  // Rancher Desktop (dockerd/moby-modus) ziet er als een gewone Docker-engine
+  // uit, maar de socket zit niet op /var/run/docker.sock: de actieve
+  // docker-context wijst naar `~/.rd/docker.sock`. Volg die context zodat we de
+  // juiste socket bind-mounten; anders vallen we terug op de standaardlocatie
+  // (echte native Docker, Docker Desktop). Rancher Desktop draait de engine op
+  // ELK platform in een VM (Lima/WSL), dus is hij altijd 'remote'.
+  const contextSocket = dockerContextSocket();
+  const isRancher = isRancherDesktopSocket(contextSocket);
   return {
     name,
-    socketPath: dockerSocketPath(),
+    socketPath: isRancher ? contextSocket! : dockerSocketPath(),
     defaultNetwork: 'bridge',
-    // Docker Desktop (macOS/Windows) draait in een VM; native Docker op Linux niet.
-    isRemote: process.platform !== 'linux',
+    // Docker Desktop (macOS/Windows) en Rancher Desktop draaien in een VM;
+    // native Docker op Linux niet.
+    isRemote: isRancher || process.platform !== 'linux',
     securityOpts: [],
   };
 }

--- a/cli/src/runtime.ts
+++ b/cli/src/runtime.ts
@@ -90,7 +90,15 @@ export function parseDockerContextSocket(json: string): string | null {
     ?.Endpoints?.docker?.Host;
   if (typeof host !== 'string' || !host.startsWith('unix://')) return null;
   const path = host.slice('unix://'.length);
-  return path.startsWith('/') ? path : null;
+  if (!path.startsWith('/')) return null;
+  // Het teruggegeven pad wordt later ONgequote in een `docker run -v <pad>:...`
+  // shell-commando geïnterpoleerd (init.ts). De `Host` uit `docker context
+  // inspect` is beïnvloedbaar (wie een docker-context kan aanmaken/activeren
+  // bepaalt de waarde), dus laat alleen tekens toe die in een echt socketpad
+  // voorkomen. Zo kan een gemanipuleerde context geen shell-metatekens
+  // ($(), backticks, ;, |, spaties, ...) binnensmokkelen — command injection.
+  if (!/^[A-Za-z0-9._/-]+$/.test(path)) return null;
+  return path;
 }
 
 /** Herkent het socketpad van Rancher Desktop (dockerd/moby-modus): `~/.rd/docker.sock`. */

--- a/cli/src/runtime.ts
+++ b/cli/src/runtime.ts
@@ -9,17 +9,18 @@ export interface ContainerRuntime {
   /** Name of the default bridge network ('bridge' for Docker, 'podman' for Podman). */
   defaultNetwork: string;
   /**
-   * Draait de engine in een VM (Podman machine, Docker Desktop) i.p.v. native op
-   * de host? Bepaalt of bind-sources zoals /tmp/dc-sockets in de VM aangemaakt
-   * moeten worden: Docker Desktop maakt een ontbrekende source zelf aan, Podman
-   * niet — dan moeten we hem via `podman machine ssh` in de VM aanmaken.
+   * Does the engine run in a VM (Podman machine, Docker Desktop) instead of
+   * natively on the host? Determines whether bind-sources such as
+   * /tmp/dc-sockets must be created inside the VM: Docker Desktop creates a
+   * missing source itself, Podman does not — then we have to create it inside
+   * the VM via `podman machine ssh`.
    */
   isRemote: boolean;
   /**
-   * Extra `--security-opt` vlaggen voor de huddle-container. Rootless Podman
-   * geeft zijn socket een SELinux-label; zonder `label=disable` mag het
-   * (SELinux-confined) huddle-proces de socket niet benaderen. Docker heeft dit
-   * niet nodig (leeg).
+   * Extra `--security-opt` flags for the huddle container. Rootless Podman
+   * gives its socket a SELinux label; without `label=disable` the
+   * (SELinux-confined) huddle process is not allowed to access the socket.
+   * Docker does not need this (empty).
    */
   securityOpts: string[];
 }
@@ -38,12 +39,12 @@ function isAvailable(runtime: RuntimeName): boolean {
 }
 
 /**
- * Bepaalt de ECHTE engine achter een commando, of undefined als de engine niet
- * bereikbaar is. Vertrouw niet op de commandonaam: `docker` is vaak een
- * symlink/shim naar Podman (podman-docker) en Podman emuleert dan zelfs
- * `docker --version`. Podman's `info` kent daarentegen het veld
- * Host.ServiceIsRemote; Docker's info-schema niet. Dat is een betrouwbaar
- * onderscheid dat ook via de shim werkt.
+ * Determines the REAL engine behind a command, or undefined if the engine is
+ * not reachable. Do not trust the command name: `docker` is often a
+ * symlink/shim to Podman (podman-docker), and Podman then even emulates
+ * `docker --version`. Podman's `info`, on the other hand, has the field
+ * Host.ServiceIsRemote; Docker's info schema does not. That is a reliable
+ * distinction that also works through the shim.
  */
 function detectEngine(command: RuntimeName): RuntimeName | undefined {
   if (commandOutput(`${command} info --format "{{.Host.ServiceIsRemote}}"`) !== undefined) {
@@ -67,15 +68,15 @@ function dockerSocketPath(): string {
 }
 
 /**
- * Haalt het unix-socketpad uit de JSON van `docker context inspect`. De actieve
- * context bepaalt naar welke engine het `docker`-commando praat; Rancher Desktop
- * (dockerd/moby-modus) zet een `rancher-desktop`-context waarvan
- * `Endpoints.docker.Host` naar `unix:///<home>/.rd/docker.sock` wijst i.p.v. de
- * standaard `/var/run/docker.sock`.
+ * Extracts the unix socket path from the JSON of `docker context inspect`. The
+ * active context determines which engine the `docker` command talks to; Rancher
+ * Desktop (dockerd/moby mode) sets a `rancher-desktop` context whose
+ * `Endpoints.docker.Host` points to `unix:///<home>/.rd/docker.sock` instead of
+ * the default `/var/run/docker.sock`.
  *
- * Pure functie zodat we het parsen los kunnen testen. Geeft `null` terug bij
- * niet-parsebare invoer of een niet-unix endpoint (npipe:// op Windows,
- * tcp:// / ssh:// remote), want die zijn niet als bestandspad te bind-mounten.
+ * Pure function so we can test the parsing in isolation. Returns `null` for
+ * non-parsable input or a non-unix endpoint (npipe:// on Windows,
+ * tcp:// / ssh:// remote), because those cannot be bind-mounted as a file path.
  */
 export function parseDockerContextSocket(json: string): string | null {
   let parsed: unknown;
@@ -84,29 +85,29 @@ export function parseDockerContextSocket(json: string): string | null {
   } catch {
     return null;
   }
-  // `docker context inspect` levert een array; één context is één element.
+  // `docker context inspect` returns an array; one context is one element.
   const entry = Array.isArray(parsed) ? parsed[0] : parsed;
   const host = (entry as { Endpoints?: { docker?: { Host?: unknown } } } | null | undefined)
     ?.Endpoints?.docker?.Host;
   if (typeof host !== 'string' || !host.startsWith('unix://')) return null;
   const path = host.slice('unix://'.length);
   if (!path.startsWith('/')) return null;
-  // Het teruggegeven pad wordt later ONgequote in een `docker run -v <pad>:...`
-  // shell-commando geïnterpoleerd (init.ts). De `Host` uit `docker context
-  // inspect` is beïnvloedbaar (wie een docker-context kan aanmaken/activeren
-  // bepaalt de waarde), dus laat alleen tekens toe die in een echt socketpad
-  // voorkomen. Zo kan een gemanipuleerde context geen shell-metatekens
-  // ($(), backticks, ;, |, spaties, ...) binnensmokkelen — command injection.
+  // The returned path is later interpolated UNquoted into a `docker run -v
+  // <path>:...` shell command (init.ts). The `Host` from `docker context
+  // inspect` is attacker-influenceable (whoever can create/activate a docker
+  // context controls the value), so only allow characters that occur in a real
+  // socket path. This way a manipulated context cannot smuggle in shell
+  // metacharacters ($(), backticks, ;, |, spaces, ...) — command injection.
   if (!/^[A-Za-z0-9._/-]+$/.test(path)) return null;
   return path;
 }
 
-/** Herkent het socketpad van Rancher Desktop (dockerd/moby-modus): `~/.rd/docker.sock`. */
+/** Recognizes the Rancher Desktop socket path (dockerd/moby mode): `~/.rd/docker.sock`. */
 export function isRancherDesktopSocket(socketPath: string | null | undefined): boolean {
   return typeof socketPath === 'string' && /(^|\/)\.rd\/docker\.sock$/.test(socketPath);
 }
 
-/** Socketpad van de actieve docker-context, of undefined als het niet op te vragen is. */
+/** Socket path of the active docker context, or undefined if it cannot be queried. */
 function dockerContextSocket(): string | undefined {
   const json = commandOutput('docker context inspect');
   if (!json) return undefined;
@@ -114,9 +115,9 @@ function dockerContextSocket(): string | undefined {
 }
 
 function podmanIsRemote(): boolean {
-  // Op macOS/Windows draait Podman altijd in een `podman machine`-VM; ook op
-  // Linux kan de client op een remote socket wijzen. `ServiceIsRemote` is de
-  // gezaghebbende bron.
+  // On macOS/Windows Podman always runs in a `podman machine` VM; on Linux too
+  // the client can point at a remote socket. `ServiceIsRemote` is the
+  // authoritative source.
   return commandOutput(`podman info --format "{{.Host.ServiceIsRemote}}"`) === 'true';
 }
 
@@ -130,20 +131,20 @@ function buildRuntime(name: RuntimeName): ContainerRuntime {
       securityOpts: ['label=disable'],
     };
   }
-  // Rancher Desktop (dockerd/moby-modus) ziet er als een gewone Docker-engine
-  // uit, maar de socket zit niet op /var/run/docker.sock: de actieve
-  // docker-context wijst naar `~/.rd/docker.sock`. Volg die context zodat we de
-  // juiste socket bind-mounten; anders vallen we terug op de standaardlocatie
-  // (echte native Docker, Docker Desktop). Rancher Desktop draait de engine op
-  // ELK platform in een VM (Lima/WSL), dus is hij altijd 'remote'.
+  // Rancher Desktop (dockerd/moby mode) looks like an ordinary Docker engine,
+  // but the socket is not at /var/run/docker.sock: the active docker context
+  // points to `~/.rd/docker.sock`. Follow that context so we bind-mount the
+  // correct socket; otherwise we fall back to the default location (real native
+  // Docker, Docker Desktop). Rancher Desktop runs the engine in a VM (Lima/WSL)
+  // on EVERY platform, so it is always 'remote'.
   const contextSocket = dockerContextSocket();
   const isRancher = isRancherDesktopSocket(contextSocket);
   return {
     name,
     socketPath: isRancher ? contextSocket! : dockerSocketPath(),
     defaultNetwork: 'bridge',
-    // Docker Desktop (macOS/Windows) en Rancher Desktop draaien in een VM;
-    // native Docker op Linux niet.
+    // Docker Desktop (macOS/Windows) and Rancher Desktop run in a VM; native
+    // Docker on Linux does not.
     isRemote: isRancher || process.platform !== 'linux',
     securityOpts: [],
   };
@@ -170,9 +171,9 @@ export function resolveRuntime(explicit?: string): ContainerRuntime {
     return buildRuntime(name);
   }
 
-  // Auto-detectie: kijk eerst achter het `docker`-commando (dat een Podman-shim
-  // kan zijn), daarna naar `podman`. Zo wint een echte Docker-engine als die er
-  // is, maar herkennen we Podman ook als het zich als `docker` voordoet.
+  // Auto-detection: first look behind the `docker` command (which may be a
+  // Podman shim), then at `podman`. This way a real Docker engine wins if there
+  // is one, but we also recognize Podman when it poses as `docker`.
   const detected = detectEngine('docker') ?? detectEngine('podman');
   if (detected) return buildRuntime(detected);
 

--- a/cli/src/runtime.ts
+++ b/cli/src/runtime.ts
@@ -92,13 +92,14 @@ export function parseDockerContextSocket(json: string): string | null {
   if (typeof host !== 'string' || !host.startsWith('unix://')) return null;
   const path = host.slice('unix://'.length);
   if (!path.startsWith('/')) return null;
-  // The returned path is later interpolated UNquoted into a `docker run -v
-  // <path>:...` shell command (init.ts). The `Host` from `docker context
+  // The returned path is interpolated into a `docker run -v "<path>:..."` shell
+  // command (init.ts), where it is DOUBLE-QUOTED. The `Host` from `docker context
   // inspect` is attacker-influenceable (whoever can create/activate a docker
-  // context controls the value), so only allow characters that occur in a real
-  // socket path. This way a manipulated context cannot smuggle in shell
-  // metacharacters ($(), backticks, ;, |, spaces, ...) — command injection.
-  if (!/^[A-Za-z0-9._/-]+$/.test(path)) return null;
+  // context controls the value), so restrict it to characters that occur in a real
+  // socket path: allow spaces (legal in e.g. macOS `/Users/First Last/.rd/...`)
+  // but never the metacharacters that stay dangerous inside double quotes
+  // ($, backtick, ", \) or the command separators (;, |, &, (), newline).
+  if (!/^[A-Za-z0-9._/ -]+$/.test(path)) return null;
   return path;
 }
 

--- a/gateway/test/rancher-desktop-socket.test.ts
+++ b/gateway/test/rancher-desktop-socket.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect } from 'vitest';
 
-// De pure helpers voor Rancher Desktop-detectie wonen in de CLI (cli/src/
-// runtime.ts), maar de CLI heeft geen eigen test-runner. Gateway draait vitest
-// (en dat is wat CI uitvoert), dus testen we het parsen hier. Alleen zuivere
-// functies zonder daemon-afhankelijkheid — geen live docker nodig.
+// The pure helpers for Rancher Desktop detection live in the CLI (cli/src/
+// runtime.ts), but the CLI has no test runner of its own. Gateway runs vitest
+// (and that is what CI executes), so we test the parsing here. Only pure
+// functions without a daemon dependency — no live docker needed.
 import { parseDockerContextSocket, isRancherDesktopSocket } from '../../cli/src/runtime';
 
 describe('parseDockerContextSocket (#81)', () => {
-  it('haalt het unix-socketpad uit de rancher-desktop context', () => {
+  it('extracts the unix socket path from the rancher-desktop context', () => {
     const json = JSON.stringify([
       {
         Name: 'rancher-desktop',
@@ -17,41 +17,41 @@ describe('parseDockerContextSocket (#81)', () => {
     expect(parseDockerContextSocket(json)).toBe('/home/toon/.rd/docker.sock');
   });
 
-  it('haalt het pad ook uit de standaard docker-context', () => {
+  it('also extracts the path from the default docker context', () => {
     const json = JSON.stringify([
       { Name: 'default', Endpoints: { docker: { Host: 'unix:///var/run/docker.sock' } } },
     ]);
     expect(parseDockerContextSocket(json)).toBe('/var/run/docker.sock');
   });
 
-  it('accepteert ook een enkel object i.p.v. een array', () => {
+  it('also accepts a single object instead of an array', () => {
     const json = JSON.stringify({ Endpoints: { docker: { Host: 'unix:///run/user/1000/docker.sock' } } });
     expect(parseDockerContextSocket(json)).toBe('/run/user/1000/docker.sock');
   });
 
-  it('geeft null voor een niet-unix endpoint (Windows npipe)', () => {
+  it('returns null for a non-unix endpoint (Windows npipe)', () => {
     const json = JSON.stringify([
       { Endpoints: { docker: { Host: 'npipe:////./pipe/docker_engine' } } },
     ]);
     expect(parseDockerContextSocket(json)).toBeNull();
   });
 
-  it('geeft null voor een remote tcp/ssh endpoint', () => {
+  it('returns null for a remote tcp/ssh endpoint', () => {
     const json = JSON.stringify([{ Endpoints: { docker: { Host: 'tcp://1.2.3.4:2375' } } }]);
     expect(parseDockerContextSocket(json)).toBeNull();
   });
 
-  it('geeft null bij onparsebare of onvolledige JSON', () => {
+  it('returns null for unparsable or incomplete JSON', () => {
     expect(parseDockerContextSocket('not json')).toBeNull();
     expect(parseDockerContextSocket('[]')).toBeNull();
     expect(parseDockerContextSocket('[{}]')).toBeNull();
     expect(parseDockerContextSocket(JSON.stringify([{ Endpoints: {} }]))).toBeNull();
   });
 
-  // Regressie (#81, security): het pad belandt ONgequote in een `docker run -v
-  // <pad>:...` shell-commando. Een beïnvloedbare docker-context mag geen
-  // shell-metatekens kunnen binnensmokkelen -> command injection.
-  it('weigert paden met shell-metatekens (command injection)', () => {
+  // Regression (#81, security): the path ends up UNquoted in a `docker run -v
+  // <path>:...` shell command. An attacker-influenceable docker context must
+  // not be able to smuggle in shell metacharacters -> command injection.
+  it('rejects paths with shell metacharacters (command injection)', () => {
     const payloads = [
       'unix:///tmp/$(touch /tmp/pwned)/.rd/docker.sock',
       'unix:///tmp/`id`/.rd/docker.sock',
@@ -68,7 +68,7 @@ describe('parseDockerContextSocket (#81)', () => {
     }
   });
 
-  it('laat gewone (veilige) absolute socketpaden ongemoeid', () => {
+  it('leaves ordinary (safe) absolute socket paths untouched', () => {
     const json = JSON.stringify([
       { Endpoints: { docker: { Host: 'unix:///home/toon/.rd/docker.sock' } } },
     ]);
@@ -77,12 +77,12 @@ describe('parseDockerContextSocket (#81)', () => {
 });
 
 describe('isRancherDesktopSocket (#81)', () => {
-  it('herkent het rancher-desktop socketpad', () => {
+  it('recognizes the rancher-desktop socket path', () => {
     expect(isRancherDesktopSocket('/home/toon/.rd/docker.sock')).toBe(true);
     expect(isRancherDesktopSocket('/Users/toon/.rd/docker.sock')).toBe(true);
   });
 
-  it('herkent gewone docker-sockets niet als Rancher Desktop', () => {
+  it('does not recognize ordinary docker sockets as Rancher Desktop', () => {
     expect(isRancherDesktopSocket('/var/run/docker.sock')).toBe(false);
     expect(isRancherDesktopSocket('/run/user/1000/docker.sock')).toBe(false);
     expect(isRancherDesktopSocket(undefined)).toBe(false);

--- a/gateway/test/rancher-desktop-socket.test.ts
+++ b/gateway/test/rancher-desktop-socket.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+
+// De pure helpers voor Rancher Desktop-detectie wonen in de CLI (cli/src/
+// runtime.ts), maar de CLI heeft geen eigen test-runner. Gateway draait vitest
+// (en dat is wat CI uitvoert), dus testen we het parsen hier. Alleen zuivere
+// functies zonder daemon-afhankelijkheid — geen live docker nodig.
+import { parseDockerContextSocket, isRancherDesktopSocket } from '../../cli/src/runtime';
+
+describe('parseDockerContextSocket (#81)', () => {
+  it('haalt het unix-socketpad uit de rancher-desktop context', () => {
+    const json = JSON.stringify([
+      {
+        Name: 'rancher-desktop',
+        Endpoints: { docker: { Host: 'unix:///home/toon/.rd/docker.sock', SkipTLSVerify: false } },
+      },
+    ]);
+    expect(parseDockerContextSocket(json)).toBe('/home/toon/.rd/docker.sock');
+  });
+
+  it('haalt het pad ook uit de standaard docker-context', () => {
+    const json = JSON.stringify([
+      { Name: 'default', Endpoints: { docker: { Host: 'unix:///var/run/docker.sock' } } },
+    ]);
+    expect(parseDockerContextSocket(json)).toBe('/var/run/docker.sock');
+  });
+
+  it('accepteert ook een enkel object i.p.v. een array', () => {
+    const json = JSON.stringify({ Endpoints: { docker: { Host: 'unix:///run/user/1000/docker.sock' } } });
+    expect(parseDockerContextSocket(json)).toBe('/run/user/1000/docker.sock');
+  });
+
+  it('geeft null voor een niet-unix endpoint (Windows npipe)', () => {
+    const json = JSON.stringify([
+      { Endpoints: { docker: { Host: 'npipe:////./pipe/docker_engine' } } },
+    ]);
+    expect(parseDockerContextSocket(json)).toBeNull();
+  });
+
+  it('geeft null voor een remote tcp/ssh endpoint', () => {
+    const json = JSON.stringify([{ Endpoints: { docker: { Host: 'tcp://1.2.3.4:2375' } } }]);
+    expect(parseDockerContextSocket(json)).toBeNull();
+  });
+
+  it('geeft null bij onparsebare of onvolledige JSON', () => {
+    expect(parseDockerContextSocket('not json')).toBeNull();
+    expect(parseDockerContextSocket('[]')).toBeNull();
+    expect(parseDockerContextSocket('[{}]')).toBeNull();
+    expect(parseDockerContextSocket(JSON.stringify([{ Endpoints: {} }]))).toBeNull();
+  });
+});
+
+describe('isRancherDesktopSocket (#81)', () => {
+  it('herkent het rancher-desktop socketpad', () => {
+    expect(isRancherDesktopSocket('/home/toon/.rd/docker.sock')).toBe(true);
+    expect(isRancherDesktopSocket('/Users/toon/.rd/docker.sock')).toBe(true);
+  });
+
+  it('herkent gewone docker-sockets niet als Rancher Desktop', () => {
+    expect(isRancherDesktopSocket('/var/run/docker.sock')).toBe(false);
+    expect(isRancherDesktopSocket('/run/user/1000/docker.sock')).toBe(false);
+    expect(isRancherDesktopSocket(undefined)).toBe(false);
+    expect(isRancherDesktopSocket(null)).toBe(false);
+  });
+});

--- a/gateway/test/rancher-desktop-socket.test.ts
+++ b/gateway/test/rancher-desktop-socket.test.ts
@@ -48,9 +48,10 @@ describe('parseDockerContextSocket (#81)', () => {
     expect(parseDockerContextSocket(JSON.stringify([{ Endpoints: {} }]))).toBeNull();
   });
 
-  // Regression (#81, security): the path ends up UNquoted in a `docker run -v
-  // <path>:...` shell command. An attacker-influenceable docker context must
-  // not be able to smuggle in shell metacharacters -> command injection.
+  // Regression (#81, security): the path is interpolated into a `docker run -v
+  // "<path>:..."` shell command where it is double-quoted. An attacker-influenceable
+  // docker context must not smuggle in metacharacters that stay active inside double
+  // quotes ($, backtick, \) or command separators -> command injection.
   it('rejects paths with shell metacharacters (command injection)', () => {
     const payloads = [
       'unix:///tmp/$(touch /tmp/pwned)/.rd/docker.sock',
@@ -59,13 +60,21 @@ describe('parseDockerContextSocket (#81)', () => {
       'unix:///tmp/x|nc evil 1/.rd/docker.sock',
       'unix:///tmp/x && curl evil/.rd/docker.sock',
       'unix:///tmp/x\n/.rd/docker.sock',
-      'unix:///home/a b/.rd/docker.sock',
       'unix:///tmp/$HOME/.rd/docker.sock',
+      'unix:///tmp/x"y/.rd/docker.sock',
+      'unix:///tmp/x\\y/.rd/docker.sock',
     ];
     for (const host of payloads) {
       const json = JSON.stringify([{ Endpoints: { docker: { Host: host } } }]);
       expect(parseDockerContextSocket(json), host).toBeNull();
     }
+  });
+
+  it('accepts a path with spaces (legal home dir, e.g. macOS) — it is double-quoted at the sink', () => {
+    const json = JSON.stringify([
+      { Endpoints: { docker: { Host: 'unix:///Users/First Last/.rd/docker.sock' } } },
+    ]);
+    expect(parseDockerContextSocket(json)).toBe('/Users/First Last/.rd/docker.sock');
   });
 
   it('leaves ordinary (safe) absolute socket paths untouched', () => {

--- a/gateway/test/rancher-desktop-socket.test.ts
+++ b/gateway/test/rancher-desktop-socket.test.ts
@@ -47,6 +47,33 @@ describe('parseDockerContextSocket (#81)', () => {
     expect(parseDockerContextSocket('[{}]')).toBeNull();
     expect(parseDockerContextSocket(JSON.stringify([{ Endpoints: {} }]))).toBeNull();
   });
+
+  // Regressie (#81, security): het pad belandt ONgequote in een `docker run -v
+  // <pad>:...` shell-commando. Een beïnvloedbare docker-context mag geen
+  // shell-metatekens kunnen binnensmokkelen -> command injection.
+  it('weigert paden met shell-metatekens (command injection)', () => {
+    const payloads = [
+      'unix:///tmp/$(touch /tmp/pwned)/.rd/docker.sock',
+      'unix:///tmp/`id`/.rd/docker.sock',
+      'unix:///tmp/x;rm -rf ~/.rd/docker.sock',
+      'unix:///tmp/x|nc evil 1/.rd/docker.sock',
+      'unix:///tmp/x && curl evil/.rd/docker.sock',
+      'unix:///tmp/x\n/.rd/docker.sock',
+      'unix:///home/a b/.rd/docker.sock',
+      'unix:///tmp/$HOME/.rd/docker.sock',
+    ];
+    for (const host of payloads) {
+      const json = JSON.stringify([{ Endpoints: { docker: { Host: host } } }]);
+      expect(parseDockerContextSocket(json), host).toBeNull();
+    }
+  });
+
+  it('laat gewone (veilige) absolute socketpaden ongemoeid', () => {
+    const json = JSON.stringify([
+      { Endpoints: { docker: { Host: 'unix:///home/toon/.rd/docker.sock' } } },
+    ]);
+    expect(parseDockerContextSocket(json)).toBe('/home/toon/.rd/docker.sock');
+  });
 });
 
 describe('isRancherDesktopSocket (#81)', () => {


### PR DESCRIPTION
Rancher Desktop in dockerd (moby) mode exposes its socket at `~/.rd/docker.sock` instead of `/var/run/docker.sock`. `resolveRuntime` now reads the active `docker context inspect` endpoint and, when it points at a Rancher Desktop socket, mounts that path and marks the engine as remote (it runs in a VM on every OS). Native Docker / Docker Desktop fall back to the default socket; Podman detection is unchanged.

- Pure helpers `parseDockerContextSocket` / `isRancherDesktopSocket` with vitest unit tests (in `gateway/test`, where the repo's test runner and CI live)
- README updated: Getting Started, FAQ and Troubleshooting cover Rancher Desktop

Closes #81