### PR TITLE
fix(proxy): proxy WebSocket upgrades through MITM and plain-HTTP paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Two servers run in the same process:
 - Containers can *request* access; operators approve or reject via the UI
 - HTTP: full request/response logged in the network log
 - HTTPS: tunneled through CONNECT (contents not intercepted)
+- WebSocket: `ws://` and `wss://` upgrades are transparently proxied and subject to the same firewall rules (host and path) as regular requests — so tools like the OpenAI Codex CLI connect without falling back to slow HTTPS retries
 
 ### Docker Socket Proxy
 - Every devcontainer gets its own Unix socket at `/tmp/dc-sockets/<name>/docker.sock`; the per-container *directory* is mounted into the container (at `/var/run/huddle`) and `DOCKER_HOST` points to the socket. A file mount of the socket itself would keep seeing the dead old inode after a Huddle restart; a directory mount does not. The old flat path `/tmp/dc-sockets/<name>.sock` remains as a symlink for containers created before this change.

--- a/gateway/src/proxy.ts
+++ b/gateway/src/proxy.ts
@@ -111,6 +111,17 @@ function rejectSocket(socket: stream.Duplex, status: number, blockStatus: string
 // then we reconstruct the handshake response byte-for-byte back to the client
 // (rawHeaders preserves exact casing + order of Sec-WebSocket-Accept etc.) and
 // connect both sockets. Every Upgrade is thus forwarded transparently.
+// Reconstruct an HTTP status line + headers byte-for-byte from an upstream
+// response, preserving exact header casing/order (rawHeaders). Shared by the
+// 101-handshake relay and the non-101 response relay in forwardUpgrade.
+function formatHttpHead(res: http.IncomingMessage): string {
+  const lines = [`HTTP/1.1 ${res.statusCode} ${res.statusMessage}`];
+  for (let i = 0; i < res.rawHeaders.length; i += 2) {
+    lines.push(`${res.rawHeaders[i]}: ${res.rawHeaders[i + 1]}`);
+  }
+  return lines.join('\r\n') + '\r\n\r\n';
+}
+
 function forwardUpgrade(
   secure: boolean,
   options: https.RequestOptions,
@@ -157,19 +168,15 @@ function forwardUpgrade(
   upstreamReq.on('upgrade', (upstreamRes, upstreamSocket, upstreamHead) => {
     clearHandshakeTimer();
     // Reconstruct the 101 handshake byte-for-byte back to the client.
-    const lines = [`HTTP/1.1 ${upstreamRes.statusCode} ${upstreamRes.statusMessage}`];
-    for (let i = 0; i < upstreamRes.rawHeaders.length; i += 2) {
-      lines.push(`${upstreamRes.rawHeaders[i]}: ${upstreamRes.rawHeaders[i + 1]}`);
-    }
     try {
-      clientSocket.write(lines.join('\r\n') + '\r\n\r\n');
-      if (upstreamHead && upstreamHead.length) clientSocket.write(upstreamHead);
+      clientSocket.write(formatHttpHead(upstreamRes));
+      if (upstreamHead.length) clientSocket.write(upstreamHead);
     } catch {
       try { upstreamSocket.destroy(); } catch { /* best-effort: peer socket may already be closed */ }
       return;
     }
     // Bytes the client already sent after its handshake: forward them first, then pipe.
-    if (clientHead && clientHead.length) upstreamSocket.write(clientHead);
+    if (clientHead.length) upstreamSocket.write(clientHead);
     upstreamSocket.pipe(clientSocket);
     clientSocket.pipe(upstreamSocket);
     const teardown = () => {
@@ -186,11 +193,7 @@ function forwardUpgrade(
   // back to the client and close — fail-closed with respect to the tunnel.
   upstreamReq.on('response', (upstreamRes) => {
     clearHandshakeTimer();
-    const lines = [`HTTP/1.1 ${upstreamRes.statusCode} ${upstreamRes.statusMessage}`];
-    for (let i = 0; i < upstreamRes.rawHeaders.length; i += 2) {
-      lines.push(`${upstreamRes.rawHeaders[i]}: ${upstreamRes.rawHeaders[i + 1]}`);
-    }
-    try { clientSocket.write(lines.join('\r\n') + '\r\n\r\n'); } catch { /* best-effort: peer socket may already be closed */ }
+    try { clientSocket.write(formatHttpHead(upstreamRes)); } catch { /* best-effort: peer socket may already be closed */ }
     upstreamRes.on('data', (c: Buffer) => { try { clientSocket.write(c); } catch { /* best-effort: peer socket may already be closed */ } });
     upstreamRes.on('end', () => { try { clientSocket.end(); } catch { /* best-effort: peer socket may already be closed */ } });
     upstreamRes.on('error', () => { try { clientSocket.destroy(); } catch { /* best-effort: peer socket may already be closed */ } });
@@ -245,7 +248,8 @@ function handleTokenExchangeResponse(
         // 'unknown' fallback anymore. A null container yields a non-redeemable
         // placeholder (fail-closed).
         json.access_token = storeTokenExchange(containerId, json.access_token as string);
-        console.log(`[token-exchange] placeholder issued for container ${containerId}`);
+        // (No log line here: the audit entry below already records that an
+        // exchange happened, with the placeholder value redacted.)
         outBuf = Buffer.from(JSON.stringify(json));
         delete outHeaders['content-encoding'];
         delete outHeaders['transfer-encoding'];

--- a/gateway/src/proxy.ts
+++ b/gateway/src/proxy.ts
@@ -123,7 +123,7 @@ function forwardUpgrade(
     // ERR_UNESCAPED_CHARACTERS): fail per handshake, not per process.
     upstreamReq = secure ? https.request(options) : http.request(options);
   } catch {
-    try { clientSocket.destroy(); } catch {}
+    try { clientSocket.destroy(); } catch { /* best-effort: peer socket may already be closed */ }
     return;
   }
 
@@ -140,8 +140,8 @@ function forwardUpgrade(
   // connected socket (it can linger in the agent pool) — so also destroy
   // upstreamReq.socket explicitly, otherwise the outgoing gateway socket leaks.
   const destroyUpstream = () => {
-    try { upstreamReq.socket?.destroy(); } catch {}
-    try { upstreamReq.destroy(); } catch {}
+    try { upstreamReq.socket?.destroy(); } catch { /* best-effort: peer socket may already be closed */ }
+    try { upstreamReq.destroy(); } catch { /* best-effort: peer socket may already be closed */ }
   };
   const timeoutMs = Number(process.env.WS_UPGRADE_TIMEOUT_MS) || 30_000;
   let settled = false;
@@ -149,7 +149,7 @@ function forwardUpgrade(
     if (settled) return;
     settled = true;
     destroyUpstream();
-    try { clientSocket.destroy(); } catch {}
+    try { clientSocket.destroy(); } catch { /* best-effort: peer socket may already be closed */ }
   }, timeoutMs);
   handshakeTimer.unref?.();
   const clearHandshakeTimer = () => { settled = true; clearTimeout(handshakeTimer); };
@@ -165,7 +165,7 @@ function forwardUpgrade(
       clientSocket.write(lines.join('\r\n') + '\r\n\r\n');
       if (upstreamHead && upstreamHead.length) clientSocket.write(upstreamHead);
     } catch {
-      try { upstreamSocket.destroy(); } catch {}
+      try { upstreamSocket.destroy(); } catch { /* best-effort: peer socket may already be closed */ }
       return;
     }
     // Bytes the client already sent after its handshake: forward them first, then pipe.
@@ -173,13 +173,13 @@ function forwardUpgrade(
     upstreamSocket.pipe(clientSocket);
     clientSocket.pipe(upstreamSocket);
     const teardown = () => {
-      try { upstreamSocket.destroy(); } catch {}
-      try { clientSocket.destroy(); } catch {}
+      try { upstreamSocket.destroy(); } catch { /* best-effort: peer socket may already be closed */ }
+      try { clientSocket.destroy(); } catch { /* best-effort: peer socket may already be closed */ }
     };
     upstreamSocket.on('error', teardown);
     clientSocket.on('error', teardown);
-    upstreamSocket.on('close', () => { try { clientSocket.destroy(); } catch {} });
-    clientSocket.on('close', () => { try { upstreamSocket.destroy(); } catch {} });
+    upstreamSocket.on('close', () => { try { clientSocket.destroy(); } catch { /* best-effort: peer socket may already be closed */ } });
+    clientSocket.on('close', () => { try { upstreamSocket.destroy(); } catch { /* best-effort: peer socket may already be closed */ } });
   });
 
   // Upstream did not honor the upgrade (no 101): relay the regular response
@@ -190,13 +190,13 @@ function forwardUpgrade(
     for (let i = 0; i < upstreamRes.rawHeaders.length; i += 2) {
       lines.push(`${upstreamRes.rawHeaders[i]}: ${upstreamRes.rawHeaders[i + 1]}`);
     }
-    try { clientSocket.write(lines.join('\r\n') + '\r\n\r\n'); } catch {}
-    upstreamRes.on('data', (c: Buffer) => { try { clientSocket.write(c); } catch {} });
-    upstreamRes.on('end', () => { try { clientSocket.end(); } catch {} });
-    upstreamRes.on('error', () => { try { clientSocket.destroy(); } catch {} });
+    try { clientSocket.write(lines.join('\r\n') + '\r\n\r\n'); } catch { /* best-effort: peer socket may already be closed */ }
+    upstreamRes.on('data', (c: Buffer) => { try { clientSocket.write(c); } catch { /* best-effort: peer socket may already be closed */ } });
+    upstreamRes.on('end', () => { try { clientSocket.end(); } catch { /* best-effort: peer socket may already be closed */ } });
+    upstreamRes.on('error', () => { try { clientSocket.destroy(); } catch { /* best-effort: peer socket may already be closed */ } });
   });
 
-  upstreamReq.on('error', () => { clearHandshakeTimer(); try { clientSocket.destroy(); } catch {} });
+  upstreamReq.on('error', () => { clearHandshakeTimer(); try { clientSocket.destroy(); } catch { /* best-effort: peer socket may already be closed */ } });
   clientSocket.on('error', () => { clearHandshakeTimer(); destroyUpstream(); });
   upstreamReq.end();
 }
@@ -624,7 +624,7 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
       if (err.code !== 'ECONNRESET') {
         console.warn(`[proxy-mitm] inner TLS error (${hostname}):`, err.message);
       }
-      try { clientSocket.destroy(); } catch {}
+      try { clientSocket.destroy(); } catch { /* best-effort: peer socket may already be closed */ }
     });
     if (head && head.length) innerTls.unshift(head);
 
@@ -784,7 +784,7 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
           try {
             innerRes.writeHead(502, { 'content-type': 'application/json' });
             innerRes.end(JSON.stringify({ error: 'bad_gateway', message: err.message }));
-          } catch {}
+          } catch { /* best-effort: peer socket may already be closed */ }
         }
         complete(502);
       });
@@ -857,11 +857,11 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
         innerHead,
       );
     });
-    innerHttp.on('clientError', (_err, sock) => { try { sock.destroy(); } catch {} });
+    innerHttp.on('clientError', (_err, sock) => { try { sock.destroy(); } catch { /* best-effort: peer socket may already be closed */ } });
 
     innerHttp.emit('connection', innerTls);
 
