### PR TITLE
feat(firewall): custom rules with in-path wildcards + UI/CLI to add them

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,43 @@ huddle firewall list -i      # interactive mode
 
 When a devcontainer tries to reach a blocked domain, the request appears on the Firewall page. From there you can allow the domain (permanently or temporarily) or reject it — per container or globally.
 
+### Custom rules and wildcards
+
+Besides triaging incoming requests, you can author your own rules up front — from the
+**Firewall** page (**Add rule**) or the CLI. Both the domain and an optional path
+pattern support wildcards:
+
+- **Domain wildcard** — a `*.` prefix matches any subdomain (but not the bare host).
+  For example `*.pkgs.dev.azure.com` matches `myorg.pkgs.dev.azure.com` but not
+  `pkgs.dev.azure.com`.
+- **Path wildcard** — a `*` in the path pattern matches any run of characters *within
+  a single segment* (it never crosses a `/`). A **trailing** `*` keeps the classic
+  prefix behaviour and spans deeper segments (`/foo/*` also matches `/foo/a/b`).
+
+This solves the Azure DevOps NuGet case, where every request carries a fresh feed GUID
+in the middle of the path so per-request approvals never match. Author one broad rule
+instead:
+
+```bash
+# Allow a whole Azure DevOps NuGet feed, GUID and endpoint wildcarded
+huddle firewall add "*.pkgs.dev.azure.com" --path "/_packaging/*/nuget/v3/*"
+
+# Deny a specific path on a domain, scoped to one container
+huddle firewall add example.com --path "/admin/*" --deny --container devcontainer-myapp
+```
+
+`huddle firewall add` options:
+
+| Option | Description |
+|--------|-------------|
+| `<domain>` | Domain to match (supports a leading `*.` wildcard). Required. |
+| `--path <pattern>` | Optional path pattern (supports `*` wildcards as described above). |
+| `--deny` | Create a block rule (default is allow). |
+| `--container <id>` | Scope the rule to one container (default is global). |
+
+Paths are normalised before matching, so traversal tricks (`/foo/../secret`,
+`/foo/..%2fsecret`) can never slip through a wildcard allow.
+
 ---
 
 ## AI configuration

--- a/cli/src/firewall.ts
+++ b/cli/src/firewall.ts
@@ -87,6 +87,42 @@ async function resolveRule(rule: Rule, status: 'allow' | 'deny', scope: 'rule' |
   await post<Rule>(`/api/rules/${rule.id}/resolve`, { status, scope });
 }
 