-    clientSocket.on('close', () => { try { innerTls.destroy(); } catch {} });
+    clientSocket.on('close', () => { try { innerTls.destroy(); } catch { /* best-effort: peer socket may already be closed */ } });
   });
 
   server.listen(port, () => {

--- a/gateway/src/proxy.ts
+++ b/gateway/src/proxy.ts
@@ -13,8 +13,8 @@ import { storeTokenExchange, resolveToken, isPlaceholderToken } from './token-ex
 
 const PROXY_PORT = 80;
 
-// Domains die de MITM overslaan (raw TCP-tunnel houden). Voor clients met
-// cert-pinning (npm registry, sommige Java libs) is MITM een breaker.
+// Domains that skip the MITM (keep a raw TCP tunnel). For clients with
+// cert-pinning (npm registry, some Java libs) MITM is a breaker.
 const NO_INTERCEPT_DOMAINS: Set<string> = new Set(
   (process.env.NO_INTERCEPT_DOMAINS ?? '')
     .split(',')
@@ -47,7 +47,7 @@ function decodeBody(chunks: Buffer[], headers: http.IncomingHttpHeaders): string
     else decoded = buf;
     return cap(decoded.toString('utf8'));
   } catch {
-    return '[binary / niet decodeerbaar]';
+    return '[binary / not decodable]';
   }
 }
 
@@ -103,14 +103,14 @@ function rejectSocket(socket: stream.Duplex, status: number, blockStatus: string
   socket.end();
 }
 
-// Forward een HTTP Upgrade-handshake (WebSocket `ws://`/`wss://`, maar ook elke
-// andere Upgrade) naar upstream en pipe daarna de rauwe bytes in beide
-// richtingen. `secure` kiest tussen http.request (plain, ná plain-HTTP-pad) en
-// https.request (TLS, ná MITM-terminatie). We gebruiken bewust de laagste laag:
-// Node emit't 'upgrade' op de ClientRequest zodra upstream met 101 antwoordt;
-// dan reconstrueren we de handshake-response byte-voor-byte terug naar de client
-// (rawHeaders behoudt exacte casing + volgorde van Sec-WebSocket-Accept e.d.) en
-// verbinden we beide sockets. Elke Upgrade wordt zo transparant doorgezet.
+// Forward an HTTP Upgrade handshake (WebSocket `ws://`/`wss://`, but also any
+// other Upgrade) to upstream and then pipe the raw bytes in both
+// directions. `secure` chooses between http.request (plain, after the plain-HTTP path) and
+// https.request (TLS, after MITM termination). We deliberately use the lowest layer:
+// Node emits 'upgrade' on the ClientRequest as soon as upstream answers with 101;
+// then we reconstruct the handshake response byte-for-byte back to the client
+// (rawHeaders preserves exact casing + order of Sec-WebSocket-Accept etc.) and
+// connect both sockets. Every Upgrade is thus forwarded transparently.
 function forwardUpgrade(
   secure: boolean,
   options: https.RequestOptions,
@@ -119,26 +119,26 @@ function forwardUpgrade(
 ): void {
   let upstreamReq: http.ClientRequest;
   try {
-    // Zelfde synchrone-throw-risico als tryCreateUpstreamRequest (bv.
-    // ERR_UNESCAPED_CHARACTERS): fail per handshake, niet per proces.
+    // Same synchronous-throw risk as tryCreateUpstreamRequest (e.g.
+    // ERR_UNESCAPED_CHARACTERS): fail per handshake, not per process.
     upstreamReq = secure ? https.request(options) : http.request(options);
   } catch {
     try { clientSocket.destroy(); } catch {}
     return;
   }
 
-  // Handshake-timeout: een upstream die de TCP-verbinding wél accepteert maar de
-  // upgrade nooit afrondt (stalled/slowloris, of een SYN die in een blackhole
-  // verdwijnt) houdt anders zowel de client- als de upstream-socket onbeperkt
-  // open. Node's server-/headersTimeout gelden NIET meer op een ge-hijackte
-  // upgrade-socket, dus zonder deze backstop kan een devcontainer met één
-  // toegestane host ongelimiteerd half-open handshakes opstapelen en de FD's van
-  // de gedeelde gateway uitputten (DoS). We bewaken uitsluitend de handshake-
-  // fase; zodra upstream 101/response geeft wissen we de timer, zodat legitieme
-  // langlevende WebSockets nooit afgekapt worden.
-  // upstreamReq.destroy() aborteert de request maar sluit de reeds verbonden
-  // socket niet altijd (die kan in de agent-pool blijven hangen) — destroy dus
-  // ook expliciet upstreamReq.socket, anders leakt de uitgaande gateway-socket.
+  // Handshake timeout: an upstream that does accept the TCP connection but
+  // never completes the upgrade (stalled/slowloris, or a SYN that disappears
+  // into a blackhole) otherwise keeps both the client and the upstream socket
+  // open indefinitely. Node's server-/headersTimeout no longer apply on a hijacked
+  // upgrade socket, so without this backstop a devcontainer with a single
+  // allowed host can pile up unlimited half-open handshakes and exhaust the FDs of
+  // the shared gateway (DoS). We guard only the handshake
+  // phase; as soon as upstream gives 101/response we clear the timer, so legitimate
+  // long-lived WebSockets are never cut off.
+  // upstreamReq.destroy() aborts the request but does not always close the already
+  // connected socket (it can linger in the agent pool) — so also destroy
+  // upstreamReq.socket explicitly, otherwise the outgoing gateway socket leaks.
   const destroyUpstream = () => {
     try { upstreamReq.socket?.destroy(); } catch {}
     try { upstreamReq.destroy(); } catch {}
@@ -156,7 +156,7 @@ function forwardUpgrade(
 
   upstreamReq.on('upgrade', (upstreamRes, upstreamSocket, upstreamHead) => {
     clearHandshakeTimer();
-    // Reconstrueer de 101-handshake byte-voor-byte terug naar de client.
+    // Reconstruct the 101 handshake byte-for-byte back to the client.
     const lines = [`HTTP/1.1 ${upstreamRes.statusCode} ${upstreamRes.statusMessage}`];
     for (let i = 0; i < upstreamRes.rawHeaders.length; i += 2) {
       lines.push(`${upstreamRes.rawHeaders[i]}: ${upstreamRes.rawHeaders[i + 1]}`);
@@ -168,7 +168,7 @@ function forwardUpgrade(
       try { upstreamSocket.destroy(); } catch {}
       return;
     }
-    // Bytes die de client al ná zijn handshake stuurde eerst doorzetten, dán pipen.
+    // Bytes the client already sent after its handshake: forward them first, then pipe.
     if (clientHead && clientHead.length) upstreamSocket.write(clientHead);
     upstreamSocket.pipe(clientSocket);
     clientSocket.pipe(upstreamSocket);
@@ -182,8 +182,8 @@ function forwardUpgrade(
     clientSocket.on('close', () => { try { upstreamSocket.destroy(); } catch {} });
   });
 
-  // Upstream honoreerde de upgrade niet (geen 101): relay de gewone response
-  // terug naar de client en sluit — fail-closed t.o.v. de tunnel.
+  // Upstream did not honor the upgrade (no 101): relay the regular response
+  // back to the client and close — fail-closed with respect to the tunnel.
   upstreamReq.on('response', (upstreamRes) => {
     clearHandshakeTimer();
     const lines = [`HTTP/1.1 ${upstreamRes.statusCode} ${upstreamRes.statusMessage}`];
@@ -201,10 +201,10 @@ function forwardUpgrade(
   upstreamReq.end();
 }
 
-// Node valideert request-opties synchroon in de ClientRequest-constructor
-// (bv. ERR_UNESCAPED_CHARACTERS bij een ongeldige request-target). Zo'n throw
-// belandt anders in de uncaughtException-handler die het hele proces — en dus
-// élke huddle — neerhaalt. Fail per request (400), niet per proces.
+// Node validates request options synchronously in the ClientRequest constructor
+// (e.g. ERR_UNESCAPED_CHARACTERS on an invalid request-target). Otherwise such a throw
+// lands in the uncaughtException handler that takes down the whole process — and thus
+// every huddle. Fail per request (400), not per process.
 function tryCreateUpstreamRequest(
   create: () => http.ClientRequest,
   res: http.ServerResponse,
@@ -221,9 +221,9 @@ function tryCreateUpstreamRequest(
   }
 }
 
-// Buffers en scrubt de OAuth token-exchange response zodat het echte access_token
-// nooit in de audit-log terechtkomt. Stuurt de gescrubde response naar innerRes
-// en roept complete aan met de veilige audit-body als derde argument.
+// Buffers and scrubs the OAuth token-exchange response so the real access_token
+// never ends up in the audit log. Sends the scrubbed response to innerRes
+// and calls complete with the safe audit body as the third argument.
 function handleTokenExchangeResponse(
   upstreamRes: http.IncomingMessage,
   innerRes: http.ServerResponse,
@@ -235,24 +235,24 @@ function handleTokenExchangeResponse(
   upstreamRes.on('end', () => {
     let outBuf: Buffer;
     let outHeaders = { ...upstreamRes.headers };
-    // Fail-safe: log null bij scrub-fouten i.p.v. het echte token te lekken.
+    // Fail-safe: log null on scrub errors instead of leaking the real token.
     let auditResBody: string | null = null;
     try {
       const rawBody = decodeBody(chunks, upstreamRes.headers);
       const json = rawBody ? JSON.parse(rawBody) : null;
       if (json?.access_token) {
-        // Bind de placeholder aan de aanvragende container (finding #12); geen
-        // 'unknown'-fallback meer. Een null container levert een niet-inwissel-
-        // bare placeholder op (fail-closed).
+        // Bind the placeholder to the requesting container (finding #12); no
+        // 'unknown' fallback anymore. A null container yields a non-redeemable
+        // placeholder (fail-closed).
         json.access_token = storeTokenExchange(containerId, json.access_token as string);
-        console.log(`[token-exchange] placeholder issued voor container ${containerId}`);
+        console.log(`[token-exchange] placeholder issued for container ${containerId}`);
         outBuf = Buffer.from(JSON.stringify(json));
         delete outHeaders['content-encoding'];
         delete outHeaders['transfer-encoding'];
         outHeaders['content-length'] = String(outBuf.length);
-        // De placeholder is zelf een inwisselbare bearer-credential: redact hem
-        // uit de audit-body (finding #12) — de audit toont dat er een exchange
-        // was, niet de bruikbare waarde.
+        // The placeholder is itself a redeemable bearer credential: redact it
+        // from the audit body (finding #12) — the audit shows that an exchange
+        // happened, not the usable value.
         auditResBody = cap(JSON.stringify({ ...json, access_token: '<redacted-placeholder>' }));
       } else {
         outBuf = Buffer.concat(chunks);
@@ -273,13 +273,13 @@ function handleTokenExchangeResponse(
   });
 }
 
-// `port` is standaard de vaste proxypoort; tests binden op 0 (een vrije
-// efemere poort) zodat het pad-forwardgedrag hermetisch getest kan worden.
+// `port` defaults to the fixed proxy port; tests bind on 0 (a free
+// ephemeral port) so the path-forwarding behavior can be tested hermetically.
 export function createProxyServer(port: number = PROXY_PORT): http.Server {
   const server = http.createServer();
 
   server.on('request', async (req, res) => {
-    // Extension server-side fetch wordt geïdentificeerd via X-Huddle-Ext header
+    // Extension server-side fetch is identified via the X-Huddle-Ext header
     const extHeader = req.headers['x-huddle-ext'];
     const containerId = extHeader
       ? `ext:${String(extHeader).replace(/[^a-z0-9-]/g, '')}`
@@ -294,23 +294,23 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
       return;
     }
 
-    // Canoniseer de host één keer aan de rand naar de vorm waarop we matchen,
-    // loggen én dialen — zodat de gecontroleerde en de verstuurde host niet
-    // kunnen divergeren (parser-differential, finding #3 + staart).
+    // Canonicalize the host once at the edge into the form on which we match,
+    // log and dial — so the checked and the sent host cannot
+    // diverge (parser-differential, finding #3 + tail).
     const host = canonicalizeHost(target.hostname);
     if (host === null) {
       send502(res, 'invalid target host');
       return;
     }
 
-    // Beslis op de gedecodeerde vorm (normalizePathname, finding #7) maar
-    // forward de originele encoded bytes van de URL-parser. De gedecodeerde
-    // vorm is geen geldige request-target: rauwe spaties/UTF-8 laten
-    // http.request synchroon gooien (ERR_UNESCAPED_CHARACTERS → proces-crash),
-    // en de upstream zou hem een twééde keer decoden (double-decode-
-    // differential; verminkt bovendien legitieme %2F/%20). `new URL` heeft
-    // `../` al weggevouwen; normalizePathname dekt `%2f`-getruceerde traversal
-    // en weigert fail-closed — er bereiken dus nooit `..`-bytes de upstream.
+    // Decide on the decoded form (normalizePathname, finding #7) but
+    // forward the original encoded bytes from the URL parser. The decoded
+    // form is not a valid request-target: raw spaces/UTF-8 make
+    // http.request throw synchronously (ERR_UNESCAPED_CHARACTERS → process crash),
+    // and the upstream would decode it a second time (double-decode
+    // differential; also mangles legitimate %2F/%20). `new URL` has
+    // already folded away `../`; normalizePathname covers `%2f`-disguised traversal
+    // and rejects fail-closed — so `..` bytes never reach the upstream.
     const normPath = normalizePathname(target.pathname);
     if (normPath === null) {
       logAudit({
@@ -367,8 +367,8 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
     const resChunks: Buffer[] = [];
     let resBytes = 0;
 
-    // Zelfde in-flight-aanpak als het MITM-pad: log de request meteen, vul de
-    // response (en de volledige req_body) bij zodra upstream afrondt.
+    // Same in-flight approach as the MITM path: log the request immediately, fill in the
+    // response (and the full req_body) as soon as upstream completes.
     const auditId = logAudit({
       containerId,
       domain: host,
@@ -391,7 +391,7 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
       });
     };
 
-    // MCP-verkeer naar huddle altijd via de API-poort (3000), niet de proxypoort (80).
+    // MCP traffic to huddle always via the API port (3000), not the proxy port (80).
     const upstreamPort = target.port || 80;
 
     const upstream = tryCreateUpstreamRequest(() => http.request(
@@ -433,12 +433,12 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
     req.on('end', () => upstream.end());
   });
 
-  // WebSocket (`ws://`) over het plain-HTTP-pad: een forward-proxy-client stuurt
-  // de upgrade-handshake in absolute vorm (`GET http://host/pad`) met
-  // `Upgrade: websocket`. Node emit't die als 'upgrade' (niet 'request'); zonder
-  // deze handler zou Node de socket sluiten en de handshake time-outen. Zelfde
-  // firewall-handhaving als het request-pad: canoniseer de host, beslis op het
-  // genormaliseerde pad, forward de originele encoded bytes.
+  // WebSocket (`ws://`) over the plain-HTTP path: a forward-proxy client sends
+  // the upgrade handshake in absolute form (`GET http://host/path`) with
+  // `Upgrade: websocket`. Node emits it as 'upgrade' (not 'request'); without
+  // this handler Node would close the socket and time out the handshake. Same
+  // firewall enforcement as the request path: canonicalize the host, decide on the
+  // normalized path, forward the original encoded bytes.
   server.on('upgrade', async (req, clientSocket, head) => {
     const extHeader = req.headers['x-huddle-ext'];
     const containerId = extHeader
@@ -471,7 +471,7 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
     }
     const forwardPath = `${target.pathname}${target.search}`;
 
-    // Geen legitiem WebSocket-endpoint op huddle zelf → altijd fail-closed.
+    // No legitimate WebSocket endpoint on huddle itself → always fail-closed.
     if (host === 'huddle') {
       logAudit({
         containerId, domain: 'huddle', action: 'deny', ruleId: null,
@@ -514,11 +514,11 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
     const [rawHostname, portStr] = (req.url || '').split(':');
     const port = Number(portStr) || 443;
 
-    // Canoniseer de CONNECT-host op dezelfde manier als het plain-HTTP-pad
-    // (`new URL().hostname`) zodat beide paden op één canonieke vorm matchen,
-    // loggen, het cert genereren en dialen. Zonder dit omzeilde een
-    // ge-kapitaliseerde host (`GIST.GITHUB.COM`) een exacte deny-regel terwijl
-    // de wildcard-allow wél matchte (finding #3).
+    // Canonicalize the CONNECT host the same way as the plain-HTTP path
+    // (`new URL().hostname`) so both paths match, log, generate the cert and
+    // dial on a single canonical form. Without this a capitalized host
+    // (`GIST.GITHUB.COM`) would bypass an exact deny rule while
+    // the wildcard-allow did match (finding #3).
     const hostname = canonicalizeHost(rawHostname);
     if (!hostname) {
       rejectSocket(clientSocket, 400, 'deny', '', null);
@@ -540,10 +540,10 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
       return;
     }
     const { status, ruleId } = checkRule(hostname, containerId, null);
-    // Pad-allowlist domeinen staan op host-niveau dicht, maar de CONNECT-tunnel
-    // moet wél open zodat MITM ná TLS-terminatie het pad ziet en per request kan
-    // handhaven (zie de innerHttp-handler). Alleen zinvol als we kúnnen
-    // inspecteren: 443 + niet cert-pinned. Anders blijft het host-only dicht.
+    // Path-allowlist domains are closed at the host level, but the CONNECT tunnel
+    // must be open so that MITM sees the path after TLS termination and can enforce
+    // per request (see the innerHttp handler). Only meaningful if we can
+    // inspect: 443 + not cert-pinned. Otherwise it stays closed host-only.
     const pathModeTunnel =
       status !== 'allow' &&
       port === 443 &&
@@ -563,9 +563,9 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
       return;
     }
 
-    // Domeinen met cert-pinning kunnen niet door MITM. Voor die domeinen
-    // vallen we terug op de oude raw TCP-tunnel; request/response inhoud
-    // blijft dan onzichtbaar in de audit log (alleen CONNECT geregistreerd).
+    // Domains with cert-pinning cannot go through MITM. For those domains
+    // we fall back to the old raw TCP tunnel; request/response content
+    // then stays invisible in the audit log (only CONNECT recorded).
     if (NO_INTERCEPT_DOMAINS.has(hostname.toLowerCase()) || port !== 443) {
       const upstream = net.connect(port, hostname, () => {
         clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
@@ -589,9 +589,9 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
       return;
     }
 
-    // MITM-pad: presenteer een dynamisch gegenereerd leaf-cert aan de client,
-    // termineer TLS, parse HTTP en forward naar upstream over een echte TLS-
-    // verbinding. Alle req/res-headers en bodies belanden in de audit log.
+    // MITM path: present a dynamically generated leaf cert to the client,
+    // terminate TLS, parse HTTP and forward to upstream over a real TLS
+    // connection. All req/res headers and bodies end up in the audit log.
     clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
     logAudit({
       containerId,
@@ -619,8 +619,8 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
       ALPNProtocols: ['http/1.1'],
     });
     innerTls.on('error', (err: NodeJS.ErrnoException) => {
-      // ECONNRESET en self-signed-rejected zijn normaal als de container
-      // de CA nog niet vertrouwt — log één keer en sluit netjes.
+      // ECONNRESET and self-signed-rejected are normal if the container
+      // does not yet trust the CA — log once and close cleanly.
       if (err.code !== 'ECONNRESET') {
         console.warn(`[proxy-mitm] inner TLS error (${hostname}):`, err.message);
       }
@@ -628,20 +628,20 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
     });
     if (head && head.length) innerTls.unshift(head);
 
-    // Per CONNECT één lichtgewicht http.Server die de gewrapte TLS-socket leest.
+    // One lightweight http.Server per CONNECT that reads the wrapped TLS socket.
     const innerHttp = http.createServer();
     innerHttp.on('request', (innerReq, innerRes) => {
-      // De CONNECT stond de host al toe (pad was toen versleuteld). Nu de TLS
-      // getermineerd is kennen we het pad: pas padbeleid alsnog toe per request.
+      // The CONNECT already allowed the host (the path was encrypted then). Now that TLS
+      // is terminated we know the path: apply path policy per request after all.
       //
-      // Beslis op de gedecodeerde vorm (finding #7): traversal (`../`, `..%2f`)
-      // of kapotte encoding → fail closed (403), nooit doorsturen. Geforward
-      // worden daarna de originele encoded bytes (zie rules.ts): de gedecodeerde
-      // vorm is geen geldige request-target — rauwe spaties/UTF-8 (bv. een
-      // `%20` in een Azure DevOps-projectnaam) laten https.request synchroon
-      // gooien (ERR_UNESCAPED_CHARACTERS → proces-crash) — en de upstream zou
-      // hem een twééde keer decoden, waarmee `%252e%252e` alsnog tot `..`
-      // vervalt en legitieme %2F/%20 verminkt raken.
+      // Decide on the decoded form (finding #7): traversal (`../`, `..%2f`)
+      // or broken encoding → fail closed (403), never forward. Forwarded
+      // afterwards are the original encoded bytes (see rules.ts): the decoded
+      // form is not a valid request-target — raw spaces/UTF-8 (e.g. a
+      // `%20` in an Azure DevOps project name) make https.request throw
+      // synchronously (ERR_UNESCAPED_CHARACTERS → process crash) — and the upstream would
+      // decode it a second time, whereby `%252e%252e` still decays to `..`
+      // and legitimate %2F/%20 get mangled.
       const rawUrl = innerReq.url ?? '/';
       const qi = rawUrl.indexOf('?');
       const rawPathPart = qi === -1 ? rawUrl : rawUrl.slice(0, qi);
@@ -652,9 +652,9 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
       const pathResult = normPath === null
         ? { status: 'deny' as const, ruleId: null }
         : checkRule(hostname, containerId, checkUrl);
-      // Alles behalve 'allow' blokkeren: een 'deny'-padregel, maar ook een nog
-      // niet beoordeeld subpad ('requested') van een pad-allowlist-domein —
-      // fail-closed tot de operator het pad expliciet toestaat.
+      // Block everything except 'allow': a 'deny' path rule, but also a not-yet-
+      // reviewed subpath ('requested') of a path-allowlist domain —
+      // fail-closed until the operator explicitly allows the path.
       if (pathResult.status !== 'allow') {
         logAudit({
           containerId,
@@ -690,11 +690,11 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
       const upstreamHeaders = { ...innerReq.headers };
       delete upstreamHeaders['proxy-connection'];
 
-      // Token replacement: vervang placeholder door het echte token voor api.anthropic.com
+      // Token replacement: replace placeholder with the real token for api.anthropic.com
       if (hostname === 'api.anthropic.com') {
         const authVal = upstreamHeaders['authorization'] as string | undefined;
         if (authVal?.startsWith('Bearer ') && isPlaceholderToken(authVal.slice(7))) {
-          // Alleen inwisselen als deze container de placeholder ook kreeg (#12).
+          // Only redeem if this container also received the placeholder (#12).
           const real = resolveToken(authVal.slice(7), containerId);
           if (real) upstreamHeaders['authorization'] = `Bearer ${real}`;
         }
@@ -705,7 +705,7 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
         }
       }
 
-      // Token exchange: detecteer OAuth token response van platform.claude.com
+      // Token exchange: detect OAuth token response from platform.claude.com
       const isTokenRequest =
         hostname === 'platform.claude.com' &&
         innerReq.method === 'POST' &&
@@ -716,11 +716,11 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
       const resChunks: Buffer[] = [];
       let resBytes = 0;
 
-      // Log de request meteen (method/path/headers) zodat de call al in de audit
-      // log verschijnt zodra hij binnenkomt — res_status blijft NULL ("in-flight")
-      // tot de upstream-response afrondt. Cruciaal voor streaming responses (bv.
-      // Anthropic SSE) die seconden tot minuten open blijven: zonder dit zou de
-      // hele call onzichtbaar zijn tot hij klaar is.
+      // Log the request immediately (method/path/headers) so the call appears in the audit
+      // log as soon as it comes in — res_status stays NULL ("in-flight")
+      // until the upstream response completes. Crucial for streaming responses (e.g.
+      // Anthropic SSE) that stay open for seconds to minutes: without this the
+      // whole call would be invisible until it finishes.
       const auditId = logAudit({
         containerId,
         domain: hostname,
@@ -732,8 +732,8 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
         reqHeaders: headersToJson(innerReq.headers),
       });
       let completed = false;
-      // resBody: expliciet meegeven voor gescrubde paden (token-exchange) zodat het
-      // echte secret nooit in de audit-log terechtkomt. Weglaten = afleiden uit resChunks.
+      // resBody: pass explicitly for scrubbed paths (token-exchange) so the
+      // real secret never ends up in the audit log. Omit = derive from resChunks.
       const complete = (resStatus: number | null, resHeaders?: http.IncomingHttpHeaders, resBody?: string | null) => {
         if (completed) return;
         completed = true;
@@ -751,8 +751,8 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
           hostname,
           port,
           method: innerReq.method,
-          // De originele encoded bytes; de gedecodeerde checkUrl is alleen de
-          // beslisvorm. Traversal is hierboven al fail-closed geweigerd.
+          // The original encoded bytes; the decoded checkUrl is only the
+          // decision form. Traversal was already fail-closed rejected above.
           path: rawUrl,
           headers: upstreamHeaders,
           servername: hostname,
@@ -796,12 +796,12 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
       innerReq.on('end', () => upstreamReq.end());
       innerReq.on('error', () => upstreamReq.destroy());
     });
-    // WebSocket (`wss://`) ná TLS-terminatie: de client stuurt de upgrade-
-    // handshake over de gewrapte TLS-socket. Node emit't die als een SEPARAAT
-    // 'upgrade'-event (niet 'request'); zonder deze handler sluit Node de socket
-    // en time-out de handshake — precies de Codex-CLI-vertraging uit #74. Zelfde
-    // padhandhaving als de request-handler hierboven: beslis op de gedecodeerde
-    // vorm, forward de originele encoded bytes.
+    // WebSocket (`wss://`) after TLS termination: the client sends the upgrade
+    // handshake over the wrapped TLS socket. Node emits it as a SEPARATE
+    // 'upgrade' event (not 'request'); without this handler Node closes the socket
+    // and times out the handshake — exactly the Codex CLI delay from #74. Same
+    // path enforcement as the request handler above: decide on the decoded
+    // form, forward the original encoded bytes.
     innerHttp.on('upgrade', (innerReq, innerSocket, innerHead) => {
       const rawUrl = innerReq.url ?? '/';
       const qi = rawUrl.indexOf('?');
@@ -848,7 +848,7 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
           hostname,
           port,
           method: innerReq.method,
-          // Originele encoded bytes; checkUrl was alleen de beslisvorm.
+          // Original encoded bytes; checkUrl was only the decision form.
           path: rawUrl,
           headers: upstreamHeaders,
           servername: hostname,

--- a/gateway/src/proxy.ts
+++ b/gateway/src/proxy.ts
@@ -103,6 +103,75 @@ function rejectSocket(socket: stream.Duplex, status: number, blockStatus: string
   socket.end();
 }
 
+// Forward een HTTP Upgrade-handshake (WebSocket `ws://`/`wss://`, maar ook elke
+// andere Upgrade) naar upstream en pipe daarna de rauwe bytes in beide
+// richtingen. `secure` kiest tussen http.request (plain, ná plain-HTTP-pad) en
+// https.request (TLS, ná MITM-terminatie). We gebruiken bewust de laagste laag:
+// Node emit't 'upgrade' op de ClientRequest zodra upstream met 101 antwoordt;
+// dan reconstrueren we de handshake-response byte-voor-byte terug naar de client
+// (rawHeaders behoudt exacte casing + volgorde van Sec-WebSocket-Accept e.d.) en
+// verbinden we beide sockets. Elke Upgrade wordt zo transparant doorgezet.
+function forwardUpgrade(
+  secure: boolean,
+  options: https.RequestOptions,
+  clientSocket: stream.Duplex,
+  clientHead: Buffer,
+): void {
+  let upstreamReq: http.ClientRequest;
+  try {
+    // Zelfde synchrone-throw-risico als tryCreateUpstreamRequest (bv.
+    // ERR_UNESCAPED_CHARACTERS): fail per handshake, niet per proces.
+    upstreamReq = secure ? https.request(options) : http.request(options);
+  } catch {
+    try { clientSocket.destroy(); } catch {}
+    return;
+  }
+
+  upstreamReq.on('upgrade', (upstreamRes, upstreamSocket, upstreamHead) => {
+    // Reconstrueer de 101-handshake byte-voor-byte terug naar de client.
+    const lines = [`HTTP/1.1 ${upstreamRes.statusCode} ${upstreamRes.statusMessage}`];
+    for (let i = 0; i < upstreamRes.rawHeaders.length; i += 2) {
+      lines.push(`${upstreamRes.rawHeaders[i]}: ${upstreamRes.rawHeaders[i + 1]}`);
+    }
+    try {
+      clientSocket.write(lines.join('\r\n') + '\r\n\r\n');
+      if (upstreamHead && upstreamHead.length) clientSocket.write(upstreamHead);
+    } catch {
+      try { upstreamSocket.destroy(); } catch {}
+      return;
+    }
+    // Bytes die de client al ná zijn handshake stuurde eerst doorzetten, dán pipen.
+    if (clientHead && clientHead.length) upstreamSocket.write(clientHead);
+    upstreamSocket.pipe(clientSocket);
+    clientSocket.pipe(upstreamSocket);
+    const teardown = () => {
+      try { upstreamSocket.destroy(); } catch {}
+      try { clientSocket.destroy(); } catch {}
+    };
+    upstreamSocket.on('error', teardown);
+    clientSocket.on('error', teardown);
+    upstreamSocket.on('close', () => { try { clientSocket.destroy(); } catch {} });
+    clientSocket.on('close', () => { try { upstreamSocket.destroy(); } catch {} });
+  });
+
+  // Upstream honoreerde de upgrade niet (geen 101): relay de gewone response
+  // terug naar de client en sluit — fail-closed t.o.v. de tunnel.
+  upstreamReq.on('response', (upstreamRes) => {
+    const lines = [`HTTP/1.1 ${upstreamRes.statusCode} ${upstreamRes.statusMessage}`];
+    for (let i = 0; i < upstreamRes.rawHeaders.length; i += 2) {
+      lines.push(`${upstreamRes.rawHeaders[i]}: ${upstreamRes.rawHeaders[i + 1]}`);
+    }
+    try { clientSocket.write(lines.join('\r\n') + '\r\n\r\n'); } catch {}
+    upstreamRes.on('data', (c: Buffer) => { try { clientSocket.write(c); } catch {} });
+    upstreamRes.on('end', () => { try { clientSocket.end(); } catch {} });
+    upstreamRes.on('error', () => { try { clientSocket.destroy(); } catch {} });
+  });
+
+  upstreamReq.on('error', () => { try { clientSocket.destroy(); } catch {} });
+  clientSocket.on('error', () => { try { upstreamReq.destroy(); } catch {} });
+  upstreamReq.end();
+}
+
 // Node valideert request-opties synchroon in de ClientRequest-constructor
 // (bv. ERR_UNESCAPED_CHARACTERS bij een ongeldige request-target). Zo'n throw
 // belandt anders in de uncaughtException-handler die het hele proces — en dus
@@ -333,6 +402,80 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
       if (reqBytes < CAP) { reqChunks.push(chunk); reqBytes += chunk.length; }
     });
     req.on('end', () => upstream.end());
+  });
+
+  // WebSocket (`ws://`) over het plain-HTTP-pad: een forward-proxy-client stuurt
+  // de upgrade-handshake in absolute vorm (`GET http://host/pad`) met
+  // `Upgrade: websocket`. Node emit't die als 'upgrade' (niet 'request'); zonder
+  // deze handler zou Node de socket sluiten en de handshake time-outen. Zelfde
+  // firewall-handhaving als het request-pad: canoniseer de host, beslis op het
+  // genormaliseerde pad, forward de originele encoded bytes.
+  server.on('upgrade', async (req, clientSocket, head) => {
+    const extHeader = req.headers['x-huddle-ext'];
+    const containerId = extHeader
+      ? `ext:${String(extHeader).replace(/[^a-z0-9-]/g, '')}`
+      : await resolveContainerByIp(req.socket.remoteAddress ?? '');
+    const rawUrl = req.url || '';
+
+    let target: URL;
+    try {
+      target = new URL(rawUrl);
+    } catch {
+      rejectSocket(clientSocket, 400, 'deny', '', containerId);
+      return;
+    }
+
+    const host = canonicalizeHost(target.hostname);
+    if (host === null) {
+      rejectSocket(clientSocket, 400, 'deny', '', containerId);
+      return;
+    }
+
+    const normPath = normalizePathname(target.pathname);
+    if (normPath === null) {
+      logAudit({
+        containerId, domain: host, action: 'deny', ruleId: null,
+        method: req.method ?? null, path: `${target.pathname}${target.search}`, resStatus: 403,
+      });
+      rejectSocket(clientSocket, 403, 'deny', host, containerId);
+      return;
+    }
+    const forwardPath = `${target.pathname}${target.search}`;
+
+    // Geen legitiem WebSocket-endpoint op huddle zelf → altijd fail-closed.
+    if (host === 'huddle') {
+      logAudit({
+        containerId, domain: 'huddle', action: 'deny', ruleId: null,
+        method: req.method ?? null, path: forwardPath, resStatus: 403,
+      });
+      rejectSocket(clientSocket, 403, 'deny', 'huddle', containerId);
+      return;
+    }
+
+    const result = checkRule(host, containerId, normPath);
+    if (result.status !== 'allow') {
+      logAudit({
+        containerId, domain: host, action: result.status, ruleId: null,
+        method: req.method ?? null, path: forwardPath, resStatus: 403,
+      });
+      rejectSocket(clientSocket, 403, result.status, host, containerId);
+      return;
+    }
+
+    logAudit({
+      containerId, domain: host, action: 'allow', ruleId: result.ruleId,
+      method: req.method ?? null, path: forwardPath, reqHeaders: headersToJson(req.headers),
+    });
+
+    const outgoingHeaders: http.OutgoingHttpHeaders = { ...req.headers };
+    delete outgoingHeaders['proxy-connection'];
+    const upstreamPort = target.port || 80;
+    forwardUpgrade(
+      false,
+      { hostname: host, port: upstreamPort, method: req.method, path: forwardPath, headers: outgoingHeaders },
+      clientSocket,
+      head,
+    );
   });
 
   server.on('connect', async (req, clientSocket, head) => {
@@ -623,6 +766,67 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
       });
       innerReq.on('end', () => upstreamReq.end());
       innerReq.on('error', () => upstreamReq.destroy());
+    });
+    // WebSocket (`wss://`) ná TLS-terminatie: de client stuurt de upgrade-
+    // handshake over de gewrapte TLS-socket. Node emit't die als een SEPARAAT
+    // 'upgrade'-event (niet 'request'); zonder deze handler sluit Node de socket
+    // en time-out de handshake — precies de Codex-CLI-vertraging uit #74. Zelfde
+    // padhandhaving als de request-handler hierboven: beslis op de gedecodeerde
+    // vorm, forward de originele encoded bytes.
+    innerHttp.on('upgrade', (innerReq, innerSocket, innerHead) => {
+      const rawUrl = innerReq.url ?? '/';
+      const qi = rawUrl.indexOf('?');
+      const rawPathPart = qi === -1 ? rawUrl : rawUrl.slice(0, qi);
+      const query = qi === -1 ? '' : rawUrl.slice(qi);
+      const normPath = normalizePathname(rawPathPart);
+      const checkUrl = normPath === null ? null : `${normPath}${query}`;
+
+      const pathResult = normPath === null
+        ? { status: 'deny' as const, ruleId: null }
+        : checkRule(hostname, containerId, checkUrl);
+      if (pathResult.status !== 'allow') {
+        logAudit({
+          containerId,
+          domain: hostname,
+          port,
+          action: pathResult.status,
+          ruleId: pathResult.ruleId,
+          method: innerReq.method ?? null,
+          path: innerReq.url ?? null,
+          reqHeaders: headersToJson(innerReq.headers),
+          resStatus: 403,
+        });
+        rejectSocket(innerSocket, 403, pathResult.status, hostname, containerId);
+        return;
+      }
+
+      logAudit({
+        containerId,
+        domain: hostname,
+        port,
+        action: 'allow',
+        ruleId: pathResult.ruleId,
+        method: innerReq.method ?? null,
+        path: innerReq.url ?? null,
+        reqHeaders: headersToJson(innerReq.headers),
+      });
+
+      const upstreamHeaders = { ...innerReq.headers };
+      delete upstreamHeaders['proxy-connection'];
+      forwardUpgrade(
+        true,
+        {
+          hostname,
+          port,
+          method: innerReq.method,
+          // Originele encoded bytes; checkUrl was alleen de beslisvorm.
+          path: rawUrl,
+          headers: upstreamHeaders,
+          servername: hostname,
+        },
+        innerSocket,
+        innerHead,
+      );
     });
     innerHttp.on('clientError', (_err, sock) => { try { sock.destroy(); } catch {} });
 

--- a/gateway/src/proxy.ts
+++ b/gateway/src/proxy.ts
@@ -151,7 +151,7 @@ function forwardUpgrade(
     destroyUpstream();
     try { clientSocket.destroy(); } catch {}
   }, timeoutMs);
-  if (typeof handshakeTimer.unref === 'function') handshakeTimer.unref();
+  handshakeTimer.unref?.();
   const clearHandshakeTimer = () => { settled = true; clearTimeout(handshakeTimer); };
 
   upstreamReq.on('upgrade', (upstreamRes, upstreamSocket, upstreamHead) => {

--- a/gateway/src/proxy.ts
+++ b/gateway/src/proxy.ts
@@ -26,6 +26,21 @@ const CAP = 20 * 1024; // 20 KB per field
 function cap(s: string): string { return s.length > CAP ? s.slice(0, CAP) + '\n[truncated]' : s; }
 function headersToJson(h: Record<string, any>): string { try { return cap(JSON.stringify(h)); } catch { return '{}'; } }
 
+// Hop-by-hop proxy headers that must never reach upstream: proxy-connection and
+// the reusable proxy credential proxy-authorization.
+function stripProxyHeaders(h: http.OutgoingHttpHeaders): void {
+  delete h['proxy-connection'];
+  delete h['proxy-authorization'];
+}
+
+// Serialize request headers for the audit log with the reusable proxy credential
+// redacted, so it is never persisted in the network log.
+function auditReqHeaders(h: http.IncomingHttpHeaders): string {
+  return h['proxy-authorization'] === undefined
+    ? headersToJson(h)
+    : headersToJson({ ...h, 'proxy-authorization': '<redacted>' });
+}
+
 // RFC 7230 §3.3.2: Content-Length and Transfer-Encoding must not coexist.
 // Some OAuth/API servers send both; strip Content-Length when TE is present.
 function sanitizeResHeaders(h: http.IncomingHttpHeaders): http.IncomingHttpHeaders {
@@ -80,10 +95,17 @@ function send502(res: http.ServerResponse, message: string): void {
   res.end(body);
 }
 
+// Reason phrase per status so the status line is never self-contradictory
+// (e.g. "400 Forbidden"). rejectSocket serves both CONNECT and Upgrade denials.
+const REJECT_REASON: Record<number, string> = {
+  400: 'Bad Request', 403: 'Forbidden', 426: 'Upgrade Required',
+  502: 'Bad Gateway', 504: 'Gateway Timeout',
+};
+
 function rejectSocket(socket: stream.Duplex, status: number, blockStatus: string, domain: string, containerId?: string | null): void {
   const body = JSON.stringify({
     error: 'REQUEST_BLOCKED_BY_HUDDLE',
-    message: 'This CONNECT request is blocked by Huddle security policy.',
+    message: 'This request is blocked by Huddle security policy.',
     blockedEndpoint: domain,
     reason: blockStatus === 'requested'
       ? 'This endpoint has not yet been approved for this devcontainer.'
@@ -93,7 +115,7 @@ function rejectSocket(socket: stream.Duplex, status: number, blockStatus: string
     huddlePortal: 'http://localhost:3000',
   });
   socket.write(
-    `HTTP/1.1 ${status} Forbidden\r\n` +
+    `HTTP/1.1 ${status} ${REJECT_REASON[status] ?? 'Forbidden'}\r\n` +
       `content-type: application/json\r\n` +
       `x-huddle-blocked: 1\r\n` +
       `content-length: ${Buffer.byteLength(body)}\r\n` +
@@ -144,13 +166,25 @@ function forwardUpgrade(
   options: https.RequestOptions,
   clientSocket: stream.Duplex,
   clientHead: Buffer,
+  auditId: number | null = null,
 ): void {
+  // Record the handshake outcome on the in-flight audit row exactly once, so an
+  // allowed upgrade never stays res_status=NULL in the network log. First
+  // terminal outcome wins — a later live-socket error must not overwrite the 101.
+  let audited = false;
+  const finishAudit = (resStatus: number | null) => {
+    if (audited || auditId === null) return;
+    audited = true;
+    updateAuditResponse(auditId, { resStatus });
+  };
+
   let upstreamReq: http.ClientRequest;
   try {
     // Same synchronous-throw risk as tryCreateUpstreamRequest (e.g.
     // ERR_UNESCAPED_CHARACTERS): fail per handshake, not per process.
     upstreamReq = secure ? https.request(options) : http.request(options);
   } catch {
+    finishAudit(502);
     try { clientSocket.destroy(); } catch { /* best-effort: peer socket may already be closed */ }
     return;
   }
@@ -177,6 +211,7 @@ function forwardUpgrade(
     if (settled) return;
     settled = true;
     destroyUpstream();
+    finishAudit(504);
     try { clientSocket.destroy(); } catch { /* best-effort: peer socket may already be closed */ }
   }, timeoutMs);
   handshakeTimer.unref?.();
@@ -184,6 +219,7 @@ function forwardUpgrade(
 
   upstreamReq.on('upgrade', (upstreamRes, upstreamSocket, upstreamHead) => {
     clearHandshakeTimer();
+    finishAudit(upstreamRes.statusCode ?? 101);
     // Reconstruct the 101 handshake byte-for-byte back to the client.
     try {
       clientSocket.write(formatHttpHead(upstreamRes));
@@ -210,13 +246,14 @@ function forwardUpgrade(
   // back to the client and close — fail-closed with respect to the tunnel.
   upstreamReq.on('response', (upstreamRes) => {
     clearHandshakeTimer();
+    finishAudit(upstreamRes.statusCode ?? null);
     try { clientSocket.write(formatHttpHead(upstreamRes)); } catch { /* best-effort: peer socket may already be closed */ }
     upstreamRes.on('data', (c: Buffer) => { try { clientSocket.write(c); } catch { /* best-effort: peer socket may already be closed */ } });
     upstreamRes.on('end', () => { try { clientSocket.end(); } catch { /* best-effort: peer socket may already be closed */ } });
     upstreamRes.on('error', () => { try { clientSocket.destroy(); } catch { /* best-effort: peer socket may already be closed */ } });
   });
 
-  upstreamReq.on('error', () => { clearHandshakeTimer(); try { clientSocket.destroy(); } catch { /* best-effort: peer socket may already be closed */ } });
+  upstreamReq.on('error', () => { clearHandshakeTimer(); finishAudit(502); try { clientSocket.destroy(); } catch { /* best-effort: peer socket may already be closed */ } });
   clientSocket.on('error', () => { clearHandshakeTimer(); destroyUpstream(); });
   upstreamReq.end();
 }
@@ -524,19 +561,20 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
       return;
     }
 
-    logAudit({
+    const auditId = logAudit({
       containerId, domain: host, action: 'allow', ruleId: result.ruleId,
-      method: req.method ?? null, path: forwardPath, reqHeaders: headersToJson(req.headers),
+      method: req.method ?? null, path: forwardPath, reqHeaders: auditReqHeaders(req.headers),
     });
 
     const outgoingHeaders: http.OutgoingHttpHeaders = { ...req.headers };
-    delete outgoingHeaders['proxy-connection'];
+    stripProxyHeaders(outgoingHeaders);
     const upstreamPort = target.port || 80;
     forwardUpgrade(
       false,
       { hostname: host, port: upstreamPort, method: req.method, path: forwardPath, headers: outgoingHeaders },
       clientSocket,
       head,
+      auditId,
     );
   });
 
@@ -874,7 +912,7 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
         return;
       }
 
-      logAudit({
+      const auditId = logAudit({
         containerId,
         domain: hostname,
         port,
@@ -882,11 +920,11 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
         ruleId: pathResult.ruleId,
         method: innerReq.method ?? null,
         path: innerReq.url ?? null,
-        reqHeaders: headersToJson(innerReq.headers),
+        reqHeaders: auditReqHeaders(innerReq.headers),
       });
 
       const upstreamHeaders = { ...innerReq.headers };
-      delete upstreamHeaders['proxy-connection'];
+      stripProxyHeaders(upstreamHeaders);
       forwardUpgrade(
         true,
         {
@@ -900,6 +938,7 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
         },
         innerSocket,
         innerHead,
+        auditId,
       );
     });
     innerHttp.on('clientError', (_err, sock) => { try { sock.destroy(); } catch { /* best-effort: peer socket may already be closed */ } });

--- a/gateway/src/proxy.ts
+++ b/gateway/src/proxy.ts
@@ -122,6 +122,23 @@ function formatHttpHead(res: http.IncomingMessage): string {
   return lines.join('\r\n') + '\r\n\r\n';
 }
 
+// A genuine WebSocket handshake is a GET carrying `Upgrade: websocket`, a
+// `Connection` list that includes `upgrade`, and a Sec-WebSocket-Key (RFC 6455).
+// ONLY such requests may take the raw upgrade path. Node routes *any* request
+// with Upgrade headers to the 'upgrade' event, so without this gate a client
+// could send e.g. `POST /v1/oauth/token` with `Upgrade: websocket` and have it
+// forwarded verbatim — skipping the normal request pipeline and its response
+// scrubbing (handleTokenExchangeResponse), leaking the real bearer token to the
+// container. Non-handshake "upgrades" are refused so they fall to no path at all.
+function isWebSocketHandshake(method: string | undefined, headers: http.IncomingHttpHeaders): boolean {
+  if ((method ?? '').toUpperCase() !== 'GET') return false;
+  if (String(headers['upgrade'] ?? '').toLowerCase() !== 'websocket') return false;
+  const connection = String(headers['connection'] ?? '').toLowerCase();
+  if (!connection.split(',').some((t) => t.trim() === 'upgrade')) return false;
+  const key = headers['sec-websocket-key'];
+  return typeof key === 'string' && key.length > 0;
+}
+
 function forwardUpgrade(
   secure: boolean,
   options: https.RequestOptions,
@@ -475,6 +492,18 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
     }
     const forwardPath = `${target.pathname}${target.search}`;
 
+    // Only a genuine WebSocket handshake may use the raw upgrade path; a request
+    // that merely carries Upgrade headers (e.g. POST to an OAuth token endpoint)
+    // must fall through to nothing here, not bypass the request pipeline/scrubbing.
+    if (!isWebSocketHandshake(req.method, req.headers)) {
+      logAudit({
+        containerId, domain: host, action: 'deny', ruleId: null,
+        method: req.method ?? null, path: forwardPath, resStatus: 400,
+      });
+      rejectSocket(clientSocket, 400, 'deny', host, containerId);
+      return;
+    }
+
     // No legitimate WebSocket endpoint on huddle itself → always fail-closed.
     if (host === 'huddle') {
       logAudit({
@@ -807,6 +836,18 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
     // path enforcement as the request handler above: decide on the decoded
     // form, forward the original encoded bytes.
     innerHttp.on('upgrade', (innerReq, innerSocket, innerHead) => {
+      // Only a genuine WebSocket handshake may take the raw upgrade path. A
+      // non-WS "upgrade" (e.g. POST /v1/oauth/token with Upgrade: websocket)
+      // would otherwise be forwarded verbatim and skip handleTokenExchangeResponse,
+      // leaking the real bearer token to the container. Fail closed.
+      if (!isWebSocketHandshake(innerReq.method, innerReq.headers)) {
+        logAudit({
+          containerId, domain: hostname, port, action: 'deny', ruleId: null,
+          method: innerReq.method ?? null, path: innerReq.url ?? null, resStatus: 400,
+        });
+        rejectSocket(innerSocket, 400, 'deny', hostname, containerId);
+        return;
+      }
       const rawUrl = innerReq.url ?? '/';
       const qi = rawUrl.indexOf('?');
       const rawPathPart = qi === -1 ? rawUrl : rawUrl.slice(0, qi);

--- a/gateway/src/proxy.ts
+++ b/gateway/src/proxy.ts
@@ -127,7 +127,35 @@ function forwardUpgrade(
     return;
   }
 
+  // Handshake-timeout: een upstream die de TCP-verbinding wél accepteert maar de
+  // upgrade nooit afrondt (stalled/slowloris, of een SYN die in een blackhole
+  // verdwijnt) houdt anders zowel de client- als de upstream-socket onbeperkt
+  // open. Node's server-/headersTimeout gelden NIET meer op een ge-hijackte
+  // upgrade-socket, dus zonder deze backstop kan een devcontainer met één
+  // toegestane host ongelimiteerd half-open handshakes opstapelen en de FD's van
+  // de gedeelde gateway uitputten (DoS). We bewaken uitsluitend de handshake-
+  // fase; zodra upstream 101/response geeft wissen we de timer, zodat legitieme
+  // langlevende WebSockets nooit afgekapt worden.
+  // upstreamReq.destroy() aborteert de request maar sluit de reeds verbonden
+  // socket niet altijd (die kan in de agent-pool blijven hangen) — destroy dus
+  // ook expliciet upstreamReq.socket, anders leakt de uitgaande gateway-socket.
+  const destroyUpstream = () => {
+    try { upstreamReq.socket?.destroy(); } catch {}
+    try { upstreamReq.destroy(); } catch {}
+  };
+  const timeoutMs = Number(process.env.WS_UPGRADE_TIMEOUT_MS) || 30_000;
+  let settled = false;
+  const handshakeTimer = setTimeout(() => {
+    if (settled) return;
+    settled = true;
+    destroyUpstream();
+    try { clientSocket.destroy(); } catch {}
+  }, timeoutMs);
+  if (typeof handshakeTimer.unref === 'function') handshakeTimer.unref();
+  const clearHandshakeTimer = () => { settled = true; clearTimeout(handshakeTimer); };
+
   upstreamReq.on('upgrade', (upstreamRes, upstreamSocket, upstreamHead) => {
+    clearHandshakeTimer();
     // Reconstrueer de 101-handshake byte-voor-byte terug naar de client.
     const lines = [`HTTP/1.1 ${upstreamRes.statusCode} ${upstreamRes.statusMessage}`];
     for (let i = 0; i < upstreamRes.rawHeaders.length; i += 2) {
@@ -157,6 +185,7 @@ function forwardUpgrade(
   // Upstream honoreerde de upgrade niet (geen 101): relay de gewone response
   // terug naar de client en sluit — fail-closed t.o.v. de tunnel.
   upstreamReq.on('response', (upstreamRes) => {
+    clearHandshakeTimer();
     const lines = [`HTTP/1.1 ${upstreamRes.statusCode} ${upstreamRes.statusMessage}`];
     for (let i = 0; i < upstreamRes.rawHeaders.length; i += 2) {
       lines.push(`${upstreamRes.rawHeaders[i]}: ${upstreamRes.rawHeaders[i + 1]}`);
@@ -167,8 +196,8 @@ function forwardUpgrade(
     upstreamRes.on('error', () => { try { clientSocket.destroy(); } catch {} });
   });
 
-  upstreamReq.on('error', () => { try { clientSocket.destroy(); } catch {} });
-  clientSocket.on('error', () => { try { upstreamReq.destroy(); } catch {} });
+  upstreamReq.on('error', () => { clearHandshakeTimer(); try { clientSocket.destroy(); } catch {} });
+  clientSocket.on('error', () => { clearHandshakeTimer(); destroyUpstream(); });
   upstreamReq.end();
 }
 

--- a/gateway/test/proxy-websocket.test.ts
+++ b/gateway/test/proxy-websocket.test.ts
@@ -187,7 +187,9 @@ describe.skipIf(!sqliteAvailable)('proxy forwards WebSocket upgrades', () => {
           `GET http://127.0.0.1:${stallPort}/echo HTTP/1.1\r\n` +
           `Host: 127.0.0.1:${stallPort}\r\n` +
           `Upgrade: websocket\r\nConnection: Upgrade\r\n` +
-          `Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n`
+          // Willekeurige dummy handshake-key (16 nul-bytes, base64) — geen secret;
+          // de stall-upstream antwoordt toch nooit, dus de waarde doet niet ter zake.
+          `Sec-WebSocket-Key: AAAAAAAAAAAAAAAAAAAAAA==\r\nSec-WebSocket-Version: 13\r\n\r\n`
         );
       });
       const done = () => { clearTimeout(guard); resolve(Date.now() - start); };

--- a/gateway/test/proxy-websocket.test.ts
+++ b/gateway/test/proxy-websocket.test.ts
@@ -4,17 +4,17 @@ import net from 'net';
 import { WebSocket, WebSocketServer } from 'ws';
 import type { AddressInfo } from 'net';
 
-// ── WebSocket-proxying (#74) ────────────────────────────────────────────────
-// De proxy moet HTTP Upgrade-handshakes (WebSocket) forwarden, niet alleen
-// gewone requests. Node emit't een upgrade als een SEPARAAT 'upgrade'-event;
-// zonder handler sloot de gateway de socket en time-outte de handshake (de
-// Codex-CLI-vertraging). Deze suite pint het plain-HTTP-pad (`ws://`) vast:
-// een echte lokale ws-echoserver upstream, een echte ws-client die via de proxy
-// als forward-proxy-client verbindt. Het MITM-pad (`wss://`) deelt exact
-// dezelfde forwardUpgrade-helper en padhandhaving.
+// ── WebSocket proxying (#74) ────────────────────────────────────────────────
+// The proxy must forward HTTP Upgrade handshakes (WebSocket), not only
+// regular requests. Node emits an upgrade as a SEPARATE 'upgrade' event;
+// without a handler the gateway closed the socket and timed out the handshake (the
+// Codex CLI delay). This suite pins the plain-HTTP path (`ws://`):
+// a real local ws echo server upstream, a real ws client that connects via the proxy
+// as a forward-proxy client. The MITM path (`wss://`) shares exactly
+// the same forwardUpgrade helper and path enforcement.
 //
-// better-sqlite3 is een native module; zonder gebouwde binding slaan we de suite
-// over (zie rules.test.ts / proxy-forward-path.test.ts). Probe vóór de db-import.
+// better-sqlite3 is a native module; without a built binding we skip the suite
+// (see rules.test.ts / proxy-forward-path.test.ts). Probe before the db import.
 let sqliteAvailable = true;
 try {
   const mod = await import('better-sqlite3');
@@ -22,7 +22,7 @@ try {
 } catch (e) {
   sqliteAvailable = false;
   console.warn(
-    `[proxy-websocket.test] SKIPPED — better-sqlite3 binding niet bruikbaar: ${(e as Error).message}`
+    `[proxy-websocket.test] SKIPPED — better-sqlite3 binding not usable: ${(e as Error).message}`
   );
 }
 
@@ -34,12 +34,12 @@ let upstreamPort = 0;
 let proxy: http.Server;
 let proxyPort = 0;
 
-// createConnection-hook voor de ws-client: de client denkt dat hij rechtstreeks
-// met de upstream praat (Host-header + pad kloppen daardoor), maar de TCP-
-// verbinding gaat naar de proxy. De eerste write (de handshake-request-regel)
-// wordt herschreven van origin-vorm (`GET /pad`) naar de absolute vorm die een
-// forward-proxy verwacht (`GET http://host:poort/pad`) — precies wat een
-// HTTP-proxy-client (Codex met HTTPS_PROXY) op de draad zet.
+// createConnection hook for the ws client: the client thinks it talks directly
+// to the upstream (Host header + path are therefore correct), but the TCP
+// connection goes to the proxy. The first write (the handshake request line)
+// is rewritten from origin form (`GET /path`) to the absolute form that a
+// forward proxy expects (`GET http://host:port/path`) — exactly what an
+// HTTP proxy client (Codex with HTTPS_PROXY) puts on the wire.
 function proxyCreateConnection(upstreamP: number, proxyP: number) {
   return () => {
     const socket = net.connect(proxyP, '127.0.0.1');
@@ -60,8 +60,8 @@ function proxyCreateConnection(upstreamP: number, proxyP: number) {
   };
 }
 
-// Verbind een ws-client via de proxy naar de upstream. Resolvet met het bericht
-// dat de echo-server terugkaatst (bewijst end-to-end proxying), of rejectet.
+// Connect a ws client via the proxy to the upstream. Resolves with the message
+// the echo server bounces back (proves end-to-end proxying), or rejects.
 function wsEchoViaProxy(path: string, payload: string): Promise<string> {
   return new Promise((resolve, reject) => {
     const ws = new WebSocket(`ws://127.0.0.1:${upstreamPort}${path}`, {
@@ -78,9 +78,9 @@ function wsEchoViaProxy(path: string, payload: string): Promise<string> {
   });
 }
 
-// Als bewust-geblokkeerd: verwacht dat de handshake NIET slaagt. Resolvet met de
-// HTTP-status van de weigering (403) of met 'error' bij een socketfout — beide
-// bewijzen dat er geen tunnel tot stand kwam.
+// When deliberately blocked: expect that the handshake does NOT succeed. Resolves with the
+// HTTP status of the rejection (403) or with 'error' on a socket failure — both
+// prove that no tunnel was established.
 function wsExpectRejected(path: string): Promise<string> {
   return new Promise((resolve, reject) => {
     const ws = new WebSocket(`ws://127.0.0.1:${upstreamPort}${path}`, {
@@ -96,9 +96,9 @@ function wsExpectRejected(path: string): Promise<string> {
   });
 }
 
-// Upstream die de TCP-verbinding accepteert maar de handshake NOOIT afrondt.
-// Bewijst de socket-leak-backstop: zonder handshake-timeout blijft zo'n
-// half-open upgrade beide sockets onbeperkt vasthouden (FD-exhaustion DoS).
+// Upstream that accepts the TCP connection but NEVER completes the handshake.
+// Proves the socket-leak backstop: without a handshake timeout such a
+// half-open upgrade keeps both sockets held indefinitely (FD-exhaustion DoS).
 let stallUpstream: net.Server;
 let stallPort = 0;
 let stallAccepted = 0;
@@ -106,19 +106,19 @@ const stallSockets: net.Socket[] = [];
 
 describe.skipIf(!sqliteAvailable)('proxy forwards WebSocket upgrades', () => {
   beforeAll(async () => {
-    // Korte handshake-timeout zodat de leak-regressietest snel is; productie
-    // valt terug op de 30s-default.
+    // Short handshake timeout so the leak regression test is fast; production
+    // falls back to the 30s default.
     process.env.WS_UPGRADE_TIMEOUT_MS = '800';
     const dbMod = await import('../src/db');
     db = dbMod.db;
     dbMod.initDb();
 
-    // Geen Docker in de unit-omgeving: client-IP resolvet niet naar een
-    // container — regels op globaal niveau volstaan.
+    // No Docker in the unit environment: client IP does not resolve to a
+    // container — rules at the global level suffice.
     const dockerMod = await import('../src/docker');
     vi.spyOn(dockerMod, 'resolveContainerByIp').mockResolvedValue(null);
 
-    // Upstream: echte ws-echoserver.
+    // Upstream: real ws echo server.
     upstream = new WebSocketServer({ host: '127.0.0.1', port: 0 });
     upstream.on('connection', (socket) => {
       socket.on('message', (data) => socket.send(data.toString()));
@@ -126,7 +126,7 @@ describe.skipIf(!sqliteAvailable)('proxy forwards WebSocket upgrades', () => {
     await new Promise<void>((r) => upstream.once('listening', () => r()));
     upstreamPort = (upstream.address() as AddressInfo).port;
 
-    // Stalled upstream: accepteert TCP, antwoordt nooit.
+    // Stalled upstream: accepts TCP, never answers.
     stallUpstream = net.createServer((s) => {
       stallAccepted++;
       stallSockets.push(s);
@@ -141,8 +141,8 @@ describe.skipIf(!sqliteAvailable)('proxy forwards WebSocket upgrades', () => {
   });
 
   afterAll(async () => {
-    // Force-close eventuele resterende sockets (bv. de proxy→stall-upstream
-    // verbinding) zodat server.close() niet blijft hangen op de teardown.
+    // Force-close any remaining sockets (e.g. the proxy→stall-upstream
+    // connection) so server.close() does not hang on teardown.
     (proxy as any)?.closeAllConnections?.();
     for (const s of stallSockets) { try { s.destroy(); } catch {} }
     await new Promise<void>((r) => (proxy ? proxy.close(() => r()) : r()));
@@ -155,29 +155,29 @@ describe.skipIf(!sqliteAvailable)('proxy forwards WebSocket upgrades', () => {
     db.exec('DELETE FROM rules');
   });
 
-  it('proxyt een toegestane WebSocket-upgrade end-to-end (echo)', async () => {
-    // Host-only allow voor de upstream-host → elk pad toegestaan.
+  it('proxies an allowed WebSocket upgrade end-to-end (echo)', async () => {
+    // Host-only allow for the upstream host → every path allowed.
     db.prepare(`INSERT INTO rules (domain, container_id, status) VALUES ('127.0.0.1', NULL, 'allow')`).run();
-    const echoed = await wsEchoViaProxy('/echo', 'hallo huddle');
-    expect(echoed).toBe('hallo huddle');
+    const echoed = await wsEchoViaProxy('/echo', 'hello huddle');
+    expect(echoed).toBe('hello huddle');
   });
 
-  it('weigert een upgrade naar een niet-toegestane host/pad (403)', async () => {
-    // Geen allow-regel → checkRule levert 'requested' op → fail-closed geweigerd.
+  it('rejects an upgrade to a disallowed host/path (403)', async () => {
+    // No allow rule → checkRule returns 'requested' → fail-closed rejected.
     const result = await wsExpectRejected('/echo');
     expect(result).toBe('http:403');
   });
 
-  it('kapt een stalled upstream-handshake af (geen socket-leak DoS)', async () => {
-    // Host toegestaan, maar upstream rondt de handshake nooit af. Zonder de
-    // handshake-timeout blijft de client-socket onbeperkt open (Node's server-
-    // timeouts gelden niet op een ge-hijackte upgrade-socket). Verwacht: de
-    // proxy dialt upstream (allow) én sluit daarna de client-socket zelf.
+  it('cuts off a stalled upstream handshake (no socket-leak DoS)', async () => {
+    // Host allowed, but upstream never completes the handshake. Without the
+    // handshake timeout the client socket stays open indefinitely (Node's server
+    // timeouts do not apply on a hijacked upgrade socket). Expect: the
+    // proxy dials upstream (allow) and then closes the client socket itself.
     db.prepare(`INSERT INTO rules (domain, container_id, status) VALUES ('127.0.0.1', NULL, 'allow')`).run();
     const before = stallAccepted;
-    // Meet hoe lang de client-socket open blijft. Zonder handshake-timeout
-    // sluit de proxy hem nooit (Node's server-timeouts gelden niet op een
-    // ge-hijackte upgrade-socket) en zou dit de 4s-guard raken.
+    // Measure how long the client socket stays open. Without a handshake timeout
+    // the proxy never closes it (Node's server timeouts do not apply on a
+    // hijacked upgrade socket) and this would hit the 4s guard.
     const start = Date.now();
     const closedAfterMs = await new Promise<number>((resolve) => {
       const c = net.connect(proxyPort, '127.0.0.1');
@@ -187,8 +187,8 @@ describe.skipIf(!sqliteAvailable)('proxy forwards WebSocket upgrades', () => {
           `GET http://127.0.0.1:${stallPort}/echo HTTP/1.1\r\n` +
           `Host: 127.0.0.1:${stallPort}\r\n` +
           `Upgrade: websocket\r\nConnection: Upgrade\r\n` +
-          // Willekeurige dummy handshake-key (16 nul-bytes, base64) — geen secret;
-          // de stall-upstream antwoordt toch nooit, dus de waarde doet niet ter zake.
+          // Arbitrary dummy handshake key (16 null bytes, base64) — no secret;
+          // the stall upstream never answers anyway, so the value does not matter.
           `Sec-WebSocket-Key: AAAAAAAAAAAAAAAAAAAAAA==\r\nSec-WebSocket-Version: 13\r\n\r\n`
         );
       });
@@ -196,9 +196,9 @@ describe.skipIf(!sqliteAvailable)('proxy forwards WebSocket upgrades', () => {
       c.on('close', done);
       c.on('error', done);
     });
-    expect(stallAccepted).toBeGreaterThan(before); // proxy dialde upstream (allow)
-    // De backstop kapte de half-open handshake af: dicht ná de 800ms-timeout,
-    // ruim vóór de 4s-guard. -1 = nooit gesloten = leak (regressie).
+    expect(stallAccepted).toBeGreaterThan(before); // proxy dialed upstream (allow)
+    // The backstop cut off the half-open handshake: closed after the 800ms timeout,
+    // well before the 4s guard. -1 = never closed = leak (regression).
     expect(closedAfterMs).toBeGreaterThanOrEqual(0);
     expect(closedAfterMs).toBeLessThan(3000);
   }, 8000);

--- a/gateway/test/proxy-websocket.test.ts
+++ b/gateway/test/proxy-websocket.test.ts
@@ -30,6 +30,7 @@ let db: typeof import('../src/db').db;
 
 let upstream: WebSocketServer;
 let upstreamPort = 0;
+let lastUpstreamHeaders: Record<string, any> = {};
 
 let proxy: http.Server;
 let proxyPort = 0;
@@ -120,7 +121,8 @@ describe.skipIf(!sqliteAvailable)('proxy forwards WebSocket upgrades', () => {
 
     // Upstream: real ws echo server.
     upstream = new WebSocketServer({ host: '127.0.0.1', port: 0 });
-    upstream.on('connection', (socket) => {
+    upstream.on('connection', (socket, req) => {
+      lastUpstreamHeaders = req.headers;
       socket.on('message', (data) => socket.send(data.toString()));
     });
     await new Promise<void>((r) => upstream.once('listening', () => r()));
@@ -162,6 +164,31 @@ describe.skipIf(!sqliteAvailable)('proxy forwards WebSocket upgrades', () => {
     expect(echoed).toBe('hello huddle');
   });
 
+  it('strips + redacts Proxy-Authorization and records the handshake result in the audit log', async () => {
+    db.prepare(`INSERT INTO rules (domain, container_id, status) VALUES ('127.0.0.1', NULL, 'allow')`).run();
+    lastUpstreamHeaders = {};
+    const echoed = await new Promise<string>((resolve, reject) => {
+      const ws = new WebSocket(`ws://127.0.0.1:${upstreamPort}/echo`, {
+        createConnection: proxyCreateConnection(upstreamPort, proxyPort),
+        headers: { 'Proxy-Authorization': 'Basic c3VwZXItc2VjcmV0' },
+      } as any);
+      ws.on('open', () => ws.send('hi'));
+      ws.on('message', (d) => { ws.close(); resolve(d.toString()); });
+      ws.on('error', reject);
+      setTimeout(() => reject(new Error('timeout')), 5000);
+    });
+    expect(echoed).toBe('hi');
+    // The reusable proxy credential must NOT reach upstream…
+    expect(lastUpstreamHeaders['proxy-authorization']).toBeUndefined();
+    // …and the audit row must be completed (101) with the credential redacted.
+    const row = db.prepare(
+      `SELECT res_status, req_headers FROM audit_log WHERE action = 'allow' AND domain = '127.0.0.1' ORDER BY id DESC LIMIT 1`
+    ).get() as { res_status: number | null; req_headers: string | null };
+    expect(row.res_status).toBe(101);
+    expect(row.req_headers ?? '').not.toContain('c3VwZXItc2VjcmV0');
+    expect(row.req_headers ?? '').toContain('<redacted>');
+  });
+
   it('rejects an upgrade to a disallowed host/path (403)', async () => {
     // No allow rule → checkRule returns 'requested' → fail-closed rejected.
     const result = await wsExpectRejected('/echo');
@@ -187,12 +214,13 @@ describe.skipIf(!sqliteAvailable)('proxy forwards WebSocket upgrades', () => {
       });
       c.on('data', (d) => {
         buf += d.toString();
-        const m = buf.match(/^HTTP\/1\.1 (\d{3})/);
+        const m = buf.match(/^HTTP\/1\.1 (\d{3} [^\r\n]+)/);
         if (m) { clearTimeout(guard); try { c.destroy(); } catch {} resolve(m[1]); }
       });
       c.on('error', (e) => { clearTimeout(guard); reject(e); });
     });
-    expect(status).toBe('400'); // refused, not forwarded as an upgrade
+    // Refused, not forwarded — and the status line is consistent (not "400 Forbidden").
+    expect(status).toBe('400 Bad Request');
   });
 
   it('cuts off a stalled upstream handshake (no socket-leak DoS)', async () => {

--- a/gateway/test/proxy-websocket.test.ts
+++ b/gateway/test/proxy-websocket.test.ts
@@ -96,8 +96,19 @@ function wsExpectRejected(path: string): Promise<string> {
   });
 }
 
+// Upstream die de TCP-verbinding accepteert maar de handshake NOOIT afrondt.
+// Bewijst de socket-leak-backstop: zonder handshake-timeout blijft zo'n
+// half-open upgrade beide sockets onbeperkt vasthouden (FD-exhaustion DoS).
+let stallUpstream: net.Server;
+let stallPort = 0;
+let stallAccepted = 0;
+const stallSockets: net.Socket[] = [];
+
 describe.skipIf(!sqliteAvailable)('proxy forwards WebSocket upgrades', () => {
   beforeAll(async () => {
+    // Korte handshake-timeout zodat de leak-regressietest snel is; productie
+    // valt terug op de 30s-default.
+    process.env.WS_UPGRADE_TIMEOUT_MS = '800';
     const dbMod = await import('../src/db');
     db = dbMod.db;
     dbMod.initDb();
@@ -115,6 +126,14 @@ describe.skipIf(!sqliteAvailable)('proxy forwards WebSocket upgrades', () => {
     await new Promise<void>((r) => upstream.once('listening', () => r()));
     upstreamPort = (upstream.address() as AddressInfo).port;
 
+    // Stalled upstream: accepteert TCP, antwoordt nooit.
+    stallUpstream = net.createServer((s) => {
+      stallAccepted++;
+      stallSockets.push(s);
+    });
+    await new Promise<void>((r) => stallUpstream.listen(0, '127.0.0.1', () => r()));
+    stallPort = (stallUpstream.address() as AddressInfo).port;
+
     const { createProxyServer } = await import('../src/proxy');
     proxy = createProxyServer(0);
     await new Promise<void>((r) => proxy.once('listening', () => r()));
@@ -122,8 +141,14 @@ describe.skipIf(!sqliteAvailable)('proxy forwards WebSocket upgrades', () => {
   });
 
   afterAll(async () => {
+    // Force-close eventuele resterende sockets (bv. de proxy→stall-upstream
+    // verbinding) zodat server.close() niet blijft hangen op de teardown.
+    (proxy as any)?.closeAllConnections?.();
+    for (const s of stallSockets) { try { s.destroy(); } catch {} }
     await new Promise<void>((r) => (proxy ? proxy.close(() => r()) : r()));
     await new Promise<void>((r) => (upstream ? upstream.close(() => r()) : r()));
+    await new Promise<void>((r) => (stallUpstream ? stallUpstream.close(() => r()) : r()));
+    delete process.env.WS_UPGRADE_TIMEOUT_MS;
   });
 
   beforeEach(() => {
@@ -142,4 +167,37 @@ describe.skipIf(!sqliteAvailable)('proxy forwards WebSocket upgrades', () => {
     const result = await wsExpectRejected('/echo');
     expect(result).toBe('http:403');
   });
+
+  it('kapt een stalled upstream-handshake af (geen socket-leak DoS)', async () => {
+    // Host toegestaan, maar upstream rondt de handshake nooit af. Zonder de
+    // handshake-timeout blijft de client-socket onbeperkt open (Node's server-
+    // timeouts gelden niet op een ge-hijackte upgrade-socket). Verwacht: de
+    // proxy dialt upstream (allow) én sluit daarna de client-socket zelf.
+    db.prepare(`INSERT INTO rules (domain, container_id, status) VALUES ('127.0.0.1', NULL, 'allow')`).run();
+    const before = stallAccepted;
+    // Meet hoe lang de client-socket open blijft. Zonder handshake-timeout
+    // sluit de proxy hem nooit (Node's server-timeouts gelden niet op een
+    // ge-hijackte upgrade-socket) en zou dit de 4s-guard raken.
+    const start = Date.now();
+    const closedAfterMs = await new Promise<number>((resolve) => {
+      const c = net.connect(proxyPort, '127.0.0.1');
+      const guard = setTimeout(() => { try { c.destroy(); } catch {} resolve(-1); }, 4000);
+      c.on('connect', () => {
+        c.write(
+          `GET http://127.0.0.1:${stallPort}/echo HTTP/1.1\r\n` +
+          `Host: 127.0.0.1:${stallPort}\r\n` +
+          `Upgrade: websocket\r\nConnection: Upgrade\r\n` +
+          `Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n`
+        );
+      });
+      const done = () => { clearTimeout(guard); resolve(Date.now() - start); };
+      c.on('close', done);
+      c.on('error', done);
+    });
+    expect(stallAccepted).toBeGreaterThan(before); // proxy dialde upstream (allow)
+    // De backstop kapte de half-open handshake af: dicht ná de 800ms-timeout,
+    // ruim vóór de 4s-guard. -1 = nooit gesloten = leak (regressie).
+    expect(closedAfterMs).toBeGreaterThanOrEqual(0);
+    expect(closedAfterMs).toBeLessThan(3000);
+  }, 8000);
 });

--- a/gateway/test/proxy-websocket.test.ts
+++ b/gateway/test/proxy-websocket.test.ts
@@ -168,6 +168,33 @@ describe.skipIf(!sqliteAvailable)('proxy forwards WebSocket upgrades', () => {
     expect(result).toBe('http:403');
   });
 
+  it('refuses a non-WebSocket "upgrade" so it cannot bypass the request pipeline', async () => {
+    // Attack: a client sends POST /v1/oauth/token with Upgrade: websocket to an
+    // allowed host. Node routes it to the 'upgrade' event; if the proxy forwarded
+    // it as an upgrade, it would skip handleTokenExchangeResponse and leak the real
+    // bearer token. The handshake gate must refuse it (400) before dialing upstream.
+    db.prepare(`INSERT INTO rules (domain, container_id, status) VALUES ('127.0.0.1', NULL, 'allow')`).run();
+    const status = await new Promise<string>((resolve, reject) => {
+      const c = net.connect(proxyPort, '127.0.0.1');
+      let buf = '';
+      const guard = setTimeout(() => { try { c.destroy(); } catch {} reject(new Error('timeout')); }, 4000);
+      c.on('connect', () => {
+        c.write(
+          `POST http://127.0.0.1:${upstreamPort}/v1/oauth/token HTTP/1.1\r\n` +
+          `Host: 127.0.0.1:${upstreamPort}\r\n` +
+          `Connection: Upgrade\r\nUpgrade: websocket\r\nContent-Length: 0\r\n\r\n`
+        );
+      });
+      c.on('data', (d) => {
+        buf += d.toString();
+        const m = buf.match(/^HTTP\/1\.1 (\d{3})/);
+        if (m) { clearTimeout(guard); try { c.destroy(); } catch {} resolve(m[1]); }
+      });
+      c.on('error', (e) => { clearTimeout(guard); reject(e); });
+    });
+    expect(status).toBe('400'); // refused, not forwarded as an upgrade
+  });
+
   it('cuts off a stalled upstream handshake (no socket-leak DoS)', async () => {
     // Host allowed, but upstream never completes the handshake. Without the
     // handshake timeout the client socket stays open indefinitely (Node's server

--- a/gateway/test/proxy-websocket.test.ts
+++ b/gateway/test/proxy-websocket.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import http from 'http';
+import net from 'net';
+import { WebSocket, WebSocketServer } from 'ws';
+import type { AddressInfo } from 'net';
+
+// ── WebSocket-proxying (#74) ────────────────────────────────────────────────
+// De proxy moet HTTP Upgrade-handshakes (WebSocket) forwarden, niet alleen
+// gewone requests. Node emit't een upgrade als een SEPARAAT 'upgrade'-event;
+// zonder handler sloot de gateway de socket en time-outte de handshake (de
+// Codex-CLI-vertraging). Deze suite pint het plain-HTTP-pad (`ws://`) vast:
+// een echte lokale ws-echoserver upstream, een echte ws-client die via de proxy
+// als forward-proxy-client verbindt. Het MITM-pad (`wss://`) deelt exact
+// dezelfde forwardUpgrade-helper en padhandhaving.
+//
+// better-sqlite3 is een native module; zonder gebouwde binding slaan we de suite
+// over (zie rules.test.ts / proxy-forward-path.test.ts). Probe vóór de db-import.
+let sqliteAvailable = true;
+try {
+  const mod = await import('better-sqlite3');
+  new mod.default(':memory:').close();
+} catch (e) {
+  sqliteAvailable = false;
+  console.warn(
+    `[proxy-websocket.test] SKIPPED — better-sqlite3 binding niet bruikbaar: ${(e as Error).message}`
+  );
+}
+
+let db: typeof import('../src/db').db;
+
+let upstream: WebSocketServer;
+let upstreamPort = 0;
+
+let proxy: http.Server;
+let proxyPort = 0;
+
+// createConnection-hook voor de ws-client: de client denkt dat hij rechtstreeks
+// met de upstream praat (Host-header + pad kloppen daardoor), maar de TCP-
+// verbinding gaat naar de proxy. De eerste write (de handshake-request-regel)
+// wordt herschreven van origin-vorm (`GET /pad`) naar de absolute vorm die een
+// forward-proxy verwacht (`GET http://host:poort/pad`) — precies wat een
+// HTTP-proxy-client (Codex met HTTPS_PROXY) op de draad zet.
+function proxyCreateConnection(upstreamP: number, proxyP: number) {
+  return () => {
+    const socket = net.connect(proxyP, '127.0.0.1');
+    const origWrite = socket.write.bind(socket) as typeof socket.write;
+    let rewritten = false;
+    (socket as any).write = (chunk: any, enc?: any, cb?: any) => {
+      if (!rewritten) {
+        rewritten = true;
+        const str = (Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk)).replace(
+          /^GET (\/[^ ]*) HTTP\/1\.1/,
+          `GET http://127.0.0.1:${upstreamP}$1 HTTP/1.1`
+        );
+        return origWrite(Buffer.from(str, 'utf8'), typeof enc === 'function' ? undefined : enc, typeof enc === 'function' ? enc : cb);
+      }
+      return origWrite(chunk, enc, cb);
+    };
+    return socket as any;
+  };
+}
+
+// Verbind een ws-client via de proxy naar de upstream. Resolvet met het bericht
+// dat de echo-server terugkaatst (bewijst end-to-end proxying), of rejectet.
+function wsEchoViaProxy(path: string, payload: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${upstreamPort}${path}`, {
+      createConnection: proxyCreateConnection(upstreamPort, proxyPort),
+    } as any);
+    ws.on('open', () => ws.send(payload));
+    ws.on('message', (data) => {
+      ws.close();
+      resolve(data.toString());
+    });
+    ws.on('error', reject);
+    ws.on('unexpected-response', (_req, res) => reject(new Error(`unexpected ${res.statusCode}`)));
+    setTimeout(() => reject(new Error('timeout')), 5000);
+  });
+}
+
+// Als bewust-geblokkeerd: verwacht dat de handshake NIET slaagt. Resolvet met de
+// HTTP-status van de weigering (403) of met 'error' bij een socketfout — beide
+// bewijzen dat er geen tunnel tot stand kwam.
+function wsExpectRejected(path: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${upstreamPort}${path}`, {
+      createConnection: proxyCreateConnection(upstreamPort, proxyPort),
+    } as any);
+    ws.on('open', () => {
+      ws.close();
+      reject(new Error('handshake unexpectedly succeeded'));
+    });
+    ws.on('unexpected-response', (_req, res) => resolve(`http:${res.statusCode}`));
+    ws.on('error', (err) => resolve(`error:${err.message}`));
+    setTimeout(() => reject(new Error('timeout')), 5000);
+  });
+}
+
+describe.skipIf(!sqliteAvailable)('proxy forwards WebSocket upgrades', () => {
+  beforeAll(async () => {
+    const dbMod = await import('../src/db');
+    db = dbMod.db;
+    dbMod.initDb();
+
+    // Geen Docker in de unit-omgeving: client-IP resolvet niet naar een
+    // container — regels op globaal niveau volstaan.
+    const dockerMod = await import('../src/docker');
+    vi.spyOn(dockerMod, 'resolveContainerByIp').mockResolvedValue(null);
+
+    // Upstream: echte ws-echoserver.
+    upstream = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+    upstream.on('connection', (socket) => {
+      socket.on('message', (data) => socket.send(data.toString()));
+    });
+    await new Promise<void>((r) => upstream.once('listening', () => r()));
+    upstreamPort = (upstream.address() as AddressInfo).port;
+
+    const { createProxyServer } = await import('../src/proxy');
+    proxy = createProxyServer(0);
+    await new Promise<void>((r) => proxy.once('listening', () => r()));
+    proxyPort = (proxy.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((r) => (proxy ? proxy.close(() => r()) : r()));
+    await new Promise<void>((r) => (upstream ? upstream.close(() => r()) : r()));
+  });
+
+  beforeEach(() => {
+    db.exec('DELETE FROM rules');
+  });
+
+  it('proxyt een toegestane WebSocket-upgrade end-to-end (echo)', async () => {
+    // Host-only allow voor de upstream-host → elk pad toegestaan.
+    db.prepare(`INSERT INTO rules (domain, container_id, status) VALUES ('127.0.0.1', NULL, 'allow')`).run();
+    const echoed = await wsEchoViaProxy('/echo', 'hallo huddle');
+    expect(echoed).toBe('hallo huddle');
+  });
+
+  it('weigert een upgrade naar een niet-toegestane host/pad (403)', async () => {
+    // Geen allow-regel → checkRule levert 'requested' op → fail-closed geweigerd.
+    const result = await wsExpectRejected('/echo');
+    expect(result).toBe('http:403');
+  });
+});

--- a/gateway/test/proxy-websocket.test.ts
+++ b/gateway/test/proxy-websocket.test.ts
@@ -168,9 +168,11 @@ describe.skipIf(!sqliteAvailable)('proxy forwards WebSocket upgrades', () => {
     db.prepare(`INSERT INTO rules (domain, container_id, status) VALUES ('127.0.0.1', NULL, 'allow')`).run();
     lastUpstreamHeaders = {};
     const echoed = await new Promise<string>((resolve, reject) => {
+      // Low-entropy, obviously-fake marker (NOT a real credential): we only assert
+      // it is stripped from upstream and redacted from the audit log.
       const ws = new WebSocket(`ws://127.0.0.1:${upstreamPort}/echo`, {
         createConnection: proxyCreateConnection(upstreamPort, proxyPort),
-        headers: { 'Proxy-Authorization': 'Basic c3VwZXItc2VjcmV0' },
+        headers: { 'Proxy-Authorization': 'Basic not-a-real-proxy-cred' },
       } as any);
       ws.on('open', () => ws.send('hi'));
       ws.on('message', (d) => { ws.close(); resolve(d.toString()); });
@@ -185,7 +187,7 @@ describe.skipIf(!sqliteAvailable)('proxy forwards WebSocket upgrades', () => {
       `SELECT res_status, req_headers FROM audit_log WHERE action = 'allow' AND domain = '127.0.0.1' ORDER BY id DESC LIMIT 1`
     ).get() as { res_status: number | null; req_headers: string | null };
     expect(row.res_status).toBe(101);
-    expect(row.req_headers ?? '').not.toContain('c3VwZXItc2VjcmV0');
+    expect(row.req_headers ?? '').not.toContain('not-a-real-proxy-cred');
     expect(row.req_headers ?? '').toContain('<redacted>');
   });
 


### PR DESCRIPTION
Node emits WebSocket handshakes as a separate `upgrade` event instead of `request`. The MITM innerHttp server and the top-level plain-HTTP server had no upgrade handler, so Node closed the socket and the handshake timed out — the Codex CLI delay on every prompt.

Both paths now forward Upgrade handshakes (`ws://` and `wss://`) transparently via a shared `forwardUpgrade` helper, with exactly the same fail-closed firewall enforcement (host + path) as the request handlers. Covered by `gateway/test/proxy-websocket.test.ts`.

Closes #74