+export interface FirewallAddOptions {
+  domain?: string;
+  path?: string;
+  deny: boolean;
+  container?: string;
+}
+
+// Maakt een eigen firewall-regel aan. Ondersteunt wildcards: `*.` in het domein
+// (bv. `*.pkgs.dev.azure.com`) en `*` in het padpatroon (bv.
+// `/_packaging/*/nuget/v3/*` voor een Azure-DevOps-feed met een wisselende
+// GUID). Standaard 'allow'; met --deny een block-regel. Zonder --container is
+// de regel globaal.
+export async function runFirewallAdd(opts: FirewallAddOptions): Promise<void> {
+  const domain = (opts.domain ?? '').trim();
+  if (!domain) {
+    throw new Error(
+      'Usage: huddle firewall add <domain> [--path <pattern>] [--deny] [--container <id>]'
+    );
+  }
+  const status: 'allow' | 'deny' = opts.deny ? 'deny' : 'allow';
+  const path = opts.path?.trim();
+
+  const body: Record<string, unknown> = {
+    domain,
+    container_id: opts.container ?? null,
+    status,
+  };
+  if (path) body.path_pattern = path;
+
+  const rule = await post<Rule>('/api/rules', body);
+  const target = formatTarget(rule);
+  const scope = rule.container_id ? `container: ${rule.container_id}` : 'global';
+  const verb = status === 'deny' ? red('Denied') : green('Allowed');
+  console.log(`${verb} ${bold(cyan(target))} ${dim(`(${scope})`)}`);
+}
+
 function printRulesTable(rules: Rule[]): void {
   const headers = ['ID', 'Status', 'Domain/path', 'Container', 'Requests', 'Seen'];
   const rows = rules.map((r) => [

--- a/cli/src/firewall.ts
+++ b/cli/src/firewall.ts
@@ -94,11 +94,11 @@ export interface FirewallAddOptions {
   container?: string;
 }
 
-// Maakt een eigen firewall-regel aan. Ondersteunt wildcards: `*.` in het domein
-// (bv. `*.pkgs.dev.azure.com`) en `*` in het padpatroon (bv.
-// `/_packaging/*/nuget/v3/*` voor een Azure-DevOps-feed met een wisselende
-// GUID). Standaard 'allow'; met --deny een block-regel. Zonder --container is
-// de regel globaal.
+// Creates a custom firewall rule. Supports wildcards: `*.` in the domain
+// (e.g. `*.pkgs.dev.azure.com`) and `*` in the path pattern (e.g.
+// `/_packaging/*/nuget/v3/*` for an Azure DevOps feed with a rotating
+// GUID). Defaults to 'allow'; with --deny a block rule. Without --container the
+// rule is global.
 export async function runFirewallAdd(opts: FirewallAddOptions): Promise<void> {
   const domain = (opts.domain ?? '').trim();
   if (!domain) {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import { setBaseUrl, ApiError } from './api';
 import { runStart } from './start';
-import { runFirewallList } from './firewall';
+import { runFirewallList, runFirewallAdd } from './firewall';
 import { runInit } from './init';
 import { resolveImages } from './images';
 import { cliVersion } from './self-update';
@@ -22,8 +22,8 @@ interface ParsedArgs {
   flags: Record<string, string | boolean>;
 }
 
-const VALUE_FLAGS = new Set(['url', 'ide', 'name', 'image', 'workspace', 'container', 'status', 'runtime', 'experiment']);
-const BOOLEAN_FLAGS = new Set(['help', 'h', 'empty', 'i', 'interactive', 'version', 'v']);
+const VALUE_FLAGS = new Set(['url', 'ide', 'name', 'image', 'workspace', 'container', 'status', 'runtime', 'experiment', 'path']);
+const BOOLEAN_FLAGS = new Set(['help', 'h', 'empty', 'i', 'interactive', 'version', 'v', 'deny']);
 const COMMANDS = new Set(['start', 'firewall', 'fw', 'init', 'experiment', 'help', 'version']);
 
 function parseArgs(argv: string[]): ParsedArgs {
@@ -104,6 +104,8 @@ Usage:
                                      start them via Docker or Podman
   huddle firewall list [options]     Show firewall requests
   huddle fw list [options]           Alias for firewall list
+  huddle firewall add <domain>       Add a custom firewall rule (wildcards
+                                     supported: *.example.com and /path/*)
   huddle experiment use <nr>         Activate the experimental build of issue/PR <nr>
                                      and run init
   huddle experiment reset            Back to the stable release
@@ -123,9 +125,15 @@ Start options:
   --empty                            Empty container without a workspace
 
 Firewall options:
-  -i, --interactive                  Interactively approve/deny
-  --container <name>                 Filter by container
+  -i, --interactive                  Interactively approve/deny (list)
+  --container <name>                 Filter by (list) / scope to (add) a container
   --status <requested|allow|deny>    Filter by status (default: requested)
+
+Firewall add options:
+  --path <pattern>                   Path pattern; * matches within a segment,
+                                     a trailing * spans deeper segments
+                                     (e.g. /_packaging/*/nuget/v3/*)
+  --deny                             Create a block rule (default: allow)
 
 Global options:
   --url <url>                        Huddle URL (default: http://localhost:3000)
@@ -216,15 +224,23 @@ async function main(): Promise<void> {
 
   if (cmd === 'firewall' || cmd === 'fw') {
     const subCmd = sub ?? 'list';
-    if (subCmd !== 'list') {
+    if (subCmd === 'list') {
+      await runFirewallList({
+        interactive: flagBool(flags, 'i', 'interactive'),
+        container: flagString(flags, 'container'),
+        status: flagString(flags, 'status'),
+      });
+    } else if (subCmd === 'add') {
+      await runFirewallAdd({
+        domain: positional[2],
+        path: flagString(flags, 'path'),
+        deny: flagBool(flags, 'deny'),
+        container: flagString(flags, 'container'),
+      });
+    } else {
       console.error(`Unknown firewall subcommand: ${subCmd}`);
       process.exit(1);
     }
-    await runFirewallList({
-      interactive: flagBool(flags, 'i', 'interactive'),
-      container: flagString(flags, 'container'),
-      status: flagString(flags, 'status'),
-    });
     return;
   }
 

--- a/gateway/frontend/src/app/pages/firewall/firewall.component.css
+++ b/gateway/frontend/src/app/pages/firewall/firewall.component.css
@@ -157,6 +157,70 @@
 .seg button.on { background: var(--surface); color: var(--text); box-shadow: var(--shadow-card); }
 .seg button.on i { background: var(--accent-soft); color: var(--accent); }
 
+/* ===== Add custom rule ===== */
+.fw-add-btn {
+  display: inline-flex; align-items: center; gap: 7px;
+  margin-left: auto;
+  border: 1px solid var(--border); background: var(--surface-2); cursor: pointer;
+  font: inherit; font-size: 13px; font-weight: 600;
+  color: var(--text-muted);
+  padding: 7px 13px; border-radius: 9px;
+  transition: all .14s;
+}
+.fw-add-btn:hover { color: var(--text); background: var(--surface-hover); }
+.fw-add-btn.on { color: var(--accent); border-color: var(--accent-soft); background: var(--accent-soft); }
+
+.fw-add {
+  display: flex; flex-direction: column; gap: 14px;
+  margin: 4px 0 14px;
+  padding: 16px;
+  border: 1px solid var(--border); border-radius: 12px;
+  background: var(--surface-2);
+  animation: toastin .2s cubic-bezier(.22,1,.36,1);
+}
+.fw-add__grid {
+  display: grid; gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+.fw-add__field { display: flex; flex-direction: column; gap: 6px; }
+.fw-add__field > span {
+  font-size: 11px; font-weight: 600; letter-spacing: .04em;
+  text-transform: uppercase; color: var(--text-muted);
+}
+.fw-add__field > span em { font-style: normal; color: var(--text-dim); text-transform: none; letter-spacing: 0; }
+.fw-add__field input,
+.fw-add__field select {
+  border: 1px solid var(--border); border-radius: 9px;
+  background: var(--surface); color: var(--text);
+  font: inherit; font-size: 13.5px;
+  padding: 9px 12px; outline: none;
+  transition: border-color .14s;
+}
+.fw-add__field input { font-family: 'Space Grotesk', monospace; }
+.fw-add__field input:focus,
+.fw-add__field select:focus { border-color: var(--accent); }
+.fw-add__field input::placeholder { color: var(--text-dim); }
+
+.fw-add__foot {
+  display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+  justify-content: space-between;
+}
+.fw-add__hint { margin: 0; font-size: 12px; color: var(--text-muted); line-height: 1.5; flex: 1 1 300px; }
+.fw-add__hint code {
+  font-family: 'Space Grotesk', monospace; font-size: 11.5px;
+  background: var(--surface-hover); color: var(--text);
+  padding: 1px 5px; border-radius: 5px;
+}
+.fw-add__submit {
+  border: 0; border-radius: 9px; cursor: pointer;
+  font: inherit; font-size: 13px; font-weight: 600;
+  color: #fff; background: var(--accent);
+  padding: 9px 18px;
+  transition: opacity .14s, filter .14s;
+}
+.fw-add__submit:hover:not(:disabled) { filter: brightness(1.08); }
+.fw-add__submit:disabled { opacity: .5; cursor: not-allowed; }
+
 /* ===== Search ===== */
 .fw-search {
   display: flex; align-items: center; gap: 9px;

--- a/gateway/frontend/src/app/pages/firewall/firewall.component.html
+++ b/gateway/frontend/src/app/pages/firewall/firewall.component.html
@@ -108,7 +108,55 @@
             Path mode <i>{{ vm.pathDomains.length }}</i>
           </button>
         </div>
+        <button class="fw-add-btn" [class.on]="showAddForm" (click)="toggleAddForm()">
+          <app-icon [name]="showAddForm ? 'x' : 'globe'" [size]="15" />
+          {{ showAddForm ? 'Close' : 'Add rule' }}
+        </button>
       </div>
+
+      <!-- ── Add custom rule ── -->
+      @if (showAddForm) {
+        <form class="fw-add" (ngSubmit)="addCustomRule()">
+          <div class="fw-add__grid">
+            <label class="fw-add__field">
+              <span>Domain</span>
+              <input type="text" name="domain" [(ngModel)]="newDomain"
+                     placeholder="e.g. *.pkgs.dev.azure.com" autocomplete="off" />
+            </label>
+            <label class="fw-add__field">
+              <span>Path pattern <em>(optional)</em></span>
+              <input type="text" name="path" [(ngModel)]="newPath"
+                     placeholder="e.g. /_packaging/*/nuget/v3/*" autocomplete="off" />
+            </label>
+            <label class="fw-add__field">
+              <span>Scope</span>
+              <select name="scope" [(ngModel)]="newScope">
+                <option value="">Global</option>
+                @for (c of containers$ | async; track c.name) {
+                  <option [value]="c.name">{{ shortContainer(c.name) }}</option>
+                }
+              </select>
+            </label>
+            <label class="fw-add__field">
+              <span>Action</span>
+              <select name="action" [(ngModel)]="newAction">
+                <option value="allow">Allow</option>
+                <option value="deny">Deny</option>
+              </select>
+            </label>
+          </div>
+          <div class="fw-add__foot">
+            <p class="fw-add__hint">
+              Wildcards: <code>*.</code> in the domain matches subdomains; <code>*</code> in the
+              path matches within a segment, a trailing <code>*</code> spans deeper segments.
+            </p>
+            <button type="submit" class="fw-add__submit"
+                    [disabled]="!newDomain.trim() || addSubmitting">
+              Add rule
+            </button>
+          </div>
+        </form>
+      }
 
       @if (activeTab !== 'path') {
         <div class="fw-search">

--- a/gateway/frontend/src/app/pages/firewall/firewall.component.ts
+++ b/gateway/frontend/src/app/pages/firewall/firewall.component.ts
@@ -40,6 +40,19 @@ export class FirewallComponent {
   toasts: Toast[] = [];
   resolving = new Set<number>();
 
+  // Bekende containers voor de scope-keuze in het "eigen regel toevoegen"-formulier.
+  containers$ = this.state.containers$;
+
+  // ── "Add custom rule"-formulier ─────────────────────────────────────────────
+  // Laat de operator zelf een regel schrijven met wildcards: `*.` in het domein
+  // en `*` in het padpatroon (bv. een Azure-DevOps-feed met een wisselende GUID).
+  showAddForm = false;
+  addSubmitting = false;
+  newDomain = '';
+  newPath = '';
+  newScope = '';                       // '' = globaal, anders container_id
+  newAction: 'allow' | 'deny' = 'allow';
+
   readonly pieConfig: PieMenuConfig = {
     families: [
       {
@@ -180,6 +193,40 @@ export class FirewallComponent {
   );
 
   reload(): void { this.state.loadAll(); }
+
+  toggleAddForm(): void {
+    this.showAddForm = !this.showAddForm;
+    if (!this.showAddForm) this.resetAddForm();
+  }
+
+  private resetAddForm(): void {
+    this.newDomain = '';
+    this.newPath = '';
+    this.newScope = '';
+    this.newAction = 'allow';
+  }
+
+  addCustomRule(): void {
+    const domain = this.newDomain.trim();
+    if (!domain || this.addSubmitting) return;
+    const path = this.newPath.trim() || null;
+    const containerId = this.newScope || null;
+    this.addSubmitting = true;
+    this.api.createRule(domain, containerId, this.newAction, path).subscribe({
+      next: () => {
+        const tone: Toast['tone'] = this.newAction === 'deny' ? 'deny' : 'allow';
+        this.pushToast(path ? `${domain}${path}` : domain, `Rule ${this.newAction}ed`, tone);
+        this.addSubmitting = false;
+        this.showAddForm = false;
+        this.resetAddForm();
+        this.state.loadAll();
+      },
+      error: (err: Error) => {
+        this.addSubmitting = false;
+        this.pushToast(domain, err.message || 'Could not add rule', 'deny');
+      },
+    });
+  }
 
   enablePathMode(rule: Rule): void { this.api.setPathMode(rule.id, true).subscribe(() => this.state.loadAll()); }
   allowRule(rule: Rule): void      { this.api.resolveRule(rule.id, 'allow').subscribe(() => this.state.loadAll()); }

--- a/gateway/frontend/src/app/pages/firewall/firewall.component.ts
+++ b/gateway/frontend/src/app/pages/firewall/firewall.component.ts
@@ -40,17 +40,17 @@ export class FirewallComponent {
   toasts: Toast[] = [];
   resolving = new Set<number>();
 
-  // Bekende containers voor de scope-keuze in het "eigen regel toevoegen"-formulier.
+  // Known containers for the scope choice in the "add custom rule" form.
   containers$ = this.state.containers$;
 
-  // ── "Add custom rule"-formulier ─────────────────────────────────────────────
-  // Laat de operator zelf een regel schrijven met wildcards: `*.` in het domein
-  // en `*` in het padpatroon (bv. een Azure-DevOps-feed met een wisselende GUID).
+  // ── "Add custom rule" form ──────────────────────────────────────────────────
+  // Lets the operator write their own rule with wildcards: `*.` in the domain
+  // and `*` in the path pattern (e.g. an Azure DevOps feed with a rotating GUID).
   showAddForm = false;
   addSubmitting = false;
   newDomain = '';
   newPath = '';
-  newScope = '';                       // '' = globaal, anders container_id
+  newScope = '';                       // '' = global, otherwise container_id
   newAction: 'allow' | 'deny' = 'allow';
 
   readonly pieConfig: PieMenuConfig = {

--- a/gateway/src/api.ts
+++ b/gateway/src/api.ts
@@ -7,6 +7,7 @@ import { stateEvents, notifyStateChanged } from './events';
 import fastifyStatic from '@fastify/static';
 import { db, getAllGrants, setGrant, deleteGrant, getGrant, setActionPolicy, logAudit, getSudoGrant, getAirlocked, setAirlocked, getSetting, setSetting, listFolderMappings, getFolderMapping, createFolderMapping, updateFolderMapping, deleteFolderMapping, FolderMapping, listApprovedHostPorts, addApprovedHostPort, removeApprovedHostPort, ApprovedHostPort } from './db';
 import { DOCKER_ACTIONS, getEffectivePolicies, isKnownAction } from './docker-actions';
+import { ensurePathModeMarker } from './rules';
 import {
   listDevcontainers,
   inspectContainer,
@@ -415,6 +416,12 @@ export async function createApiServer(): Promise<FastifyInstance> {
       // supplies mixed-case here.
       if (container_id === null && path_pattern === null && (status === 'allow' || status === 'deny')) {
         db.prepare(`DELETE FROM rules WHERE domain = ? COLLATE NOCASE AND status = 'requested' AND path_pattern IS NULL`).run(domain);
+      }
+      // A path-scoped rule is inert over HTTPS unless its domain is in path-mode
+      // (finding #6a): establish the host-only path_mode=1 marker so the CONNECT
+      // is admitted and the path rule can actually fire, matching the portal flow.
+      if (path_pattern !== null) {
+        ensurePathModeMarker(domain, container_id);
       }
       logAudit({ containerId: container_id, domain, action: `admin:rule-${status}`, ruleId: Number(info.lastInsertRowid) });
       notifyStateChanged();

--- a/gateway/src/rules.ts
+++ b/gateway/src/rules.ts
@@ -397,3 +397,27 @@ export function isPathMode(domain: string, containerId: string | null): boolean 
   ];
   return rows.some(r => r.path_pattern === null && r.path_mode === 1);
 }
+
+// Ensure a domain is in path-allowlist mode after a path-scoped rule is created.
+// A path rule is inert over HTTPS unless a host-only marker (path_pattern IS NULL)
+// with path_mode=1 exists: the proxy only sees the host at CONNECT and admits the
+// tunnel (so MITM can read the path) only for a path-mode domain. Without the
+// marker the CONNECT is refused and the path rule never fires (finding #6a).
+// Idempotent: creates the marker, or promotes an existing host-only row to one
+// (a stale 'requested' placeholder becomes a default-deny marker; an explicit
+// allow/deny keeps its decision).
+export function ensurePathModeMarker(domain: string, containerId: string | null): void {
+  const marker = db
+    .prepare(
+      `SELECT id, status, path_mode FROM rules WHERE domain = ? COLLATE NOCASE AND COALESCE(container_id, '') = COALESCE(?, '') AND path_pattern IS NULL`
+    )
+    .get(domain, containerId) as { id: number; status: RuleStatus; path_mode: number } | undefined;
+  if (!marker) {
+    db.prepare(
+      `INSERT INTO rules (domain, container_id, status, path_pattern, path_mode) VALUES (?, ?, 'deny', NULL, 1)`
+    ).run(domain, containerId);
+  } else if (marker.path_mode !== 1) {
+    const status = marker.status === 'requested' ? 'deny' : marker.status;
+    db.prepare(`UPDATE rules SET path_mode = 1, status = ?, updated_at = unixepoch() WHERE id = ?`).run(status, marker.id);
+  }
+}

--- a/gateway/src/rules.ts
+++ b/gateway/src/rules.ts
@@ -104,46 +104,88 @@ export function matchDomain(pattern: string, host: string): boolean {
   return suffix.every((seg, i) => seg === hostSuffix[i]);
 }
 
-// Escape regex-metatekens in een letterlijk pad-fragment, zodat alleen onze
-// eigen `*`-vertaling (zie wildcardToRegExp) een speciale betekenis krijgt en
-// bv. een `.` in het patroon letterlijk een punt matcht i.p.v. "elk teken".
-function escapeRegExp(literal: string): string {
-  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+// Wildcard-matching gebeurt met een LINEAIRE two-pointer-scan i.p.v. een RegExp.
+// Reden (security, ReDoS): een `*`-patroon dat naar `new RegExp` gaat, zou bij
+// meerdere wildcards catastrofaal kunnen backtracken. Ook al escapen we alle
+// regex-metatekens in de letterlijke stukken, dan nog levert een patroon als
+// `/a*a*a*…X` de regex `^/a[^/]*a[^/]*a…X$` op — meerdere naast elkaar liggende
+// onbegrensde quantifiers die op een lang segment (attacker-gestuurd request-pad)
+// in polynomiale/exponentiële tijd ontsporen en de event-loop laten hangen.
+// Het glob-algoritme hieronder is O(n·m) en kent geen backtracking-explosie.
+
+// Een token in een gecompileerd patroon: een letterlijk teken (string), of een
+// wildcard. MID matcht een run tekens BINNEN één segment (kruist nooit `/`);
+// CROSS matcht alles incl. `/` (voor de trailing-prefix-semantiek).
+const MID_STAR = 0;
+const CROSS_STAR = 1;
+type Token = string | typeof MID_STAR | typeof CROSS_STAR;
+
+function tokenizeMid(literal: string): Token[] {
+  const out: Token[] = [];
+  for (const ch of literal) out.push(ch === '*' ? MID_STAR : ch);
+  return out;
 }
 
-// Vertaalt een padpatroon met `*`-wildcards naar een geankerde RegExp.
-// Regels:
-//   • Elke `*` MIDDEN in het patroon matcht een run tekens BINNEN één segment
-//     (`[^/]*`) en kruist dus nooit een `/` — precies wat de Azure-DevOps-case
-//     nodig heeft (een willekeurig segment als `/_packaging/<random>/nuget/…`).
-//   • Een `*` aan het EIND behoudt de oude prefix-semantiek en mag wél
-//     segment-grenzen kruisen, zodat bestaande `/foo/*`-regels niet regresseren
-//     (`/foo/*` matcht ook `/foo/a/b`). Staat er géén `/` vlak vóór de trailing
-//     `*`, dan moet de rest leeg zijn of op een segment-grens beginnen
-//     (`/safe*` matcht `/safe` en `/safe/x`, maar NIET `/safe-danger`).
-function wildcardToRegExp(pattern: string): RegExp {
-  const parts = pattern.split('*');
-  let re = '^';
-  for (let i = 0; i < parts.length; i++) {
-    re += escapeRegExp(parts[i]);
-    if (i === parts.length - 1) break; // laatste letterlijke deel, geen `*` meer
-    const isTrailing = i === parts.length - 2 && parts[parts.length - 1] === '';
-    if (isTrailing) {
-      // Trailing `*`: kruist segment-grenzen. Direct na een `/` (of aan de root)
-      // matcht het de hele rest incl. leeg (`.*`); anders eerst een segment-grens
-      // afdwingen zodat `/safe*` niet `/safe-danger` vangt (`(?:/.*)?`).
-      re += parts[i] === '' || parts[i].endsWith('/') ? '.*' : '(?:/.*)?';
+// Klassieke greedy glob-match met één onthouden wildcard-positie → O(n·m), geen
+// exponentieel backtracken. Een MID_STAR mag `/` niet opeten; een CROSS_STAR wel.
+function matchTokens(tokens: Token[], str: string): boolean {
+  let ti = 0;
+  let si = 0;
+  let starTi = -1;
+  let starCross = false;
+  let mark = 0;
+  const n = tokens.length;
+  const m = str.length;
+  while (si < m) {
+    if (ti < n && typeof tokens[ti] === 'string' && tokens[ti] === str[si]) {
+      ti++;
+      si++;
+    } else if (ti < n && typeof tokens[ti] !== 'string') {
+      starTi = ti;
+      starCross = tokens[ti] === CROSS_STAR;
+      mark = si;
+      ti++;
+    } else if (starTi !== -1) {
+      // Rek de laatst geziene wildcard één teken op. Een MID_STAR stopt bij `/`.
+      if (!starCross && str[mark] === '/') return false;
+      ti = starTi + 1;
+      mark++;
+      si = mark;
     } else {
-      re += '[^/]*';
+      return false;
     }
   }
-  re += '$';
-  return new RegExp(re);
+  while (ti < n && typeof tokens[ti] !== 'string') ti++;
+  return ti === n;
+}
+
+// Matcht een padpatroon met `*`-wildcards tegen een pad. Semantiek:
+//   • Elke `*` MIDDEN in het patroon matcht binnen één segment (kruist geen `/`)
+//     — precies wat de Azure-DevOps-case nodig heeft (`/_packaging/<random>/…`).
+//   • Een `*` aan het EIND mag segment-grenzen kruisen (prefix-match), zodat
+//     `/foo/*` ook `/foo/a/b` matcht. Staat er géén `/` vlak vóór die trailing
+//     `*`, dan moet de rest leeg zijn of op een segment-grens beginnen
+//     (`/safe*` matcht `/safe` en `/safe/x`, maar NIET `/safe-danger`).
+// Opeenvolgende `*` worden samengetrokken tot één (`**` ≡ `*`); dat is bewust
+// (voorkomt naast elkaar liggende wildcards) en semantisch onbeduidend.
+function matchWildcardPath(rawPattern: string, path: string): boolean {
+  const pattern = rawPattern.replace(/\*+/g, '*');
+  if (pattern.endsWith('*')) {
+    const core = pattern.slice(0, -1); // patroon zonder de trailing `*`
+    const crossSegment = core === '' || core.endsWith('/');
+    if (crossSegment) {
+      return matchTokens([...tokenizeMid(core), CROSS_STAR], path);
+    }
+    // Trailing `*` niet op een grens: rest leeg (exacte core) OF `/` + wat dan ook.
+    if (matchTokens(tokenizeMid(core), path)) return true;
+    return matchTokens([...tokenizeMid(core), '/', CROSS_STAR], path);
+  }
+  return matchTokens(tokenizeMid(pattern), path);
 }
 
 // Matcht een padpatroon tegen een pad. Een null/leeg patroon is een host-only
 // regel en matcht elk pad. Een patroon mag `*`-wildcards bevatten (zie
-// wildcardToRegExp: midden = binnen één segment, eind = prefix-match die
+// matchWildcardPath: midden = binnen één segment, eind = prefix-match die
 // segmenten mag kruisen). Zonder `*` geldt exacte gelijkheid.
 //
 // Het pad wordt eerst genormaliseerd (query eraf, één decode, `..` fail-closed)
@@ -155,7 +197,7 @@ export function matchPath(pattern: string | null, path: string | null): boolean 
   const reqPath = normalizePathname(path);
   if (reqPath === null) return false; // traversal / kapotte encoding → fail closed
   if (!pattern.includes('*')) return reqPath === pattern;
-  return wildcardToRegExp(pattern).test(reqPath);
+  return matchWildcardPath(pattern, reqPath);
 }
 
 // Groepeert een pad op zijn eerste segment tot een prefix-patroon, bv.

--- a/gateway/src/rules.ts
+++ b/gateway/src/rules.ts
@@ -314,9 +314,17 @@ export function checkRule(
   }
 
   if (candidates.length > 0) {
-    // Pick the most specific. On equal specificity, deny wins over allow
+    // Pick the winning rule. A concrete decision (allow/deny) always outranks an
+    // unresolved 'requested' placeholder, regardless of host-specificity —
+    // otherwise a stale exact-host 'requested' row (auto-created on an earlier
+    // block) would shadow a matching wildcard allow and keep the host blocked
+    // even after the operator added a covering rule (finding #7). Among concrete
+    // rules the most specific wins, and on equal specificity deny beats allow
     // (fail-closed).
     candidates.sort((a, b) => {
+      const concrete = (st: RuleStatus) => (st === 'requested' ? 0 : 1);
+      const c = concrete(b.status) - concrete(a.status);
+      if (c !== 0) return c;
       const d = specificity(b) - specificity(a);
       if (d !== 0) return d;
       const rank = (st: RuleStatus) => (st === 'deny' ? 0 : st === 'allow' ? 1 : 2);

--- a/gateway/src/rules.ts
+++ b/gateway/src/rules.ts
@@ -104,10 +104,47 @@ export function matchDomain(pattern: string, host: string): boolean {
   return suffix.every((seg, i) => seg === hostSuffix[i]);
 }
 
+// Escape regex-metatekens in een letterlijk pad-fragment, zodat alleen onze
+// eigen `*`-vertaling (zie wildcardToRegExp) een speciale betekenis krijgt en
+// bv. een `.` in het patroon letterlijk een punt matcht i.p.v. "elk teken".
+function escapeRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Vertaalt een padpatroon met `*`-wildcards naar een geankerde RegExp.
+// Regels:
+//   • Elke `*` MIDDEN in het patroon matcht een run tekens BINNEN één segment
+//     (`[^/]*`) en kruist dus nooit een `/` — precies wat de Azure-DevOps-case
+//     nodig heeft (een willekeurig segment als `/_packaging/<random>/nuget/…`).
+//   • Een `*` aan het EIND behoudt de oude prefix-semantiek en mag wél
+//     segment-grenzen kruisen, zodat bestaande `/foo/*`-regels niet regresseren
+//     (`/foo/*` matcht ook `/foo/a/b`). Staat er géén `/` vlak vóór de trailing
+//     `*`, dan moet de rest leeg zijn of op een segment-grens beginnen
+//     (`/safe*` matcht `/safe` en `/safe/x`, maar NIET `/safe-danger`).
+function wildcardToRegExp(pattern: string): RegExp {
+  const parts = pattern.split('*');
+  let re = '^';
+  for (let i = 0; i < parts.length; i++) {
+    re += escapeRegExp(parts[i]);
+    if (i === parts.length - 1) break; // laatste letterlijke deel, geen `*` meer
+    const isTrailing = i === parts.length - 2 && parts[parts.length - 1] === '';
+    if (isTrailing) {
+      // Trailing `*`: kruist segment-grenzen. Direct na een `/` (of aan de root)
+      // matcht het de hele rest incl. leeg (`.*`); anders eerst een segment-grens
+      // afdwingen zodat `/safe*` niet `/safe-danger` vangt (`(?:/.*)?`).
+      re += parts[i] === '' || parts[i].endsWith('/') ? '.*' : '(?:/.*)?';
+    } else {
+      re += '[^/]*';
+    }
+  }
+  re += '$';
+  return new RegExp(re);
+}
+
 // Matcht een padpatroon tegen een pad. Een null/leeg patroon is een host-only
-// regel en matcht elk pad. `*` aan het eind is een prefix-match op
-// SEGMENT-grens (`/api/v1/*` matcht `/api/v1/foo` maar `/safe*` matcht NIET
-// `/safe-danger`); anders exacte gelijkheid.
+// regel en matcht elk pad. Een patroon mag `*`-wildcards bevatten (zie
+// wildcardToRegExp: midden = binnen één segment, eind = prefix-match die
+// segmenten mag kruisen). Zonder `*` geldt exacte gelijkheid.
 //
 // Het pad wordt eerst genormaliseerd (query eraf, één decode, `..` fail-closed)
 // zodat traversal-trucs (`/foo/../secret`, `/foo/..%2fsecret`) niet door een
@@ -117,17 +154,8 @@ export function matchPath(pattern: string | null, path: string | null): boolean 
   if (pattern === null || pattern === '') return true;
   const reqPath = normalizePathname(path);
   if (reqPath === null) return false; // traversal / kapotte encoding → fail closed
-  if (pattern.endsWith('*')) {
-    const prefix = pattern.slice(0, -1);
-    if (!reqPath.startsWith(prefix)) return false;
-    // Prefix die al op een segment-grens eindigt (`/foo/`) — of leeg is —
-    // matcht direct. Anders moet het volgende teken een `/` zijn (of het eind),
-    // zodat `/safe*` niet `/safe-danger` vangt.
-    if (prefix === '' || prefix.endsWith('/')) return true;
-    const rest = reqPath.slice(prefix.length);
-    return rest === '' || rest.startsWith('/');
-  }
-  return reqPath === pattern;
+  if (!pattern.includes('*')) return reqPath === pattern;
+  return wildcardToRegExp(pattern).test(reqPath);
 }
 
 // Groepeert een pad op zijn eerste segment tot een prefix-patroon, bv.

--- a/gateway/src/rules.ts
+++ b/gateway/src/rules.ts
@@ -13,82 +13,81 @@ interface RuleRow {
   path_mode: number;
 }
 
-// ── Pure match-helpers (geen DB) ─────────────────────────────────────────────
-// Bewust los van de DB zodat ze deterministisch testbaar zijn zonder draaiende
-// SQLite-binding.
+// ── Pure match helpers (no DB) ───────────────────────────────────────────────
+// Deliberately decoupled from the DB so they are deterministically testable
+// without a running SQLite binding.
 
-// Canoniseer een host naar precies de vorm waarop de downstream (OS-resolver,
-// SNI, upstream-server) hem zal interpreteren, zodat de proxy op één plek — aan
-// de grens — normaliseert en daarna zowel matcht als forward't op diezelfde
-// waarde. Voorkomt de parser-differential-klasse (finding #3 en de staart:
-// hoofdletters, IDN/punycode, trailing dot, control chars).
+// Canonicalize a host to exactly the form in which the downstream (OS resolver,
+// SNI, upstream server) will interpret it, so the proxy normalizes in one place
+// — at the boundary — and then both matches and forwards on that same value.
+// Prevents the parser-differential class (finding #3 and its tail: uppercase,
+// IDN/punycode, trailing dot, control chars).
 //
-// Retourneert de canonieke host (lowercase, punycode, zonder trailing dot) of
-// null wanneer de host ongeldig/verdacht is (control chars, whitespace, lege of
-// onparseerbare host) — de caller moet dan fail-closed weigeren.
+// Returns the canonical host (lowercase, punycode, without trailing dot) or
+// null when the host is invalid/suspicious (control chars, whitespace, empty or
+// unparseable host) — the caller must then fail-closed and reject.
 export function canonicalizeHost(raw: string): string | null {
   if (typeof raw !== 'string') return null;
   const trimmed = raw.trim();
   if (!trimmed) return null;
-  // Control chars en whitespace horen nooit in een host (request-smuggling /
-  // log-injectie) — weiger ze expliciet vóór het parsen.
+  // Control chars and whitespace never belong in a host (request smuggling /
+  // log injection) — reject them explicitly before parsing.
   // eslint-disable-next-line no-control-regex
   if (/[\s\u0000-\u001f\u007f]/.test(trimmed)) return null;
   let host: string;
   try {
-    // De WHATWG-URL-parser doet precies de canonicalisatie die de downstream
-    // ook doet: lowercasen, IDNA/punycode toepassen, de host valideren en
-    // bracketed IPv6 normaliseren. We voeren enkel de authority in.
+    // The WHATWG URL parser performs exactly the canonicalization the
+    // downstream also does: lowercasing, applying IDNA/punycode, validating the
+    // host and normalizing bracketed IPv6. We only feed in the authority.
     host = new URL(`http://${trimmed}`).hostname;
   } catch {
     return null;
   }
   if (!host) return null;
-  // Eén trailing dot (FQDN-root) strippen: `a.b.` en `a.b` zijn dezelfde host
-  // voor DNS/SNI. Een dubbele punt aan het eind is ongeldig → laten vallen.
+  // Strip one trailing dot (FQDN root): `a.b.` and `a.b` are the same host for
+  // DNS/SNI. A double dot at the end is invalid → drop it.
   if (host.endsWith('.') && !host.endsWith('..')) host = host.slice(0, -1);
   return host.toLowerCase();
 }
 
-// Normaliseer een request-pad naar de vorm waarop de upstream het zal
-// interpreteren, zodat pad-allowlist-matching niet te omzeilen is met traversal
-// (finding #7). Strategie: query/fragment eraf, één keer percent-decoden, en
-// fail-closed weigeren (null) zodra er een `..`-segment overblijft of de
-// encoding kapot is. `.`-segmenten worden weggevouwen. Bewust NIET verder
-// canonicaliseren dan dat: het pad dat we forwarden blijft de originele
-// (encoded) bytes, zodat legitieme %-encoded tekens niet verminkt worden — we
-// beslissen op de gedecodeerde vorm, maar traversal wordt altijd geblokkeerd,
-// dus er worden nooit `..`-bytes doorgestuurd.
+// Normalize a request path to the form in which the upstream will interpret it,
+// so path-allowlist matching cannot be bypassed with traversal (finding #7).
+// Strategy: drop query/fragment, percent-decode once, and fail-closed reject
+// (null) as soon as a `..` segment remains or the encoding is broken. `.`
+// segments are folded away. Deliberately NO further canonicalization than that:
+// the path we forward stays the original (encoded) bytes, so legitimate
+// %-encoded characters are not mangled — we decide on the decoded form, but
+// traversal is always blocked, so `..` bytes are never forwarded.
 export function normalizePathname(raw: string | null): string | null {
   const input = raw ?? '';
-  // Query en fragment horen niet bij het pad; strip ze vóór het decoden.
+  // Query and fragment are not part of the path; strip them before decoding.
   let p = input.split('#')[0].split('?')[0];
   if (p === '') p = '/';
   let decoded: string;
   try {
     decoded = decodeURIComponent(p);
   } catch {
-    // Kapotte percent-encoding (bv. `%zz`, `%2`) → fail closed.
+    // Broken percent-encoding (e.g. `%zz`, `%2`) → fail closed.
     return null;
   }
   const segs = decoded.split('/');
-  // Elk `..`-segment na één decode is traversal — legitieme flows hebben het
-  // niet nodig. Fail closed i.p.v. proberen te resolven (dat opent double-decode
-  // en clamp-tot-root varianten).
+  // Every `..` segment after one decode is traversal — legitimate flows do not
+  // need it. Fail closed instead of trying to resolve (which opens double-decode
+  // and clamp-to-root variants).
   if (segs.some(s => s === '..')) return null;
-  // `.`-segmenten (huidige map) zijn onschuldig maar vervuilen de match; vouw ze
-  // weg. Lege segmenten (`//`, leidende `/`) blijven staan zodat een trailing
-  // slash behouden blijft.
+  // `.` segments (current directory) are harmless but pollute the match; fold
+  // them away. Empty segments (`//`, leading `/`) remain so that a trailing
+  // slash is preserved.
   const out = segs.filter(s => s !== '.');
   let result = out.join('/');
   if (!result.startsWith('/')) result = '/' + result;
   return result;
 }
 
-// Matcht een domein-patroon tegen een host. Exacte gelijkheid, of een wildcard
-// `*.example.com` die elke subdomein-host matcht (maar NIET kaal `example.com`).
-// Bewust strikt: split op punten en vergelijk segment-voor-segment, zodat
-// substring-trucs (`evilexample.com`, `a.b.example.com.attacker.com`) falen.
+// Matches a domain pattern against a host. Exact equality, or a wildcard
+// `*.example.com` that matches every subdomain host (but NOT bare `example.com`).
+// Deliberately strict: split on dots and compare segment by segment, so
+// substring tricks (`evilexample.com`, `a.b.example.com.attacker.com`) fail.
 export function matchDomain(pattern: string, host: string): boolean {
   if (!pattern || !host) return false;
   const p = pattern.toLowerCase();
@@ -96,26 +95,26 @@ export function matchDomain(pattern: string, host: string): boolean {
   if (p === h) return true;
   if (!p.startsWith('*.')) return false;
 
-  const suffix = p.slice(2).split('.'); // segmenten ná de "*."
+  const suffix = p.slice(2).split('.'); // segments after the "*."
   const hostSegs = h.split('.');
-  // Een wildcard vereist minstens één subdomein-segment vóór het suffix.
+  // A wildcard requires at least one subdomain segment before the suffix.
   if (hostSegs.length <= suffix.length) return false;
   const hostSuffix = hostSegs.slice(hostSegs.length - suffix.length);
   return suffix.every((seg, i) => seg === hostSuffix[i]);
 }
 
-// Wildcard-matching gebeurt met een LINEAIRE two-pointer-scan i.p.v. een RegExp.
-// Reden (security, ReDoS): een `*`-patroon dat naar `new RegExp` gaat, zou bij
-// meerdere wildcards catastrofaal kunnen backtracken. Ook al escapen we alle
-// regex-metatekens in de letterlijke stukken, dan nog levert een patroon als
-// `/a*a*a*…X` de regex `^/a[^/]*a[^/]*a…X$` op — meerdere naast elkaar liggende
-// onbegrensde quantifiers die op een lang segment (attacker-gestuurd request-pad)
-// in polynomiale/exponentiële tijd ontsporen en de event-loop laten hangen.
-// Het glob-algoritme hieronder is O(n·m) en kent geen backtracking-explosie.
+// Wildcard matching is done with a LINEAR two-pointer scan instead of a RegExp.
+// Reason (security, ReDoS): a `*` pattern that goes into `new RegExp` could
+// backtrack catastrophically with multiple wildcards. Even if we escape all
+// regex metacharacters in the literal parts, a pattern like `/a*a*a*…X` still
+// yields the regex `^/a[^/]*a[^/]*a…X$` — multiple adjacent unbounded
+// quantifiers that, on a long segment (attacker-controlled request path), blow
+// up in polynomial/exponential time and hang the event loop. The glob algorithm
+// below is O(n·m) and has no backtracking explosion.
 
-// Een token in een gecompileerd patroon: een letterlijk teken (string), of een
-// wildcard. MID matcht een run tekens BINNEN één segment (kruist nooit `/`);
-// CROSS matcht alles incl. `/` (voor de trailing-prefix-semantiek).
+// A token in a compiled pattern: a literal character (string), or a wildcard.
+// MID matches a run of characters WITHIN one segment (never crosses `/`); CROSS
+// matches everything incl. `/` (for the trailing-prefix semantics).
 const MID_STAR = 0;
 const CROSS_STAR = 1;
 type Token = string | typeof MID_STAR | typeof CROSS_STAR;
@@ -126,8 +125,8 @@ function tokenizeMid(literal: string): Token[] {
   return out;
 }
 
-// Klassieke greedy glob-match met één onthouden wildcard-positie → O(n·m), geen
-// exponentieel backtracken. Een MID_STAR mag `/` niet opeten; een CROSS_STAR wel.
+// Classic greedy glob match with a single remembered wildcard position → O(n·m),
+// no exponential backtracking. A MID_STAR may not eat `/`; a CROSS_STAR may.
 function matchTokens(tokens: Token[], str: string): boolean {
   let ti = 0;
   let si = 0;
@@ -146,7 +145,7 @@ function matchTokens(tokens: Token[], str: string): boolean {
       mark = si;
       ti++;
     } else if (starTi !== -1) {
-      // Rek de laatst geziene wildcard één teken op. Een MID_STAR stopt bij `/`.
+      // Stretch the last-seen wildcard by one character. A MID_STAR stops at `/`.
       if (!starCross && str[mark] === '/') return false;
       ti = starTi + 1;
       mark++;
@@ -159,51 +158,52 @@ function matchTokens(tokens: Token[], str: string): boolean {
   return ti === n;
 }
 
-// Matcht een padpatroon met `*`-wildcards tegen een pad. Semantiek:
-//   • Elke `*` MIDDEN in het patroon matcht binnen één segment (kruist geen `/`)
-//     — precies wat de Azure-DevOps-case nodig heeft (`/_packaging/<random>/…`).
-//   • Een `*` aan het EIND mag segment-grenzen kruisen (prefix-match), zodat
-//     `/foo/*` ook `/foo/a/b` matcht. Staat er géén `/` vlak vóór die trailing
-//     `*`, dan moet de rest leeg zijn of op een segment-grens beginnen
-//     (`/safe*` matcht `/safe` en `/safe/x`, maar NIET `/safe-danger`).
-// Opeenvolgende `*` worden samengetrokken tot één (`**` ≡ `*`); dat is bewust
-// (voorkomt naast elkaar liggende wildcards) en semantisch onbeduidend.
+// Matches a path pattern with `*` wildcards against a path. Semantics:
+//   • Every `*` in the MIDDLE of the pattern matches within one segment (does
+//     not cross `/`) — exactly what the Azure DevOps case needs
+//     (`/_packaging/<random>/…`).
+//   • A `*` at the END may cross segment boundaries (prefix match), so `/foo/*`
+//     also matches `/foo/a/b`. If there is NO `/` right before that trailing
+//     `*`, the rest must be empty or start on a segment boundary (`/safe*`
+//     matches `/safe` and `/safe/x`, but NOT `/safe-danger`).
+// Consecutive `*` are collapsed into one (`**` ≡ `*`); that is deliberate
+// (avoids adjacent wildcards) and semantically insignificant.
 function matchWildcardPath(rawPattern: string, path: string): boolean {
   const pattern = rawPattern.replace(/\*+/g, '*');
   if (pattern.endsWith('*')) {
-    const core = pattern.slice(0, -1); // patroon zonder de trailing `*`
+    const core = pattern.slice(0, -1); // pattern without the trailing `*`
     const crossSegment = core === '' || core.endsWith('/');
     if (crossSegment) {
       return matchTokens([...tokenizeMid(core), CROSS_STAR], path);
     }
-    // Trailing `*` niet op een grens: rest leeg (exacte core) OF `/` + wat dan ook.
+    // Trailing `*` not on a boundary: rest empty (exact core) OR `/` + anything.
     if (matchTokens(tokenizeMid(core), path)) return true;
     return matchTokens([...tokenizeMid(core), '/', CROSS_STAR], path);
   }
   return matchTokens(tokenizeMid(pattern), path);
 }
 
-// Matcht een padpatroon tegen een pad. Een null/leeg patroon is een host-only
-// regel en matcht elk pad. Een patroon mag `*`-wildcards bevatten (zie
-// matchWildcardPath: midden = binnen één segment, eind = prefix-match die
-// segmenten mag kruisen). Zonder `*` geldt exacte gelijkheid.
+// Matches a path pattern against a path. A null/empty pattern is a host-only
+// rule and matches every path. A pattern may contain `*` wildcards (see
+// matchWildcardPath: middle = within one segment, end = prefix match that may
+// cross segments). Without `*`, exact equality applies.
 //
-// Het pad wordt eerst genormaliseerd (query eraf, één decode, `..` fail-closed)
-// zodat traversal-trucs (`/foo/../secret`, `/foo/..%2fsecret`) niet door een
-// `/foo/*`-allow glippen (finding #7). Een pad dat niet veilig normaliseert
-// matcht nooit.
+// The path is normalized first (drop query, one decode, `..` fail-closed) so
+// that traversal tricks (`/foo/../secret`, `/foo/..%2fsecret`) do not slip
+// through a `/foo/*` allow (finding #7). A path that does not normalize safely
+// never matches.
 export function matchPath(pattern: string | null, path: string | null): boolean {
   if (pattern === null || pattern === '') return true;
   const reqPath = normalizePathname(path);
-  if (reqPath === null) return false; // traversal / kapotte encoding → fail closed
+  if (reqPath === null) return false; // traversal / broken encoding → fail closed
   if (!pattern.includes('*')) return reqPath === pattern;
   return matchWildcardPath(pattern, reqPath);
 }
 
-// Groepeert een pad op zijn eerste segment tot een prefix-patroon, bv.
-// `/api/v1/users?x=1` → `/api/*`. Dit is het patroon waarmee een onbekend subpad
-// van een pad-allowlist-domein als 'requested' wordt opgevoerd; de operator kan
-// het later verfijnen naar iets specifiekers (`/api/v1/*` of exact `/api/v1/x`).
+// Groups a path by its first segment into a prefix pattern, e.g.
+// `/api/v1/users?x=1` → `/api/*`. This is the pattern under which an unknown
+// subpath of a path-allowlist domain is filed as 'requested'; the operator can
+// refine it later into something more specific (`/api/v1/*` or exact `/api/v1/x`).
 export function firstSegmentPattern(path: string): string {
   const clean = path.split('?')[0].split('#')[0];
   const segs = clean.split('/').filter(Boolean);
@@ -215,11 +215,11 @@ let stmts: ReturnType<typeof prepareStmts> | null = null;
 
 function prepareStmts() {
   return {
-    // COLLATE NOCASE: de exacte-host lookup moet hoofdletter-ongevoelig zijn,
-    // net als matchDomain (dat beide kanten lowercase't). Zonder dit werd een
-    // exacte deny-regel omzeild door de host anders te kapitaliseren (finding
-    // #3). Domeinen worden bovendien lowercase opgeslagen (zie checkRule +
-    // db.ts-migratie) — dit is de belt-and-suspenders SQL-kant.
+    // COLLATE NOCASE: the exact-host lookup must be case-insensitive, just like
+    // matchDomain (which lowercases both sides). Without this an exact deny rule
+    // was bypassed by capitalizing the host differently (finding #3). Domains
+    // are moreover stored lowercase (see checkRule + db.ts migration) — this is
+    // the belt-and-suspenders SQL side.
     selectPerContainer: db.prepare<[string, string]>(
       `SELECT id, domain, status, expires_at, container_id, path_pattern, path_mode FROM rules WHERE domain = ? COLLATE NOCASE AND container_id = ?`
     ),
@@ -257,8 +257,8 @@ function s() {
 
 type Candidate = RuleRow & { domain_is_wildcard: boolean };
 
-// Specificiteit van een kandidaat-regel. Hoger = specifieker = wint. Volgorde:
-// per-container > globaal; exacte host > wildcard host; mét pad > zonder pad.
+// Specificity of a candidate rule. Higher = more specific = wins. Order:
+// per-container > global; exact host > wildcard host; with path > without path.
 function specificity(c: Candidate): number {
   let score = 0;
   if (c.container_id !== null) score += 4;
@@ -272,18 +272,18 @@ export function checkRule(
   containerId: string | null,
   path: string | null = null,
 ): { status: RuleStatus; ruleId: number | null } {
-  // Canoniseer de host één keer aan de rand: lowercase zodat exacte lookups en
-  // wildcard-matching op dezelfde vorm werken (finding #3). De proxy voert al de
-  // volledige punycode/trailing-dot-canonicalisatie uit via canonicalizeHost;
-  // hier lowercasen we defensief voor directe callers/tests.
+  // Canonicalize the host once at the boundary: lowercase so that exact lookups
+  // and wildcard matching operate on the same form (finding #3). The proxy
+  // already performs the full punycode/trailing-dot canonicalization via
+  // canonicalizeHost; here we lowercase defensively for direct callers/tests.
   const domain = rawDomain.toLowerCase();
   const {
     selectPerContainer, selectGlobal, selectWildcardPerContainer, selectWildcardGlobal,
     touchRule, setLastPath, insertRequested, insertRequestedPath, resetExpired,
   } = s();
 
-  // Verzamel alle kandidaat-regels: exacte-host (per-container + globaal) en
-  // wildcard-host (per-container + globaal). Filter daarna in TypeScript.
+  // Collect all candidate rules: exact-host (per-container + global) and
+  // wildcard-host (per-container + global). Then filter in TypeScript.
   const candidates: Candidate[] = [];
 
   const addExact = (rows: RuleRow[]) => {
@@ -299,9 +299,9 @@ export function checkRule(
     }
   };
 
-  // Airlock: een geïsoleerde container krijgt géén globale-regel-fallback. Alleen
-  // zijn eigen allow-regels tellen; al het overige verkeer wordt als requested
-  // opgevoerd (zie de no-match-tak onderaan). De globale lookup wordt overgeslagen.
+  // Airlock: an isolated container gets NO global-rule fallback. Only its own
+  // allow rules count; all other traffic is filed as requested (see the no-match
+  // branch at the bottom). The global lookup is skipped.
   const airlocked = containerId ? getAirlocked(containerId) : false;
 
   if (containerId) {
@@ -314,7 +314,7 @@ export function checkRule(
   }
 
   if (candidates.length > 0) {
-    // Kies de meest specifieke. Bij gelijke specificiteit wint deny van allow
+    // Pick the most specific. On equal specificity, deny wins over allow
     // (fail-closed).
     candidates.sort((a, b) => {
       const d = specificity(b) - specificity(a);
@@ -324,19 +324,18 @@ export function checkRule(
     });
     const best = candidates[0];
 
-    // Pad-allowlist modus: er bestaat een host-only marker-regel (path_mode=1).
-    // Matchte alléén die marker (geen specifiekere padregel), dan is dit subpad
-    // nog onbekend: voer het — gegroepeerd op het eerste padsegment — als
-    // 'requested' op zodat de operator het kan beoordelen, i.p.v. het stil te
-    // weigeren. Een wél matchende padregel (allow/deny/requested) wordt hieronder
-    // gewoon gehonoreerd.
+    // Path-allowlist mode: a host-only marker rule exists (path_mode=1). If only
+    // that marker matched (no more specific path rule), this subpath is still
+    // unknown: file it — grouped by the first path segment — as 'requested' so
+    // the operator can review it, instead of silently rejecting it. A path rule
+    // that does match (allow/deny/requested) is simply honored below.
     const inPathMode = candidates.some(c => c.path_pattern === null && c.path_mode === 1);
     if (inPathMode && path !== null) {
       const hostOnlyBest = best.path_pattern === null || best.path_pattern === '';
       if (hostOnlyBest) {
-        // Alléén de host-only marker matchte → onbekend subpad: groepeer op het
-        // eerste segment en voer het als requested op. Bewaar het volledige pad
-        // als concreet voorbeeld voor de operator.
+        // Only the host-only marker matched → unknown subpath: group by the
+        // first segment and file it as requested. Keep the full path as a
+        // concrete example for the operator.
         const grp = firstSegmentPattern(path);
         const containerForRule = best.container_id;
         const inserted = insertRequestedPath.run(domain, containerForRule, grp);
@@ -348,12 +347,12 @@ export function checkRule(
         return { status: 'requested', ruleId: created?.id ?? null };
       }
       if (best.status === 'requested') {
-        // Bestaande requested-groep opnieuw geraakt → ververs het voorbeeld-pad.
+        // Existing requested group hit again → refresh the example path.
         setLastPath.run(path, best.id);
         touchRule.run(best.id);
         return { status: 'requested', ruleId: best.id };
       }
-      // Anders won een expliciete allow/deny-padregel → normale afhandeling.
+      // Otherwise an explicit allow/deny path rule won → normal handling.
     }
 
     if (best.status === 'allow' && best.expires_at !== null && best.expires_at < Math.floor(Date.now() / 1000)) {
@@ -364,8 +363,8 @@ export function checkRule(
     return { status: best.status, ruleId: best.id };
   }
 
-  // Geen match → maak een host-only requested-regel aan zodat de operator hem
-  // in de UI ziet. (Pad wordt niet vastgelegd: de operator kiest zelf scope.)
+  // No match → create a host-only requested rule so the operator sees it in the
+  // UI. (The path is not recorded: the operator chooses the scope themselves.)
   const inserted = insertRequested.run(domain, containerId);
   if (inserted.changes > 0) notifyStateChanged();
   const created = (containerId
@@ -378,10 +377,10 @@ export function checkRule(
   return { status: 'requested', ruleId: created?.id ?? null };
 }
 
-// Staat dit domein in pad-allowlist modus? D.w.z. bestaat er een host-only
-// marker-regel (path_mode=1) die geldt voor deze container of globaal. De proxy
-// gebruikt dit bij CONNECT (pad nog versleuteld) om de HTTPS-tunnel tóch toe te
-// laten, zodat MITM het pad kan zien en de echte handhaving per request gebeurt.
+// Is this domain in path-allowlist mode? I.e. does a host-only marker rule
+// (path_mode=1) exist that applies to this container or globally. The proxy uses
+// this at CONNECT (path still encrypted) to allow the HTTPS tunnel anyway, so
+// that MITM can see the path and the real enforcement happens per request.
 export function isPathMode(domain: string, containerId: string | null): boolean {
   const { selectPerContainer, selectGlobal } = s();
   const rows = [

--- a/gateway/test/rules.test.ts
+++ b/gateway/test/rules.test.ts
@@ -31,6 +31,7 @@ let matchDomain: typeof import('../src/rules').matchDomain;
 let matchPath: typeof import('../src/rules').matchPath;
 let firstSegmentPattern: typeof import('../src/rules').firstSegmentPattern;
 let isPathMode: typeof import('../src/rules').isPathMode;
+let ensurePathModeMarker: typeof import('../src/rules').ensurePathModeMarker;
 let canonicalizeHost: typeof import('../src/rules').canonicalizeHost;
 let normalizePathname: typeof import('../src/rules').normalizePathname;
 
@@ -60,6 +61,7 @@ describe.skipIf(!sqliteAvailable)('checkRule', () => {
     matchPath = rulesMod.matchPath;
     firstSegmentPattern = rulesMod.firstSegmentPattern;
     isPathMode = rulesMod.isPathMode;
+    ensurePathModeMarker = rulesMod.ensurePathModeMarker;
     canonicalizeHost = rulesMod.canonicalizeHost;
     normalizePathname = rulesMod.normalizePathname;
     dbMod.initDb();
@@ -79,6 +81,18 @@ describe.skipIf(!sqliteAvailable)('checkRule', () => {
       setRule('sub.example.com', null, 'requested');
       setRule('*.example.com', null, 'deny');
       expect(checkRule('sub.example.com', null).status).toBe('deny');
+    });
+  });
+
+  describe('finding #6a: a path-scoped rule establishes path mode', () => {
+    it('ensurePathModeMarker admits the CONNECT and makes the path rule fire', () => {
+      // `firewall add example.com --path /get*`: a path allow with no marker.
+      setRule('example.com', null, 'allow', null, '/get*', 0);
+      expect(isPathMode('example.com', null)).toBe(false); // inert without the marker
+      ensurePathModeMarker('example.com', null);
+      expect(isPathMode('example.com', null)).toBe(true);  // path-mode -> CONNECT admitted
+      expect(checkRule('example.com', null, '/get').status).toBe('allow');
+      expect(checkRule('example.com', null, '/other').status).not.toBe('allow');
     });
   });
 

--- a/gateway/test/rules.test.ts
+++ b/gateway/test/rules.test.ts
@@ -174,6 +174,14 @@ describe.skipIf(!sqliteAvailable)('checkRule', () => {
     it('is hoofdletter-ongevoelig', () => {
       expect(matchDomain('*.NPMJS.org', 'Registry.npmjs.ORG')).toBe(true);
     });
+    it('handmatig geschreven Azure-DevOps wildcard-domein matcht de feed-hosts', () => {
+      expect(matchDomain('*.pkgs.dev.azure.com', 'myorg.pkgs.dev.azure.com')).toBe(true);
+      expect(matchDomain('*.pkgs.dev.azure.com', 'other.pkgs.dev.azure.com')).toBe(true);
+      // Kale host zonder subdomein matcht niet.
+      expect(matchDomain('*.pkgs.dev.azure.com', 'pkgs.dev.azure.com')).toBe(false);
+      // Geen substring-truc naar een aanvaller-domein.
+      expect(matchDomain('*.pkgs.dev.azure.com', 'myorg.pkgs.dev.azure.com.evil.test')).toBe(false);
+    });
   });
 
   describe('matchPath (pure helper)', () => {
@@ -190,6 +198,44 @@ describe.skipIf(!sqliteAvailable)('checkRule', () => {
     it('exacte match zonder wildcard', () => {
       expect(matchPath('/exact', '/exact')).toBe(true);
       expect(matchPath('/exact', '/exact/more')).toBe(false);
+    });
+    it('wildcard midden in het pad matcht binnen één segment', () => {
+      expect(matchPath('/foo/*/bar', '/foo/xyz/bar')).toBe(true);
+      expect(matchPath('/foo/*/bar', '/foo/123/bar')).toBe(true);
+      // `*` kruist geen `/`: een extra segment mag niet.
+      expect(matchPath('/foo/*/bar', '/foo/a/b/bar')).toBe(false);
+      // De letterlijke delen moeten kloppen.
+      expect(matchPath('/foo/*/bar', '/foo/x/baz')).toBe(false);
+    });
+    it('meerdere wildcards in één patroon', () => {
+      expect(matchPath('/a/*/b/*/c', '/a/1/b/2/c')).toBe(true);
+      expect(matchPath('/a/*/b/*/c', '/a/1/b/2/3/c')).toBe(false);
+    });
+    it('wildcard binnen een segment (niet op een grens)', () => {
+      expect(matchPath('/pkg-*.nupkg', '/pkg-abc.nupkg')).toBe(true);
+      expect(matchPath('/pkg-*.nupkg', '/pkg-a/b.nupkg')).toBe(false);
+    });
+    it('Azure DevOps NuGet-feed: random segment in het midden', () => {
+      // De feed-GUID wisselt per request, de rest van het endpoint is stabiel.
+      const pat = '/_packaging/*/nuget/v3/*';
+      expect(matchPath(pat, '/_packaging/1a2b3c/nuget/v3/index.json')).toBe(true);
+      // Trailing `*` mag diepere segmenten kruisen (flat2/registrations2/…).
+      expect(matchPath(pat, '/_packaging/1a2b3c/nuget/v3/flat2/newtonsoft.json/index.json')).toBe(true);
+      // Het random GUID-segment mag zelf geen `/` bevatten.
+      expect(matchPath(pat, '/_packaging/a/b/nuget/v3/index.json')).toBe(false);
+      // Een ander endpoint valt buiten het patroon.
+      expect(matchPath(pat, '/_packaging/1a2b3c/npm/registry')).toBe(false);
+    });
+    it('mid-wildcard laat traversal nog steeds fail-closed', () => {
+      // Normalisatie draait vóór de match: `..` → null → nooit een match.
+      expect(matchPath('/foo/*/bar', '/foo/../bar')).toBe(false);
+      expect(matchPath('/_packaging/*/nuget/v3/*', '/_packaging/x/..%2f..%2fadmin')).toBe(false);
+    });
+    it('regex-metatekens in het patroon zijn letterlijk', () => {
+      // De `.` mag geen "elk teken" worden.
+      expect(matchPath('/v3/index.json', '/v3/indexXjson')).toBe(false);
+      expect(matchPath('/a.b/*', '/aXb/c')).toBe(false);
+      expect(matchPath('/a.b/*', '/a.b/c')).toBe(true);
     });
   });
 

--- a/gateway/test/rules.test.ts
+++ b/gateway/test/rules.test.ts
@@ -66,6 +66,22 @@ describe.skipIf(!sqliteAvailable)('checkRule', () => {
   });
   beforeEach(() => { db.exec('DELETE FROM rules'); db.exec('DELETE FROM containers'); });
 
+  describe('finding #7: a concrete rule outranks a stale requested placeholder', () => {
+    it('a matching wildcard allow wins over an exact-host requested row', () => {
+      // Host blocked earlier -> exact-host 'requested' row auto-created; operator
+      // then adds a covering wildcard allow. The allow must win (not stay blocked).
+      setRule('sub.example.com', null, 'requested');
+      setRule('*.example.com', null, 'allow');
+      expect(checkRule('sub.example.com', null).status).toBe('allow');
+    });
+
+    it('a matching wildcard deny also wins over an exact-host requested row', () => {
+      setRule('sub.example.com', null, 'requested');
+      setRule('*.example.com', null, 'deny');
+      expect(checkRule('sub.example.com', null).status).toBe('deny');
+    });
+  });
+
   describe('per-container rules', () => {
     it('allow for an allowed domain', () => {
       setRule('example.com', CID, 'allow');

--- a/gateway/test/rules.test.ts
+++ b/gateway/test/rules.test.ts
@@ -237,6 +237,25 @@ describe.skipIf(!sqliteAvailable)('checkRule', () => {
       expect(matchPath('/a.b/*', '/aXb/c')).toBe(false);
       expect(matchPath('/a.b/*', '/a.b/c')).toBe(true);
     });
+    it('ReDoS-hard: veel wildcards op een lang segment blijven snel (geen backtracking-explosie)', () => {
+      // Een patroon met veel wildcards + een lang, attacker-gestuurd segment
+      // dat NIET matcht liet de oude RegExp-aanpak (`[^/]*a[^/]*a…X$`)
+      // catastrofaal backtracken en hing de event-loop. De lineaire matcher is
+      // O(n·m): dit moet ruim binnen een paar milliseconden falen.
+      const evil = '/' + 'a*'.repeat(50) + 'X';
+      const longSegment = '/' + 'a'.repeat(5000); // één segment, geen `/`, geen `X`
+      const t0 = performance.now();
+      const result = matchPath(evil, longSegment);
+      const elapsed = performance.now() - t0;
+      expect(result).toBe(false);
+      expect(elapsed).toBeLessThan(100);
+    });
+    it('opeenvolgende `*` worden samengetrokken (`**` ≡ `*`)', () => {
+      // `**` is één wildcard: dezelfde segment-grens-semantiek als één `*`.
+      expect(matchPath('/safe**', '/safe')).toBe(true);
+      expect(matchPath('/safe**', '/safe/x')).toBe(true);
+      expect(matchPath('/safe**', '/safe-danger')).toBe(false);
+    });
   });
 
   describe('padgebaseerde regels', () => {

--- a/gateway/test/rules.test.ts
+++ b/gateway/test/rules.test.ts
@@ -1,29 +1,29 @@
 import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
 
-// ── Boundary A — per-domein firewall rules engine ───────────────────────────
-// checkRule is het hart van de proxy-beslissing (allow / deny / requested).
-// Draait tegen een in-memory SQLite (zie vitest.config.ts env DB_PATH).
+// ── Boundary A — per-domain firewall rules engine ───────────────────────────
+// checkRule is the heart of the proxy decision (allow / deny / requested).
+// Runs against an in-memory SQLite (see vitest.config.ts env DB_PATH).
 //
-// better-sqlite3 is een native module. In een DMZ-devcontainer zonder gebouwde
-// binding (nodejs.org geblokkeerd → node-gyp kan geen headers halen) slaan we
-// deze suite over; in de huddle-image / CI is de binding wél aanwezig en draait
-// hij volledig. Probe daarom de binding voordat we db.ts importeren.
+// better-sqlite3 is a native module. In a DMZ devcontainer without a built
+// binding (nodejs.org blocked → node-gyp can't fetch headers) we skip this
+// suite; in the huddle image / CI the binding is present and it runs fully.
+// Therefore probe the binding before we import db.ts.
 let sqliteAvailable = true;
 try {
   const mod = await import('better-sqlite3');
   new mod.default(':memory:').close();
 } catch (e) {
   sqliteAvailable = false;
-  // Niet stil overslaan — anders verbergt een verkeerde/ontbrekende native binding
-  // (bv. node_modules van een ander platform) dat deze suite niet draait.
+  // Don't skip silently — otherwise a wrong/missing native binding
+  // (e.g. node_modules from another platform) hides that this suite isn't running.
   console.warn(
-    `[rules.test] SKIPPED — better-sqlite3 binding niet bruikbaar: ${(e as Error).message}\n` +
-    `  Fix op je host: \`npm rebuild better-sqlite3\` (of verwijder node_modules en \`npm install\`).`
+    `[rules.test] SKIPPED — better-sqlite3 binding not usable: ${(e as Error).message}\n` +
+    `  Fix on your host: \`npm rebuild better-sqlite3\` (or remove node_modules and \`npm install\`).`
   );
 }
 
-// Dynamisch geïmporteerd (pas ná de probe) zodat het ontbreken van de binding
-// niet de hele testfile laat crashen.
+// Dynamically imported (only after the probe) so that a missing binding does not
+// crash the entire test file.
 let db: typeof import('../src/db').db;
 let setAirlocked: typeof import('../src/db').setAirlocked;
 let checkRule: typeof import('../src/rules').checkRule;
@@ -67,62 +67,62 @@ describe.skipIf(!sqliteAvailable)('checkRule', () => {
   beforeEach(() => { db.exec('DELETE FROM rules'); db.exec('DELETE FROM containers'); });
 
   describe('per-container rules', () => {
-    it('allow voor een toegestaan domein', () => {
+    it('allow for an allowed domain', () => {
       setRule('example.com', CID, 'allow');
       expect(checkRule('example.com', CID).status).toBe('allow');
     });
 
-    it('deny voor een geblokkeerd domein', () => {
+    it('deny for a blocked domain', () => {
       setRule('evil.test', CID, 'deny');
       expect(checkRule('evil.test', CID).status).toBe('deny');
     });
 
-    it('onbekend domein wordt automatisch als "requested" aangemaakt', () => {
+    it('unknown domain is automatically created as "requested"', () => {
       const r = checkRule('new-domain.test', CID);
       expect(r.status).toBe('requested');
       const row = db.prepare(`SELECT status FROM rules WHERE domain=? AND container_id=?`).get('new-domain.test', CID) as any;
       expect(row?.status).toBe('requested');
     });
 
-    it('per-container rule heeft voorrang op een globale rule', () => {
-      setRule('split.test', null, 'deny');   // globaal geblokkeerd
-      setRule('split.test', CID, 'allow');    // maar voor deze container toegestaan
+    it('per-container rule takes precedence over a global rule', () => {
+      setRule('split.test', null, 'deny');   // globally blocked
+      setRule('split.test', CID, 'allow');    // but allowed for this container
       expect(checkRule('split.test', CID).status).toBe('allow');
     });
   });
 
   describe('global rules', () => {
-    it('globale allow geldt wanneer er geen per-container rule is', () => {
+    it('global allow applies when there is no per-container rule', () => {
       setRule('global.test', null, 'allow');
       expect(checkRule('global.test', CID).status).toBe('allow');
     });
 
-    it('globale rules gelden ook zonder containerId', () => {
+    it('global rules also apply without a containerId', () => {
       setRule('global.test', null, 'deny');
       expect(checkRule('global.test', null).status).toBe('deny');
     });
   });
 
   describe('airlock', () => {
-    it('airlocked container negeert een globale allow-regel', () => {
+    it('airlocked container ignores a global allow rule', () => {
       setRule('global.test', null, 'allow');
       setAirlocked(CID, true);
-      // Geen per-container regel + globale lookup overgeslagen → requested.
+      // No per-container rule + global lookup skipped → requested.
       expect(checkRule('global.test', CID).status).toBe('requested');
     });
 
-    it('zonder airlock geldt dezelfde globale allow-regel wél', () => {
+    it('without airlock the same global allow rule does apply', () => {
       setRule('global.test', null, 'allow');
       expect(checkRule('global.test', CID).status).toBe('allow');
     });
 
-    it('airlocked container honoreert nog steeds zijn eigen allow-regel', () => {
+    it('airlocked container still honors its own allow rule', () => {
       setRule('own.test', CID, 'allow');
       setAirlocked(CID, true);
       expect(checkRule('own.test', CID).status).toBe('allow');
     });
 
-    it('airlock uitschakelen herstelt de globale fallback', () => {
+    it('disabling airlock restores the global fallback', () => {
       setRule('global.test', null, 'allow');
       setAirlocked(CID, true);
       expect(checkRule('global.test', CID).status).toBe('requested');
@@ -134,10 +134,10 @@ describe.skipIf(!sqliteAvailable)('checkRule', () => {
   });
 
   describe('temp-allow expiry', () => {
-    it('een verlopen temp-allow valt terug naar "requested"', () => {
+    it('an expired temp-allow falls back to "requested"', () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date('2026-06-01T12:00:00Z'));
-      const past = Math.floor(Date.now() / 1000) - 60; // 1 min geleden verlopen
+      const past = Math.floor(Date.now() / 1000) - 60; // expired 1 min ago
       setRule('temp.test', CID, 'allow', past);
       expect(checkRule('temp.test', CID).status).toBe('requested');
       const row = db.prepare(`SELECT status FROM rules WHERE domain=? AND container_id=?`).get('temp.test', CID) as any;
@@ -145,10 +145,10 @@ describe.skipIf(!sqliteAvailable)('checkRule', () => {
       vi.useRealTimers();
     });
 
-    it('een nog-geldige temp-allow blijft "allow"', () => {
+    it('a still-valid temp-allow stays "allow"', () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date('2026-06-01T12:00:00Z'));
-      const future = Math.floor(Date.now() / 1000) + 600; // nog 10 min geldig
+      const future = Math.floor(Date.now() / 1000) + 600; // still valid for 10 min
       setRule('temp2.test', CID, 'allow', future);
       expect(checkRule('temp2.test', CID).status).toBe('allow');
       vi.useRealTimers();
@@ -156,138 +156,138 @@ describe.skipIf(!sqliteAvailable)('checkRule', () => {
   });
 
   describe('matchDomain (pure helper)', () => {
-    it('matcht exacte host', () => {
+    it('matches exact host', () => {
       expect(matchDomain('npmjs.org', 'npmjs.org')).toBe(true);
       expect(matchDomain('npmjs.org', 'other.org')).toBe(false);
     });
-    it('wildcard matcht subdomein', () => {
+    it('wildcard matches subdomain', () => {
       expect(matchDomain('*.npmjs.org', 'registry.npmjs.org')).toBe(true);
       expect(matchDomain('*.npmjs.org', 'dist.npmjs.org')).toBe(true);
     });
-    it('wildcard matcht NIET de kale host', () => {
+    it('wildcard does NOT match the bare host', () => {
       expect(matchDomain('*.npmjs.org', 'npmjs.org')).toBe(false);
     });
-    it('wildcard glipt niet via substring-trucs', () => {
+    it('wildcard does not slip through via substring tricks', () => {
       expect(matchDomain('*.npmjs.org', 'evilnpmjs.org')).toBe(false);
       expect(matchDomain('*.npmjs.org', 'a.b.npmjs.org.attacker.com')).toBe(false);
     });
-    it('is hoofdletter-ongevoelig', () => {
+    it('is case-insensitive', () => {
       expect(matchDomain('*.NPMJS.org', 'Registry.npmjs.ORG')).toBe(true);
     });
-    it('handmatig geschreven Azure-DevOps wildcard-domein matcht de feed-hosts', () => {
+    it('hand-written Azure DevOps wildcard domain matches the feed hosts', () => {
       expect(matchDomain('*.pkgs.dev.azure.com', 'myorg.pkgs.dev.azure.com')).toBe(true);
       expect(matchDomain('*.pkgs.dev.azure.com', 'other.pkgs.dev.azure.com')).toBe(true);
-      // Kale host zonder subdomein matcht niet.
+      // Bare host without a subdomain does not match.
       expect(matchDomain('*.pkgs.dev.azure.com', 'pkgs.dev.azure.com')).toBe(false);
-      // Geen substring-truc naar een aanvaller-domein.
+      // No substring trick to an attacker domain.
       expect(matchDomain('*.pkgs.dev.azure.com', 'myorg.pkgs.dev.azure.com.evil.test')).toBe(false);
     });
   });
 
   describe('matchPath (pure helper)', () => {
-    it('null/leeg patroon matcht elk pad', () => {
+    it('null/empty pattern matches every path', () => {
       expect(matchPath(null, '/anything')).toBe(true);
       expect(matchPath('', '/anything')).toBe(true);
       expect(matchPath(null, null)).toBe(true);
     });
-    it('prefix-match met trailing *', () => {
+    it('prefix match with trailing *', () => {
       expect(matchPath('/api/v1/*', '/api/v1/foo')).toBe(true);
       expect(matchPath('/api/v1/*', '/api/v1/')).toBe(true);
       expect(matchPath('/api/v1/*', '/api/v2/x')).toBe(false);
     });
-    it('exacte match zonder wildcard', () => {
+    it('exact match without wildcard', () => {
       expect(matchPath('/exact', '/exact')).toBe(true);
       expect(matchPath('/exact', '/exact/more')).toBe(false);
     });
-    it('wildcard midden in het pad matcht binnen één segment', () => {
+    it('wildcard in the middle of the path matches within one segment', () => {
       expect(matchPath('/foo/*/bar', '/foo/xyz/bar')).toBe(true);
       expect(matchPath('/foo/*/bar', '/foo/123/bar')).toBe(true);
-      // `*` kruist geen `/`: een extra segment mag niet.
+      // `*` does not cross `/`: an extra segment is not allowed.
       expect(matchPath('/foo/*/bar', '/foo/a/b/bar')).toBe(false);
-      // De letterlijke delen moeten kloppen.
+      // The literal parts must match.
       expect(matchPath('/foo/*/bar', '/foo/x/baz')).toBe(false);
     });
-    it('meerdere wildcards in één patroon', () => {
+    it('multiple wildcards in one pattern', () => {
       expect(matchPath('/a/*/b/*/c', '/a/1/b/2/c')).toBe(true);
       expect(matchPath('/a/*/b/*/c', '/a/1/b/2/3/c')).toBe(false);
     });
-    it('wildcard binnen een segment (niet op een grens)', () => {
+    it('wildcard within a segment (not on a boundary)', () => {
       expect(matchPath('/pkg-*.nupkg', '/pkg-abc.nupkg')).toBe(true);
       expect(matchPath('/pkg-*.nupkg', '/pkg-a/b.nupkg')).toBe(false);
     });
-    it('Azure DevOps NuGet-feed: random segment in het midden', () => {
-      // De feed-GUID wisselt per request, de rest van het endpoint is stabiel.
+    it('Azure DevOps NuGet feed: random segment in the middle', () => {
+      // The feed GUID changes per request, the rest of the endpoint is stable.
       const pat = '/_packaging/*/nuget/v3/*';
       expect(matchPath(pat, '/_packaging/1a2b3c/nuget/v3/index.json')).toBe(true);
-      // Trailing `*` mag diepere segmenten kruisen (flat2/registrations2/…).
+      // Trailing `*` may cross deeper segments (flat2/registrations2/…).
       expect(matchPath(pat, '/_packaging/1a2b3c/nuget/v3/flat2/newtonsoft.json/index.json')).toBe(true);
-      // Het random GUID-segment mag zelf geen `/` bevatten.
+      // The random GUID segment itself may not contain a `/`.
       expect(matchPath(pat, '/_packaging/a/b/nuget/v3/index.json')).toBe(false);
-      // Een ander endpoint valt buiten het patroon.
+      // A different endpoint falls outside the pattern.
       expect(matchPath(pat, '/_packaging/1a2b3c/npm/registry')).toBe(false);
     });
-    it('mid-wildcard laat traversal nog steeds fail-closed', () => {
-      // Normalisatie draait vóór de match: `..` → null → nooit een match.
+    it('mid-wildcard still leaves traversal fail-closed', () => {
+      // Normalization runs before the match: `..` → null → never a match.
       expect(matchPath('/foo/*/bar', '/foo/../bar')).toBe(false);
       expect(matchPath('/_packaging/*/nuget/v3/*', '/_packaging/x/..%2f..%2fadmin')).toBe(false);
     });
-    it('regex-metatekens in het patroon zijn letterlijk', () => {
-      // De `.` mag geen "elk teken" worden.
+    it('regex metacharacters in the pattern are literal', () => {
+      // The `.` must not become "any character".
       expect(matchPath('/v3/index.json', '/v3/indexXjson')).toBe(false);
       expect(matchPath('/a.b/*', '/aXb/c')).toBe(false);
       expect(matchPath('/a.b/*', '/a.b/c')).toBe(true);
     });
-    it('ReDoS-hard: veel wildcards op een lang segment blijven snel (geen backtracking-explosie)', () => {
-      // Een patroon met veel wildcards + een lang, attacker-gestuurd segment
-      // dat NIET matcht liet de oude RegExp-aanpak (`[^/]*a[^/]*a…X$`)
-      // catastrofaal backtracken en hing de event-loop. De lineaire matcher is
-      // O(n·m): dit moet ruim binnen een paar milliseconden falen.
+    it('ReDoS-hard: many wildcards on a long segment stay fast (no backtracking explosion)', () => {
+      // A pattern with many wildcards + a long, attacker-controlled segment
+      // that does NOT match made the old RegExp approach (`[^/]*a[^/]*a…X$`)
+      // backtrack catastrophically and hung the event loop. The linear matcher
+      // is O(n·m): this must fail well within a few milliseconds.
       const evil = '/' + 'a*'.repeat(50) + 'X';
-      const longSegment = '/' + 'a'.repeat(5000); // één segment, geen `/`, geen `X`
+      const longSegment = '/' + 'a'.repeat(5000); // one segment, no `/`, no `X`
       const t0 = performance.now();
       const result = matchPath(evil, longSegment);
       const elapsed = performance.now() - t0;
       expect(result).toBe(false);
       expect(elapsed).toBeLessThan(100);
     });
-    it('opeenvolgende `*` worden samengetrokken (`**` ≡ `*`)', () => {
-      // `**` is één wildcard: dezelfde segment-grens-semantiek als één `*`.
+    it('consecutive `*` are collapsed (`**` ≡ `*`)', () => {
+      // `**` is one wildcard: the same segment-boundary semantics as a single `*`.
       expect(matchPath('/safe**', '/safe')).toBe(true);
       expect(matchPath('/safe**', '/safe/x')).toBe(true);
       expect(matchPath('/safe**', '/safe-danger')).toBe(false);
     });
   });
 
-  describe('padgebaseerde regels', () => {
-    it('padregel allow matcht alleen het toegestane pad', () => {
+  describe('path-based rules', () => {
+    it('path rule allow matches only the allowed path', () => {
       setRule('github.com', CID, 'allow', null, '/anthropics/*');
       expect(checkRule('github.com', CID, '/anthropics/x').status).toBe('allow');
-      // Geen andere regel → onbekend pad wordt "requested"
+      // No other rule → unknown path becomes "requested"
       expect(checkRule('github.com', CID, '/other').status).toBe('requested');
     });
 
-    it('padregel wint van host-only regel', () => {
+    it('path rule wins over host-only rule', () => {
       setRule('github.com', CID, 'deny');                       // host-only deny
-      setRule('github.com', CID, 'allow', null, '/anthropics/*'); // specifieker
+      setRule('github.com', CID, 'allow', null, '/anthropics/*'); // more specific
       expect(checkRule('github.com', CID, '/anthropics/x').status).toBe('allow');
-      expect(checkRule('github.com', CID, '/elders').status).toBe('deny');
+      expect(checkRule('github.com', CID, '/elsewhere').status).toBe('deny');
     });
 
-    it('per-container padregel wint van globale host-regel', () => {
-      setRule('github.com', null, 'deny');                      // globaal host-only
-      setRule('github.com', CID, 'allow', null, '/org/*');      // per-container + pad
+    it('per-container path rule wins over global host rule', () => {
+      setRule('github.com', null, 'deny');                      // global host-only
+      setRule('github.com', CID, 'allow', null, '/org/*');      // per-container + path
       expect(checkRule('github.com', CID, '/org/x').status).toBe('allow');
     });
 
-    it('wildcard-domein allow matcht subdomein', () => {
+    it('wildcard domain allow matches subdomain', () => {
       setRule('*.npmjs.org', null, 'allow');
       expect(checkRule('registry.npmjs.org', CID).status).toBe('allow');
       expect(checkRule('npmjs.org', CID).status).toBe('requested');
     });
 
-    it('deny wint van allow bij gelijke specificiteit (fail-closed)', () => {
-      // Twee verschillende wildcard-domeinen die allebei dezelfde host matchen:
-      // gelijke specificiteit (globaal, wildcard, geen pad), distinct identity.
+    it('deny wins over allow on equal specificity (fail-closed)', () => {
+      // Two different wildcard domains that both match the same host:
+      // equal specificity (global, wildcard, no path), distinct identity.
       setRule('*.npmjs.org', null, 'allow');
       setRule('*.org', null, 'deny');
       expect(checkRule('registry.npmjs.org', CID).status).toBe('deny');
@@ -295,31 +295,31 @@ describe.skipIf(!sqliteAvailable)('checkRule', () => {
   });
 
   describe('firstSegmentPattern (pure helper)', () => {
-    it('groepeert op het eerste padsegment', () => {
+    it('groups by the first path segment', () => {
       expect(firstSegmentPattern('/api/v1/users')).toBe('/api/*');
       expect(firstSegmentPattern('/api')).toBe('/api/*');
     });
-    it('negeert query- en fragment-delen', () => {
+    it('ignores query and fragment parts', () => {
       expect(firstSegmentPattern('/api/v1?x=1')).toBe('/api/*');
       expect(firstSegmentPattern('/repos/foo#frag')).toBe('/repos/*');
     });
-    it('root-pad wordt /*', () => {
+    it('root path becomes /*', () => {
       expect(firstSegmentPattern('/')).toBe('/*');
       expect(firstSegmentPattern('')).toBe('/*');
     });
   });
 
-  describe('pad-allowlist modus (path_mode)', () => {
-    it('host-only marker blokkeert het kale domein, maar voert subpaden op als requested', () => {
+  describe('path-allowlist mode (path_mode)', () => {
+    it('host-only marker blocks the bare domain, but files subpaths as requested', () => {
       setRule('github.com', CID, 'deny', null, null, 1); // marker
 
-      // Onbekend subpad → requested, en er ontstaat een gegroepeerde padregel.
+      // Unknown subpath → requested, and a grouped path rule is created.
       expect(checkRule('github.com', CID, '/anthropics/claude').status).toBe('requested');
       const row = db.prepare(
         `SELECT status, path_pattern, last_path FROM rules WHERE domain=? AND container_id=? AND path_pattern=?`
       ).get('github.com', CID, '/anthropics/*') as any;
       expect(row?.status).toBe('requested');
-      // Het volledige pad wordt als voorbeeld bewaard en bij een nieuwe hit ververst.
+      // The full path is kept as an example and refreshed on a new hit.
       expect(row?.last_path).toBe('/anthropics/claude');
       checkRule('github.com', CID, '/anthropics/codex?x=1');
       const row2 = db.prepare(
@@ -327,72 +327,72 @@ describe.skipIf(!sqliteAvailable)('checkRule', () => {
       ).get('github.com', CID, '/anthropics/*') as any;
       expect(row2?.last_path).toBe('/anthropics/codex?x=1');
 
-      // Het kale domein (geen pad / null) blijft dicht.
+      // The bare domain (no path / null) stays closed.
       expect(checkRule('github.com', CID, null).status).toBe('deny');
     });
 
-    it('een toegestaan subpad wint van de host-only marker', () => {
+    it('an allowed subpath wins over the host-only marker', () => {
       setRule('github.com', CID, 'deny', null, null, 1);          // marker
-      setRule('github.com', CID, 'allow', null, '/anthropics/*');  // toegestaan pad
+      setRule('github.com', CID, 'allow', null, '/anthropics/*');  // allowed path
       expect(checkRule('github.com', CID, '/anthropics/claude').status).toBe('allow');
-      // Ander pad blijft onbekend → requested
+      // A different path stays unknown → requested
       expect(checkRule('github.com', CID, '/torvalds/linux').status).toBe('requested');
     });
 
-    it('een afgekeurd subpad blijft deny (geen her-opvoeren als requested)', () => {
+    it('a rejected subpath stays deny (no re-filing as requested)', () => {
       setRule('github.com', CID, 'deny', null, null, 1);        // marker
-      setRule('github.com', CID, 'deny', null, '/secret/*');     // expliciet geblokkeerd pad
+      setRule('github.com', CID, 'deny', null, '/secret/*');     // explicitly blocked path
       expect(checkRule('github.com', CID, '/secret/x').status).toBe('deny');
     });
 
-    it('isPathMode herkent een domein in pad-modus', () => {
+    it('isPathMode recognizes a domain in path mode', () => {
       setRule('github.com', null, 'deny', null, null, 1);
       expect(isPathMode('github.com', CID)).toBe(true);
-      expect(isPathMode('elders.test', CID)).toBe(false);
+      expect(isPathMode('elsewhere.test', CID)).toBe(false);
     });
   });
 
-  describe('regressie: path-argument verandert host-only gedrag niet', () => {
-    it('expliciet null pad geeft zelfde resultaat als zonder argument', () => {
+  describe('regression: path argument does not change host-only behavior', () => {
+    it('explicit null path gives the same result as without an argument', () => {
       setRule('regress.test', CID, 'allow');
       expect(checkRule('regress.test', CID).status).toBe('allow');
       expect(checkRule('regress.test', CID, null).status).toBe('allow');
     });
-    it('host-only allow matcht ongeacht het pad', () => {
+    it('host-only allow matches regardless of the path', () => {
       setRule('hostonly.test', CID, 'allow');
       expect(checkRule('hostonly.test', CID, '/any/path').status).toBe('allow');
     });
   });
 
-  // ── Finding #3 — hoofdletter-bypass van exacte deny-regels ─────────────────
-  // De klassieke broad-allow/specific-deny vorm: `*.github.com` allow +
-  // `gist.github.com` deny. Een ge-kapitaliseerde host mocht de deny NIET
-  // omzeilen (was een reliable firewall-bypass via CONNECT GIST.GITHUB.COM).
-  describe('regressie #3: casing omzeilt geen exacte deny', () => {
-    it('exacte deny wint van wildcard allow, ongeacht de host-casing', () => {
+  // ── Finding #3 — uppercase bypass of exact deny rules ──────────────────────
+  // The classic broad-allow/specific-deny form: `*.github.com` allow +
+  // `gist.github.com` deny. A capitalized host must NOT bypass the deny (this
+  // was a reliable firewall bypass via CONNECT GIST.GITHUB.COM).
+  describe('regression #3: casing does not bypass an exact deny', () => {
+    it('exact deny wins over wildcard allow, regardless of the host casing', () => {
       setRule('*.github.com', null, 'allow');
       setRule('gist.github.com', null, 'deny');
       expect(checkRule('gist.github.com', CID).status).toBe('deny');
-      // Zelfde host, ge-kapitaliseerd — checkRule lowercase't het domein-argument
-      // en de exacte SQL-lookup is COLLATE NOCASE.
+      // Same host, capitalized — checkRule lowercases the domain argument
+      // and the exact SQL lookup is COLLATE NOCASE.
       expect(checkRule('GIST.GITHUB.COM', CID).status).toBe('deny');
       expect(checkRule('Gist.GitHub.Com', CID).status).toBe('deny');
     });
-    it('een deny-regel die zelf ge-kapitaliseerd is opgeslagen matcht ook', () => {
-      // Simuleer een oude, niet-gemigreerde rij (mixed case) — COLLATE NOCASE
-      // op de index/lookup vangt hem alsnog.
+    it('a deny rule that is itself stored capitalized also matches', () => {
+      // Simulate an old, non-migrated row (mixed case) — COLLATE NOCASE
+      // on the index/lookup catches it anyway.
       db.prepare(`INSERT INTO rules (domain, container_id, status) VALUES ('EVIL.TEST', NULL, 'deny')`).run();
       expect(checkRule('evil.test', CID).status).toBe('deny');
     });
   });
 
-  // ── Finding #7 — pad-traversal door een pad-allowlist ──────────────────────
-  describe('regressie #7: pad-normalisatie blokkeert traversal', () => {
-    it('`/foo/../secret` matcht niet langer een `/foo/*` allow', () => {
+  // ── Finding #7 — path traversal through a path allowlist ───────────────────
+  describe('regression #7: path normalization blocks traversal', () => {
+    it('`/foo/../secret` no longer matches a `/foo/*` allow', () => {
       setRule('example.com', CID, 'deny', null, null, 1);          // path-mode marker
-      setRule('example.com', CID, 'allow', null, '/foo/*');        // alleen /foo/* toegestaan
+      setRule('example.com', CID, 'allow', null, '/foo/*');        // only /foo/* allowed
       expect(checkRule('example.com', CID, '/foo/bar').status).toBe('allow');
-      // Traversal → normaliseert weg van /foo/ → niet meer 'allow'.
+      // Traversal → normalizes away from /foo/ → no longer 'allow'.
       expect(checkRule('example.com', CID, '/foo/../secret').status).not.toBe('allow');
       expect(checkRule('example.com', CID, '/foo/..%2f..%2fadmin').status).not.toBe('allow');
       expect(checkRule('example.com', CID, '/foo/../').status).not.toBe('allow');
@@ -400,75 +400,75 @@ describe.skipIf(!sqliteAvailable)('checkRule', () => {
   });
 
   describe('canonicalizeHost (pure helper)', () => {
-    it('lowercase + trailing dot strippen', () => {
+    it('lowercase + strip trailing dot', () => {
       expect(canonicalizeHost('GIST.GITHUB.COM')).toBe('gist.github.com');
       expect(canonicalizeHost('example.com.')).toBe('example.com');
       expect(canonicalizeHost('Example.COM.')).toBe('example.com');
     });
-    it('IDN → punycode (de vorm die DNS/SNI zien)', () => {
+    it('IDN → punycode (the form DNS/SNI see)', () => {
       // bücher.example → xn--bcher-kva.example
       expect(canonicalizeHost('bücher.example')).toBe('xn--bcher-kva.example');
     });
-    it('weigert control chars, whitespace en lege host', () => {
+    it('rejects control chars, whitespace and empty host', () => {
       expect(canonicalizeHost('')).toBeNull();
       expect(canonicalizeHost('  ')).toBeNull();
       expect(canonicalizeHost('evil.com\r\nHost: x')).toBeNull();
       expect(canonicalizeHost('a b.com')).toBeNull();
     });
-    it('is idempotent op een al-canonieke host', () => {
+    it('is idempotent on an already-canonical host', () => {
       expect(canonicalizeHost('gist.github.com')).toBe('gist.github.com');
     });
   });
 
   describe('normalizePathname (pure helper)', () => {
-    it('laat een normaal pad ongemoeid (incl. trailing slash)', () => {
+    it('leaves a normal path untouched (incl. trailing slash)', () => {
       expect(normalizePathname('/api/v1/foo')).toBe('/api/v1/foo');
       expect(normalizePathname('/api/v1/')).toBe('/api/v1/');
       expect(normalizePathname('/')).toBe('/');
     });
-    it('strip query en fragment', () => {
+    it('strips query and fragment', () => {
       expect(normalizePathname('/foo?x=1')).toBe('/foo');
       expect(normalizePathname('/foo#frag')).toBe('/foo');
     });
-    it('vouwt `.`-segmenten weg', () => {
+    it('folds `.` segments away', () => {
       expect(normalizePathname('/foo/./bar')).toBe('/foo/bar');
     });
-    it('fail-closed op `..`-traversal (plain, %-encoded, dubbel-slash)', () => {
+    it('fail-closed on `..` traversal (plain, %-encoded, double-slash)', () => {
       expect(normalizePathname('/foo/../secret')).toBeNull();
       expect(normalizePathname('/foo/..%2f..%2fadmin')).toBeNull();
       expect(normalizePathname('/foo/../')).toBeNull();
       expect(normalizePathname('/..')).toBeNull();
     });
-    it('fail-closed op kapotte percent-encoding', () => {
+    it('fail-closed on broken percent-encoding', () => {
       expect(normalizePathname('/foo/%zz')).toBeNull();
       expect(normalizePathname('/foo/%2')).toBeNull();
     });
-    it('behandelt dubbel-encoded `..` als een letterlijk segment (single decode)', () => {
-      // %252e%252e → één decode → %2e%2e (geen `..`-segment) → géén traversal.
+    it('treats double-encoded `..` as a literal segment (single decode)', () => {
+      // %252e%252e → one decode → %2e%2e (no `..` segment) → no traversal.
       expect(normalizePathname('/foo/%252e%252e/x')).toBe('/foo/%2e%2e/x');
     });
-    it('behoudt legitieme %-encoded tekens (geen verminking van de beslissing)', () => {
+    it('preserves legitimate %-encoded characters (no mangling of the decision)', () => {
       // %2e%2e = `..` → traversal → fail closed.
       expect(normalizePathname('/foo/%2e%2e/x')).toBeNull();
-      // een gewoon encoded teken (spatie) in een segment blijft een geldig pad.
+      // a plain encoded character (space) in a segment stays a valid path.
       expect(normalizePathname('/a%20b/c')).toBe('/a b/c');
     });
   });
 
-  describe('matchPath: segment-grens (regressie #7 tail)', () => {
-    it('`*`-suffix matcht alleen op een segment-grens', () => {
+  describe('matchPath: segment boundary (regression #7 tail)', () => {
+    it('`*` suffix matches only on a segment boundary', () => {
       expect(matchPath('/safe*', '/safe')).toBe(true);
       expect(matchPath('/safe*', '/safe/x')).toBe(true);
       expect(matchPath('/safe*', '/safe-danger')).toBe(false);
     });
-    it('`/foo/*` matcht subpaden maar niet na traversal', () => {
+    it('`/foo/*` matches subpaths but not after traversal', () => {
       expect(matchPath('/foo/*', '/foo/bar')).toBe(true);
       expect(matchPath('/foo/*', '/foo/../secret')).toBe(false);
       expect(matchPath('/foo/*', '/foo/..%2fsecret')).toBe(false);
     });
-    it('null/leeg patroon (host-only) matcht elk pad, ook traversal', () => {
-      // Host-only regels handhaven geen pad; traversal-bescherming zit in de
-      // pad-regels zelf.
+    it('null/empty pattern (host-only) matches every path, including traversal', () => {
+      // Host-only rules do not enforce a path; traversal protection lives in the
+      // path rules themselves.
       expect(matchPath(null, '/foo/../secret')).toBe(true);
       expect(matchPath('', '/whatever')).toBe(true);
     });


### PR DESCRIPTION
Support `*` wildcards anywhere in a firewall path pattern: a mid-path `*` matches within a single segment (never crossing `/`), while a trailing `*` keeps the existing prefix semantics. This lets operators approve a broad, predictable endpoint (e.g. an Azure DevOps NuGet feed `/_packaging/*/nuget/v3/*` whose feed GUID changes per request) instead of a fresh per-request approval. Path normalisation still runs first, so traversal tricks fail closed.

New ways to author custom rules:
- **UI**: "Add rule" form on the Firewall page (domain, optional path pattern, global/container scope, allow/deny) posting to `/api/rules`
- **CLI**: `huddle firewall add <domain> [--path <pattern>] [--deny] [--container <id>]`
- **Docs**: README section on custom rules and wildcard support (domain `*.` and in-path `*`) with the Azure DevOps NuGet example

Closes #73