### PR TITLE
feat(cli): migrate existing docker-compose devcontainers behind Huddle

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,22 @@ The CLI also prints a direct gateway link once the JetBrains backend has started
 
 ---
 
+## Migrating an existing Dev Container / Compose project
+
+Already have a `docker-compose.yml` + `devcontainer.json` and want to keep it while routing it
+through Huddle? Mark the network your services share with `huddle.network: "true"` and run:
+
+```bash
+huddle migrate
+```
+
+This generates a `docker-compose.huddle.yml` override that attaches your services to Huddle's
+internal network and injects the proxy env vars and CA path — your own files stay untouched.
+See [docs/migrate-devcontainers.md](docs/migrate-devcontainers.md) for the convention, an
+example, and the exact steps.
+
+---
+
 ## Managing the firewall
 
 Blocked requests are visible in the web UI under **Firewall**. Via the CLI:

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -6,6 +6,7 @@ import { setBaseUrl, ApiError } from './api';
 import { runStart } from './start';
 import { runFirewallList, runFirewallAdd, runFirewallExport, runFirewallImport, runFirewallGroup, runFirewallFolder } from './firewall';
 import { runInit } from './init';
+import { runMigrate } from './migrate';
 import { resolveImages } from './images';
 import { cliVersion } from './self-update';
 import { dim } from './utils';
@@ -22,9 +23,9 @@ interface ParsedArgs {
   flags: Record<string, string | boolean>;
 }
 
-const VALUE_FLAGS = new Set(['url', 'ide', 'name', 'image', 'workspace', 'container', 'status', 'runtime', 'experiment', 'path', 'out']);
-const BOOLEAN_FLAGS = new Set(['help', 'h', 'empty', 'i', 'interactive', 'version', 'v', 'deny', 'replace']);
-const COMMANDS = new Set(['start', 'firewall', 'fw', 'init', 'restart', 'experiment', 'help', 'version']);
+const VALUE_FLAGS = new Set(['url', 'ide', 'name', 'image', 'workspace', 'container', 'status', 'runtime', 'experiment', 'path', 'out', 'ca-path', 'output']);
+const BOOLEAN_FLAGS = new Set(['help', 'h', 'empty', 'i', 'interactive', 'version', 'v', 'deny', 'replace', 'docker-socket', 'force']);
+const COMMANDS = new Set(['start', 'firewall', 'fw', 'init', 'restart', 'experiment', 'migrate', 'help', 'version']);
 
 function parseArgs(argv: string[]): ParsedArgs {
   const positional: string[] = [];
@@ -104,6 +105,8 @@ Usage:
                                      start them via Docker or Podman
   huddle restart                     Recreate the gateway (e.g. to mount a changed
                                      team firewall-rules folder)
+  huddle migrate [folder]            Wire an existing docker-compose devcontainer
+                                     behind Huddle by generating an override file
   huddle firewall list [options]     Show firewall requests
   huddle fw list [options]           Alias for firewall list
   huddle firewall add <domain>       Add a custom firewall rule (wildcards
@@ -133,6 +136,15 @@ Start options:
   --name <name>                      Container name (default: devcontainer-<foldername>)
   --image <image>                    Use a specific image
   --empty                            Empty container without a workspace
+
+Migrate options:
+  --ca-path <path>                   Where the Huddle CA lands in the container
+                                     (NODE_EXTRA_CA_CERTS; default /home/vscode/.huddle-ca.crt)
+  --docker-socket                    Also wire the filtered Docker socket + DOCKER_HOST
+                                     (requires gateway socket pre-provisioning; see docs)
+  --output <path>                    Override file to write
+                                     (default: docker-compose.huddle.yml next to the source)
+  --force                            Overwrite an existing override file
 
 Firewall options:
   -i, --interactive                  Interactively approve/deny (list)
@@ -294,6 +306,18 @@ async function main(): Promise<void> {
       console.error(`Unknown firewall subcommand: ${subCmd}`);
       process.exit(1);
     }
+    return;
+  }
+
+  if (cmd === 'migrate') {
+    await runMigrate({
+      path: positional[1],
+      caPath: flagString(flags, 'ca-path'),
+      dockerSocket: flagBool(flags, 'docker-socket'),
+      output: flagString(flags, 'output'),
+      force: flagBool(flags, 'force'),
+      runtime: flagString(flags, 'runtime'),
+    });
     return;
   }
 

--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -8,7 +8,20 @@ import fs from 'fs';
 
 const CONTAINER = 'huddle';
 const VOLUME = 'huddle-data';
-const INTERNAL_NET = 'devcontainer-net';
+/**
+ * The shared, internal network that `huddle init` creates (`--internal`, so it
+ * has no route to the internet of its own). Devcontainers attach to it to reach
+ * the Huddle proxy — it is the only way out. Exported so `huddle migrate` can
+ * point an existing Compose project at the exact same network.
+ */
+export const INTERNAL_NET = 'devcontainer-net';
+/**
+ * Directory on the Docker ENGINE host where the gateway serves each
+ * devcontainer's filtered Docker socket (`<HOST_SOCKET_DIR>/<container_name>`).
+ * Kept in sync with SOCKET_DIR in gateway/src/docker.ts. Exported so
+ * `huddle migrate` can generate the matching bind mount.
+ */
+export const HOST_SOCKET_DIR = '/tmp/dc-sockets';
 const HOST_PORT = process.env.HUDDLE_PORT ?? '3000';
 
 export interface InitOptions {
@@ -91,7 +104,7 @@ export async function runInit(opts: InitOptions, images: ResolvedImages): Promis
   // /tmp/dc-sockets on the engine host; mounting a Windows temp dir splits
   // gateway and devcontainers across two filesystems, and Unix sockets are
   // unreliable on such a drvfs/9p mount anyway.
-  const hostTmpSockets = '/tmp/dc-sockets';
+  const hostTmpSockets = HOST_SOCKET_DIR;
   if (runtime.isRemote) {
     if (runtime.name === 'podman') {
       // Podman does NOT create a missing bind source itself (unlike Docker

--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -133,10 +133,10 @@ export async function runInit(opts: InitOptions, images: ResolvedImages): Promis
   // SELinux-labeled proxy socket.
   const securityOptFlags = runtime.securityOpts.map((opt) => ` --security-opt ${opt}`).join('');
 
-  // Operator-token voor de control-plane-auth. Hergebruik het token uit de
-  // config (zodat een bestaande browser-sessie/CLI blijft werken over re-inits),
-  // anders genereer er één. We geven het aan de gateway mee via env én bewaren
-  // het lokaal zodat volgende `huddle`-commando's zich kunnen authenticeren.
+  // Operator token for control-plane auth. Reuse the token from the config (so an
+  // existing browser session/CLI keeps working across re-inits), otherwise
+  // generate one. We pass it to the gateway via env AND store it locally so that
+  // subsequent `huddle` commands can authenticate.
   const cfg = readConfig();
   const operatorToken =
     process.env.HUDDLE_OPERATOR_TOKEN?.trim() ||
@@ -189,9 +189,9 @@ export async function runInit(opts: InitOptions, images: ResolvedImages): Promis
   console.log();
   console.log(green(`[OK] Huddle is running at http://localhost:${HOST_PORT}`));
   console.log();
-  // Volledige auto-login-link: open deze en de portal logt je automatisch in met
-  // het operator-token (de frontend leest ?token=..., logt in en verwijdert het
-  // daarna uit de adresbalk). Zo hoef je niets te plakken.
+  // Full auto-login link: open it and the portal logs you in automatically with
+  // the operator token (the frontend reads ?token=..., logs in and then removes it
+  // from the address bar). This way you don't have to paste anything.
   const loginUrl = `http://localhost:${HOST_PORT}/?token=${encodeURIComponent(operatorToken)}`;
   console.log(bold('Open the portal (auto-login link):'));
   console.log(green(`    ${loginUrl}`));

--- a/cli/src/migrate.ts
+++ b/cli/src/migrate.ts
@@ -531,8 +531,8 @@ export function resolveComposeFile(target?: string): string {
 function huddleNetworkExists(internalNet: string, runtime?: string): boolean | undefined {
   try {
     const rt = resolveRuntime(runtime);
-    // execFileSync (arg-array, geen shell) i.p.v. execSync: er komt geen shell aan
-    // te pas, dus geen command-injection-oppervlak via de runtime-/netwerknaam.
+    // execFileSync (arg array, no shell) instead of execSync: no shell is
+    // involved, so there is no command-injection surface via the runtime/network name.
     execFileSync(rt.name, ['network', 'inspect', internalNet], { stdio: 'ignore' });
     return true;
   } catch {

--- a/cli/src/migrate.ts
+++ b/cli/src/migrate.ts
@@ -437,17 +437,22 @@ export function dumpYaml(obj: unknown, indent = 0): string {
     if (entries.length === 0) return `${pad}{}\n`;
     let out = '';
     for (const [key, value] of entries) {
+      // Keys can come straight from an untrusted compose file (service/network
+      // names). Emit them through the same quote/escape path as scalar values so
+      // a crafted key (`a: b`, `evil #comment`, or one containing a newline)
+      // cannot break out of its line and inject sibling compose directives.
+      const k = formatScalar(key);
       if (value === null || value === undefined) {
-        out += `${pad}${key}:\n`;
+        out += `${pad}${k}:\n`;
       } else if (typeof value === 'object') {
         const isEmpty = Array.isArray(value) ? value.length === 0 : Object.keys(value).length === 0;
         if (isEmpty) {
-          out += `${pad}${key}: ${Array.isArray(value) ? '[]' : '{}'}\n`;
+          out += `${pad}${k}: ${Array.isArray(value) ? '[]' : '{}'}\n`;
         } else {
-          out += `${pad}${key}:\n${dumpYaml(value, indent + 1)}`;
+          out += `${pad}${k}:\n${dumpYaml(value, indent + 1)}`;
         }
       } else {
-        out += `${pad}${key}: ${formatScalar(value)}\n`;
+        out += `${pad}${k}: ${formatScalar(value)}\n`;
       }
     }
     return out;
@@ -467,7 +472,18 @@ function dumpInlineOrBlock(item: unknown, indent: number): string {
 function formatScalar(value: unknown): string {
   if (typeof value === 'boolean' || typeof value === 'number') return String(value);
   const str = String(value);
-  if (needsQuote(str)) return `"${str.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  if (needsQuote(str)) {
+    // Escape backslash first, then quotes, then control chars — otherwise a raw
+    // newline/CR/tab would terminate the current line and let attacker-supplied
+    // text be reparsed as fresh YAML structure.
+    const escaped = str
+      .replace(/\\/g, '\\\\')
+      .replace(/"/g, '\\"')
+      .replace(/\n/g, '\\n')
+      .replace(/\r/g, '\\r')
+      .replace(/\t/g, '\\t');
+    return `"${escaped}"`;
+  }
   return str;
 }
 
@@ -476,6 +492,7 @@ function needsQuote(str: string): boolean {
   if (/^(true|false|null|~|yes|no|on|off)$/i.test(str)) return true;
   if (/^-?\d+(\.\d+)?$/.test(str)) return true;
   if (/[:#[\]{}&*!|>%@`,"']/.test(str)) return true;
+  if (/[\n\r\t]/.test(str)) return true;
   if (/^\s|\s$/.test(str)) return true;
   return false;
 }

--- a/cli/src/migrate.ts
+++ b/cli/src/migrate.ts
@@ -289,8 +289,48 @@ function stripComment(line: string): string {
   return line;
 }
 
+function unsupportedYaml(feature: string): Error {
+  return new Error(
+    `the compose file uses ${feature}, which \`huddle migrate\`'s built-in YAML reader does ` +
+      'not support and would mis-parse (risking a dropped, un-filtered service). Inline or ' +
+      'quote it, or flatten the file first with `docker compose config`, then re-run `huddle migrate`.',
+  );
+}
+
+// A YAML block-scalar header: `|` or `>` followed by an optional indentation
+// indicator (1-9) and/or chomping indicator (+/-), each at most once, in either
+// order. Anchored so plain scalars that merely start with `>`/`|` (e.g. `>=1.0`)
+// do not match.
+const BLOCK_SCALAR_HEADER = /^[|>]([1-9][+-]?|[+-][1-9]?)?$/;
+
+// The value carried by a tokenized line: a mapping value (after `key:`), a
+// sequence-item value (after `- `), or the bare line.
+function lineValue(text: string): string {
+  const colon = findKeyColon(text);
+  if (colon >= 0) return text.slice(colon + 1).trim();
+  if (isSeqItem(text)) return text.replace(/^-\s*/, '').trim();
+  return text;
+}
+
+// Fail-closed on YAML features the indentation reader below cannot represent
+// (finding #9). Block scalars (`|`/`>`), anchors/aliases (`&`/`*`) and merge keys
+// (`<<`) are silently mis-parsed — a block scalar's indented body is read as real
+// structure, which can swallow the next service and drop it from the generated
+// override (leaving it with an unfiltered route out). Detect them up front and
+// refuse with a clear, actionable error instead of guessing.
+function rejectUnsupportedYaml(lines: Line[]): void {
+  for (const { text } of lines) {
+    if (/^<<\s*:/.test(text)) throw unsupportedYaml('a merge key (`<<`)');
+    const value = lineValue(text);
+    if (BLOCK_SCALAR_HEADER.test(value)) throw unsupportedYaml('a block scalar (`|` or `>`)');
+    if (/^&[A-Za-z0-9_]/.test(value)) throw unsupportedYaml('a YAML anchor (`&`)');
+    if (/^\*[A-Za-z0-9_]/.test(value)) throw unsupportedYaml('a YAML alias (`*`)');
+  }
+}
+
 export function parseYaml(input: string): ComposeDoc {
   const lines = tokenize(input);
+  rejectUnsupportedYaml(lines);
   let pos = 0;
 
   function parseNode(indent: number): unknown {

--- a/cli/src/migrate.ts
+++ b/cli/src/migrate.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
-import { bold, green, cyan, dim, yellow } from './utils';
+import { bold, green, cyan, dim, yellow, red } from './utils';
 import { resolveRuntime } from './runtime';
 import { INTERNAL_NET, HOST_SOCKET_DIR } from './init';
 
@@ -52,8 +52,15 @@ export interface AnalysisResult {
   services: string[];
   /** The generated Compose override object (dump with dumpYaml). */
   override: ComposeDoc;
-  /** Non-fatal advisories (e.g. marked network not internal). */
+  /** Non-fatal advisories (e.g. a service without container_name). */
   warnings: string[];
+  /**
+   * Security-critical problems that leave the service with a direct internet
+   * path (marked network not internal, or a second non-internal network). The
+   * override is still generated, but `runMigrate` refuses to write it unless
+   * `--force` is given — reporting success here would be misleading.
+   */
+  blockers: string[];
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -158,6 +165,7 @@ export function buildOverride(compose: ComposeDoc, opts: OverrideOptions = {}): 
   const internalNet = opts.internalNet ?? INTERNAL_NET;
   const socketDir = opts.socketDir ?? HOST_SOCKET_DIR;
   const warnings: string[] = [];
+  const blockers: string[] = [];
 
   const marked = findMarkedNetworks(compose);
   if (marked.length === 0) {
@@ -171,18 +179,26 @@ export function buildOverride(compose: ComposeDoc, opts: OverrideOptions = {}): 
   }
   const markedNetwork = marked[0];
 
-  // Pick a collision-free key for the injected egress network.
-  const existingNetKeys = new Set(Object.keys(compose.networks ?? {}));
+  // Pick a key for the injected egress network that collides with NOTHING: not
+  // an existing network, and not the marked network itself (otherwise the two
+  // keys in the service's `networks` map below collapse into one and the egress
+  // net is silently never added). Keep suffixing until it is unique.
+  const taken = new Set(Object.keys(compose.networks ?? {}));
+  taken.add(markedNetwork);
   let huddleNetKey = opts.huddleNetKey ?? HUDDLE_NET_KEY;
-  if (existingNetKeys.has(huddleNetKey) && huddleNetKey !== markedNetwork) {
-    huddleNetKey = `${HUDDLE_NET_KEY}-egress`;
+  if (taken.has(huddleNetKey)) {
+    let n = 0;
+    do {
+      huddleNetKey = n === 0 ? `${HUDDLE_NET_KEY}-egress` : `${HUDDLE_NET_KEY}-egress-${n}`;
+      n++;
+    } while (taken.has(huddleNetKey));
   }
 
   // Guardrail: the marked network must be internal, otherwise it already has a
   // route to the internet and would bypass the firewall/proxy.
   const markedDef = (compose.networks?.[markedNetwork] ?? {}) as ComposeNetwork;
   if (!isTruthy(markedDef.internal)) {
-    warnings.push(
+    blockers.push(
       `Network "${markedNetwork}" is not marked \`internal: true\`. It must be internal, ` +
         'otherwise services can reach the internet directly and bypass Huddle.',
     );
@@ -206,7 +222,7 @@ export function buildOverride(compose: ComposeDoc, opts: OverrideOptions = {}): 
       if (netKey === markedNetwork) continue;
       const def = (compose.networks?.[netKey] ?? {}) as ComposeNetwork;
       if (!isTruthy(def.internal)) {
-        warnings.push(
+        blockers.push(
           `Service "${name}" is also on network "${netKey}", which is not internal. ` +
             'Remove it or make it internal — a second non-internal network bypasses Huddle.',
         );
@@ -244,7 +260,7 @@ export function buildOverride(compose: ComposeDoc, opts: OverrideOptions = {}): 
     },
   };
 
-  return { markedNetwork, services, override, warnings };
+  return { markedNetwork, services, override, warnings, blockers };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -323,8 +339,13 @@ function rejectUnsupportedYaml(lines: Line[]): void {
     if (/^<<\s*:/.test(text)) throw unsupportedYaml('a merge key (`<<`)');
     const value = lineValue(text);
     if (BLOCK_SCALAR_HEADER.test(value)) throw unsupportedYaml('a block scalar (`|` or `>`)');
-    if (/^&[A-Za-z0-9_]/.test(value)) throw unsupportedYaml('a YAML anchor (`&`)');
-    if (/^\*[A-Za-z0-9_]/.test(value)) throw unsupportedYaml('a YAML alias (`*`)');
+    // Match an anchor/alias in any NODE position: at the value start OR right
+    // after a flow opener/separator (`[`, `{`, `,`) or a flow-map colon — so
+    // `networks: [*net]` and `{n: *net}` are caught too, not just `x: *net`.
+    // The trailing name char keeps this off scalar `&`/`*` (env URLs, globs like
+    // `*.log`), which never start an anchor/alias name.
+    if (/(^|[[{,:]\s*)&[A-Za-z0-9_]/.test(value)) throw unsupportedYaml('a YAML anchor (`&`)');
+    if (/(^|[[{,:]\s*)\*[A-Za-z0-9_]/.test(value)) throw unsupportedYaml('a YAML alias (`*`)');
   }
 }
 
@@ -333,12 +354,18 @@ export function parseYaml(input: string): ComposeDoc {
   rejectUnsupportedYaml(lines);
   let pos = 0;
 
-  function parseNode(indent: number): unknown {
+  // Cap the mutual recursion (parseNode ↔ parseMapping/parseSequence) so a deeply
+  // nested (malformed or hostile) compose file cannot exhaust the stack (CWE-674).
+  const MAX_DEPTH = 64;
+  function parseNode(indent: number, depth: number): unknown {
+    if (depth > MAX_DEPTH) {
+      throw new Error(`YAML nesting exceeds ${MAX_DEPTH} levels; refusing to parse this compose file.`);
+    }
     if (pos >= lines.length || lines[pos].indent < indent) return null;
-    return isSeqItem(lines[pos].text) ? parseSequence(indent) : parseMapping(indent);
+    return isSeqItem(lines[pos].text) ? parseSequence(indent, depth) : parseMapping(indent, depth);
   }
 
-  function parseMapping(indent: number): Record<string, unknown> {
+  function parseMapping(indent: number, depth: number): Record<string, unknown> {
     const map: Record<string, unknown> = {};
     while (pos < lines.length && lines[pos].indent === indent && !isSeqItem(lines[pos].text)) {
       const { text } = lines[pos];
@@ -353,7 +380,7 @@ export function parseYaml(input: string): ComposeDoc {
       if (rest !== '') {
         map[key] = parseScalar(rest);
       } else if (pos < lines.length && lines[pos].indent > indent) {
-        map[key] = parseNode(lines[pos].indent);
+        map[key] = parseNode(lines[pos].indent, depth + 1);
       } else {
         map[key] = null;
       }
@@ -361,19 +388,19 @@ export function parseYaml(input: string): ComposeDoc {
     return map;
   }
 
-  function parseSequence(indent: number): unknown[] {
+  function parseSequence(indent: number, depth: number): unknown[] {
     const arr: unknown[] = [];
     while (pos < lines.length && lines[pos].indent === indent && isSeqItem(lines[pos].text)) {
       const afterDash = lines[pos].text.replace(/^-\s*/, '');
       if (afterDash === '') {
         pos++;
-        arr.push(pos < lines.length && lines[pos].indent > indent ? parseNode(lines[pos].indent) : null);
+        arr.push(pos < lines.length && lines[pos].indent > indent ? parseNode(lines[pos].indent, depth + 1) : null);
       } else if (findKeyColon(afterDash) >= 0) {
         // Inline map item: "- key: value". Re-interpret the remainder as a
         // mapping that starts at a virtual indent past the dash.
         const virtualIndent = indent + (lines[pos].text.length - afterDash.length);
         lines[pos] = { indent: virtualIndent, text: afterDash };
-        arr.push(parseMapping(virtualIndent));
+        arr.push(parseMapping(virtualIndent, depth + 1));
       } else {
         arr.push(parseScalar(afterDash));
         pos++;
@@ -382,7 +409,7 @@ export function parseYaml(input: string): ComposeDoc {
     return arr;
   }
 
-  const root = parseNode(lines.length ? lines[0].indent : 0);
+  const root = parseNode(lines.length ? lines[0].indent : 0, 0);
   return (root && typeof root === 'object' ? root : {}) as ComposeDoc;
 }
 
@@ -600,7 +627,19 @@ export async function runMigrate(opts: MigrateOptions): Promise<void> {
   console.log(`Marked network:  ${bold(result.markedNetwork)}`);
   console.log(`Wired services:  ${result.services.length ? result.services.map(bold).join(', ') : dim('(none)')}`);
   for (const w of result.warnings) console.log(yellow(`[!] ${w}`));
+  for (const b of result.blockers) console.log(red(`[x] ${b}`));
   console.log();
+
+  // Fail closed: these blockers mean the migrated service would keep a direct
+  // route to the internet, so writing the override and reporting success would
+  // be misleading. Refuse unless the operator explicitly overrides with --force.
+  if (result.blockers.length > 0 && !opts.force) {
+    throw new Error(
+      `Refusing to write the override: the migration would leave a direct internet path ` +
+        `(${result.blockers.length} blocker(s) above). Fix your compose file, or re-run with ` +
+        `--force to generate it anyway.`,
+    );
+  }
 
   const overrideText =
     '# Generated by `huddle migrate` — do NOT edit by hand; re-run the command instead.\n' +

--- a/cli/src/migrate.ts
+++ b/cli/src/migrate.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import { bold, green, cyan, dim, yellow } from './utils';
@@ -531,7 +531,9 @@ export function resolveComposeFile(target?: string): string {
 function huddleNetworkExists(internalNet: string, runtime?: string): boolean | undefined {
   try {
     const rt = resolveRuntime(runtime);
-    execSync(`${rt.name} network inspect ${internalNet}`, { stdio: 'ignore' });
+    // execFileSync (arg-array, geen shell) i.p.v. execSync: er komt geen shell aan
+    // te pas, dus geen command-injection-oppervlak via de runtime-/netwerknaam.
+    execFileSync(rt.name, ['network', 'inspect', internalNet], { stdio: 'ignore' });
     return true;
   } catch {
     return undefined; // runtime unavailable or network missing — don't block.

--- a/cli/src/migrate.ts
+++ b/cli/src/migrate.ts
@@ -1,0 +1,603 @@
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { bold, green, cyan, dim, yellow } from './utils';
+import { resolveRuntime } from './runtime';
+import { INTERNAL_NET, HOST_SOCKET_DIR } from './init';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Conventions
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Label a developer puts on ONE network in their existing docker-compose.yml to
+ * mark it as "the network whose services should run behind Huddle". Every
+ * service attached to that network gets the proxy env, the CA path and (opt-in)
+ * the filtered Docker socket injected via the generated override — the
+ * developer never hand-writes any of that.
+ */
+export const HUDDLE_NETWORK_LABEL = 'huddle.network';
+
+/**
+ * Network key added by the override that points at Huddle's shared internal
+ * network. Marked services are additionally attached to it so they reach the
+ * Huddle proxy; their own (internal) network is left untouched. Renamed if the
+ * project already uses this key.
+ */
+export const HUDDLE_NET_KEY = 'huddle';
+
+/** Default absolute path the CA is fetched to (see the printed postCreateCommand). */
+export const DEFAULT_CA_PATH = '/home/vscode/.huddle-ca.crt';
+
+/** Default filename for the generated Compose override. */
+export const OVERRIDE_FILENAME = 'docker-compose.huddle.yml';
+
+export interface OverrideOptions {
+  /** Where the CA ends up in the container (NODE_EXTRA_CA_CERTS). */
+  caPath?: string;
+  /** Also inject the filtered Docker socket mount + DOCKER_HOST (opt-in). */
+  dockerSocket?: boolean;
+  /** Network key/name that points at Huddle's internal net (defaults to HUDDLE_NET_KEY). */
+  huddleNetKey?: string;
+  /** Name of Huddle's shared internal network (defaults to INTERNAL_NET). */
+  internalNet?: string;
+  /** Host directory holding the per-container sockets (defaults to HOST_SOCKET_DIR). */
+  socketDir?: string;
+}
+
+export interface AnalysisResult {
+  /** Key of the network marked with `huddle.network`. */
+  markedNetwork: string;
+  /** Services (by compose key) attached to the marked network. */
+  services: string[];
+  /** The generated Compose override object (dump with dumpYaml). */
+  override: ComposeDoc;
+  /** Non-fatal advisories (e.g. marked network not internal). */
+  warnings: string[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Egress wiring that gets injected (mirrors the working .devcontainer example,
+// which issue-66-reply.md calls the source of truth). `huddle` stays in NO_PROXY
+// so the direct CA fetch to huddle:3000 does not loop through the proxy on :80.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function huddleProxyEnv(caPath: string, dockerSocket: boolean): Record<string, string> {
+  const env: Record<string, string> = {
+    HTTP_PROXY: 'http://huddle:80',
+    HTTPS_PROXY: 'http://huddle:80',
+    http_proxy: 'http://huddle:80',
+    https_proxy: 'http://huddle:80',
+    NO_PROXY: 'localhost,127.0.0.1,::1,[::1],huddle',
+    no_proxy: 'localhost,127.0.0.1,::1,[::1],huddle',
+    NODE_EXTRA_CA_CERTS: caPath,
+  };
+  if (dockerSocket) {
+    // The container talks to Huddle's filtered socket, never the raw engine.
+    env.DOCKER_HOST = 'unix:///var/run/huddle/docker.sock';
+  }
+  return env;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Marked-network detection + override generation (pure — unit-tested)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface ComposeDoc {
+  services?: Record<string, ComposeService>;
+  networks?: Record<string, ComposeNetwork | null>;
+  [k: string]: unknown;
+}
+
+export interface ComposeService {
+  container_name?: string;
+  networks?: string[] | Record<string, unknown | null>;
+  environment?: string[] | Record<string, unknown>;
+  volumes?: string[];
+  [k: string]: unknown;
+}
+
+export interface ComposeNetwork {
+  internal?: unknown;
+  labels?: string[] | Record<string, unknown>;
+  [k: string]: unknown;
+}
+
+/** YAML/Compose truthiness: accepts booleans and the usual string spellings. */
+function isTruthy(value: unknown): boolean {
+  if (value === true) return true;
+  if (typeof value === 'string') return ['true', '1', 'yes', 'on'].includes(value.trim().toLowerCase());
+  return false;
+}
+
+/** Reads a `labels:` block (map form or `- key=value` list form) into a plain map. */
+export function normalizeLabels(labels: ComposeNetwork['labels']): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!labels) return out;
+  if (Array.isArray(labels)) {
+    for (const entry of labels) {
+      if (typeof entry !== 'string') continue;
+      const eq = entry.indexOf('=');
+      if (eq >= 0) out[entry.slice(0, eq).trim()] = entry.slice(eq + 1).trim();
+      else out[entry.trim()] = '';
+    }
+  } else {
+    for (const [k, v] of Object.entries(labels)) out[k] = v == null ? '' : String(v);
+  }
+  return out;
+}
+
+/** Network keys of a service (map form or list form) as a plain array. */
+export function serviceNetworkKeys(service: ComposeService): string[] {
+  const nets = service.networks;
+  if (!nets) return [];
+  if (Array.isArray(nets)) return nets.filter((n): n is string => typeof n === 'string');
+  return Object.keys(nets);
+}
+
+/** All network keys carrying the `huddle.network` label. */
+export function findMarkedNetworks(compose: ComposeDoc): string[] {
+  const networks = compose.networks ?? {};
+  return Object.entries(networks)
+    .filter(([, def]) => def && isTruthy(normalizeLabels((def as ComposeNetwork).labels)[HUDDLE_NETWORK_LABEL]))
+    .map(([key]) => key);
+}
+
+/**
+ * Core generator: given a parsed compose object, produce the Compose OVERRIDE
+ * that wires every service on the marked network behind Huddle. Purely additive
+ * — it never rewrites the user's own network (which would clash with a base
+ * `internal: true` when Compose merges the two files), it only ADDS a second
+ * `huddle` network (external → Huddle's internal net) plus env/CA/socket.
+ *
+ * Throws on hard configuration errors (no/ambiguous marked network); collects
+ * softer problems in `warnings`.
+ */
+export function buildOverride(compose: ComposeDoc, opts: OverrideOptions = {}): AnalysisResult {
+  const caPath = opts.caPath ?? DEFAULT_CA_PATH;
+  const internalNet = opts.internalNet ?? INTERNAL_NET;
+  const socketDir = opts.socketDir ?? HOST_SOCKET_DIR;
+  const warnings: string[] = [];
+
+  const marked = findMarkedNetworks(compose);
+  if (marked.length === 0) {
+    throw new Error(
+      `No network marked with \`${HUDDLE_NETWORK_LABEL}: "true"\` was found. ` +
+        'Add that label to the (internal) network your services use.',
+    );
+  }
+  if (marked.length > 1) {
+    throw new Error(`Multiple networks marked with \`${HUDDLE_NETWORK_LABEL}\`: ${marked.join(', ')}. Mark exactly one.`);
+  }
+  const markedNetwork = marked[0];
+
+  // Pick a collision-free key for the injected egress network.
+  const existingNetKeys = new Set(Object.keys(compose.networks ?? {}));
+  let huddleNetKey = opts.huddleNetKey ?? HUDDLE_NET_KEY;
+  if (existingNetKeys.has(huddleNetKey) && huddleNetKey !== markedNetwork) {
+    huddleNetKey = `${HUDDLE_NET_KEY}-egress`;
+  }
+
+  // Guardrail: the marked network must be internal, otherwise it already has a
+  // route to the internet and would bypass the firewall/proxy.
+  const markedDef = (compose.networks?.[markedNetwork] ?? {}) as ComposeNetwork;
+  if (!isTruthy(markedDef.internal)) {
+    warnings.push(
+      `Network "${markedNetwork}" is not marked \`internal: true\`. It must be internal, ` +
+        'otherwise services can reach the internet directly and bypass Huddle.',
+    );
+  }
+
+  const services = Object.entries(compose.services ?? {})
+    .filter(([, svc]) => serviceNetworkKeys(svc as ComposeService).includes(markedNetwork))
+    .map(([key]) => key);
+
+  if (services.length === 0) {
+    warnings.push(`No service is attached to the marked network "${markedNetwork}"; the override wires nothing.`);
+  }
+
+  const overrideServices: Record<string, ComposeService> = {};
+  for (const name of services) {
+    const svc = (compose.services?.[name] ?? {}) as ComposeService;
+
+    // Guardrail: warn if the service also sits on another network that is not
+    // internal — that would be a second, unfiltered route out.
+    for (const netKey of serviceNetworkKeys(svc)) {
+      if (netKey === markedNetwork) continue;
+      const def = (compose.networks?.[netKey] ?? {}) as ComposeNetwork;
+      if (!isTruthy(def.internal)) {
+        warnings.push(
+          `Service "${name}" is also on network "${netKey}", which is not internal. ` +
+            'Remove it or make it internal — a second non-internal network bypasses Huddle.',
+        );
+      }
+    }
+
+    const injected: ComposeService = {
+      // Keep the service on its own network AND add the Huddle egress network.
+      // Map form is robust regardless of Compose's list merge semantics.
+      networks: { [markedNetwork]: null, [huddleNetKey]: null },
+      environment: huddleProxyEnv(caPath, !!opts.dockerSocket),
+    };
+
+    if (opts.dockerSocket) {
+      const cn = svc.container_name;
+      if (!cn) {
+        warnings.push(
+          `Service "${name}" has no \`container_name\`, so the filtered Docker socket cannot be mounted ` +
+            'at a stable path. Set a fixed container_name or drop --docker-socket for this service.',
+        );
+      } else {
+        injected.volumes = [`${socketDir}/${cn}:/var/run/huddle`];
+      }
+    }
+
+    overrideServices[name] = injected;
+  }
+
+  const override: ComposeDoc = {
+    services: overrideServices,
+    networks: {
+      // external: true → reuse the network `huddle init` already created; do not
+      // create or take ownership of it here.
+      [huddleNetKey]: { external: true, name: internalNet } as unknown as ComposeNetwork,
+    },
+  };
+
+  return { markedNetwork, services, override, warnings };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Minimal YAML support
+//
+// The CLI ships with zero runtime dependencies (see cli/package.json), so we do
+// not pull in a YAML library. This is a pragmatic, indentation-based reader for
+// the subset docker-compose files use (nested maps, block/flow sequences,
+// `key=value` label lists, quoted/plain scalars). It is NOT a general YAML
+// parser: anchors, multi-line block scalars and complex flow nesting are out of
+// scope. Both functions are unit-tested.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface Line {
+  indent: number;
+  text: string;
+}
+
+function tokenize(input: string): Line[] {
+  const out: Line[] = [];
+  for (const rawLine of input.split(/\r?\n/)) {
+    const stripped = stripComment(rawLine);
+    if (stripped.trim() === '') continue;
+    const indent = stripped.length - stripped.trimStart().length;
+    out.push({ indent, text: stripped.trim() });
+  }
+  return out;
+}
+
+/** Removes a `# comment`, but never one that sits inside quotes or a `://` URL. */
+function stripComment(line: string): string {
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i];
+    if (c === "'" && !inDouble) inSingle = !inSingle;
+    else if (c === '"' && !inSingle) inDouble = !inDouble;
+    else if (c === '#' && !inSingle && !inDouble && (i === 0 || /\s/.test(line[i - 1]))) {
+      return line.slice(0, i);
+    }
+  }
+  return line;
+}
+
+export function parseYaml(input: string): ComposeDoc {
+  const lines = tokenize(input);
+  let pos = 0;
+
+  function parseNode(indent: number): unknown {
+    if (pos >= lines.length || lines[pos].indent < indent) return null;
+    return isSeqItem(lines[pos].text) ? parseSequence(indent) : parseMapping(indent);
+  }
+
+  function parseMapping(indent: number): Record<string, unknown> {
+    const map: Record<string, unknown> = {};
+    while (pos < lines.length && lines[pos].indent === indent && !isSeqItem(lines[pos].text)) {
+      const { text } = lines[pos];
+      const colon = findKeyColon(text);
+      if (colon < 0) {
+        // Not a mapping line where we expected one — stop and let the caller cope.
+        break;
+      }
+      const key = unquote(text.slice(0, colon).trim());
+      const rest = text.slice(colon + 1).trim();
+      pos++;
+      if (rest !== '') {
+        map[key] = parseScalar(rest);
+      } else if (pos < lines.length && lines[pos].indent > indent) {
+        map[key] = parseNode(lines[pos].indent);
+      } else {
+        map[key] = null;
+      }
+    }
+    return map;
+  }
+
+  function parseSequence(indent: number): unknown[] {
+    const arr: unknown[] = [];
+    while (pos < lines.length && lines[pos].indent === indent && isSeqItem(lines[pos].text)) {
+      const afterDash = lines[pos].text.replace(/^-\s*/, '');
+      if (afterDash === '') {
+        pos++;
+        arr.push(pos < lines.length && lines[pos].indent > indent ? parseNode(lines[pos].indent) : null);
+      } else if (findKeyColon(afterDash) >= 0) {
+        // Inline map item: "- key: value". Re-interpret the remainder as a
+        // mapping that starts at a virtual indent past the dash.
+        const virtualIndent = indent + (lines[pos].text.length - afterDash.length);
+        lines[pos] = { indent: virtualIndent, text: afterDash };
+        arr.push(parseMapping(virtualIndent));
+      } else {
+        arr.push(parseScalar(afterDash));
+        pos++;
+      }
+    }
+    return arr;
+  }
+
+  const root = parseNode(lines.length ? lines[0].indent : 0);
+  return (root && typeof root === 'object' ? root : {}) as ComposeDoc;
+}
+
+function isSeqItem(text: string): boolean {
+  return text === '-' || text.startsWith('- ');
+}
+
+/** Index of the `key:` colon (the first colon followed by space or end-of-line). */
+function findKeyColon(text: string): number {
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (c === "'" && !inDouble) inSingle = !inSingle;
+    else if (c === '"' && !inSingle) inDouble = !inDouble;
+    else if (c === ':' && !inSingle && !inDouble && (i + 1 === text.length || text[i + 1] === ' ')) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function parseScalar(raw: string): unknown {
+  const value = raw.trim();
+  if (value.startsWith('[') && value.endsWith(']')) {
+    return splitFlow(value.slice(1, -1)).map((v) => parseScalar(v));
+  }
+  if (value.startsWith('{') && value.endsWith('}')) {
+    const map: Record<string, unknown> = {};
+    for (const part of splitFlow(value.slice(1, -1))) {
+      const colon = findKeyColon(part);
+      if (colon < 0) continue;
+      map[unquote(part.slice(0, colon).trim())] = parseScalar(part.slice(colon + 1).trim());
+    }
+    return map;
+  }
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    return unquote(value);
+  }
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  if (value === 'null' || value === '~' || value === '') return null;
+  if (/^-?\d+(\.\d+)?$/.test(value)) return Number(value);
+  return value;
+}
+
+/** Splits a flow collection body on top-level commas (ignores commas in quotes/brackets). */
+function splitFlow(body: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let inSingle = false;
+  let inDouble = false;
+  let current = '';
+  for (const c of body) {
+    if (c === "'" && !inDouble) inSingle = !inSingle;
+    else if (c === '"' && !inSingle) inDouble = !inDouble;
+    if (!inSingle && !inDouble) {
+      if (c === '[' || c === '{') depth++;
+      else if (c === ']' || c === '}') depth--;
+      else if (c === ',' && depth === 0) {
+        if (current.trim() !== '') parts.push(current.trim());
+        current = '';
+        continue;
+      }
+    }
+    current += c;
+  }
+  if (current.trim() !== '') parts.push(current.trim());
+  return parts;
+}
+
+function unquote(value: string): string {
+  if (value.startsWith('"') && value.endsWith('"') && value.length >= 2) {
+    return value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+  }
+  if (value.startsWith("'") && value.endsWith("'") && value.length >= 2) {
+    return value.slice(1, -1).replace(/''/g, "'");
+  }
+  return value;
+}
+
+/** Emits an object as YAML using the subset the reader understands. */
+export function dumpYaml(obj: unknown, indent = 0): string {
+  const pad = '  '.repeat(indent);
+  if (obj === null || obj === undefined) return '';
+  if (Array.isArray(obj)) {
+    if (obj.length === 0) return `${pad}[]\n`;
+    return obj.map((item) => `${pad}- ${dumpInlineOrBlock(item, indent)}`).join('');
+  }
+  if (typeof obj === 'object') {
+    const entries = Object.entries(obj as Record<string, unknown>);
+    if (entries.length === 0) return `${pad}{}\n`;
+    let out = '';
+    for (const [key, value] of entries) {
+      if (value === null || value === undefined) {
+        out += `${pad}${key}:\n`;
+      } else if (typeof value === 'object') {
+        const isEmpty = Array.isArray(value) ? value.length === 0 : Object.keys(value).length === 0;
+        if (isEmpty) {
+          out += `${pad}${key}: ${Array.isArray(value) ? '[]' : '{}'}\n`;
+        } else {
+          out += `${pad}${key}:\n${dumpYaml(value, indent + 1)}`;
+        }
+      } else {
+        out += `${pad}${key}: ${formatScalar(value)}\n`;
+      }
+    }
+    return out;
+  }
+  return `${pad}${formatScalar(obj)}\n`;
+}
+
+function dumpInlineOrBlock(item: unknown, indent: number): string {
+  if (item !== null && typeof item === 'object') {
+    // Render the nested structure, then splice its first line onto the dash.
+    const block = dumpYaml(item, indent + 1);
+    return block.trimStart();
+  }
+  return `${formatScalar(item)}\n`;
+}
+
+function formatScalar(value: unknown): string {
+  if (typeof value === 'boolean' || typeof value === 'number') return String(value);
+  const str = String(value);
+  if (needsQuote(str)) return `"${str.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  return str;
+}
+
+function needsQuote(str: string): boolean {
+  if (str === '') return true;
+  if (/^(true|false|null|~|yes|no|on|off)$/i.test(str)) return true;
+  if (/^-?\d+(\.\d+)?$/.test(str)) return true;
+  if (/[:#[\]{}&*!|>%@`,"']/.test(str)) return true;
+  if (/^\s|\s$/.test(str)) return true;
+  return false;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CLI command
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface MigrateOptions {
+  path?: string;
+  caPath?: string;
+  dockerSocket?: boolean;
+  output?: string;
+  force?: boolean;
+  runtime?: string;
+}
+
+/** Resolves the docker-compose file for a project directory (or an explicit file). */
+export function resolveComposeFile(target?: string): string {
+  const resolved = path.resolve(target ?? process.cwd());
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(resolved);
+  } catch {
+    throw new Error(`Path does not exist: ${resolved}`);
+  }
+  if (stat.isFile()) return resolved;
+  for (const name of ['docker-compose.yml', 'docker-compose.yaml', 'compose.yml', 'compose.yaml']) {
+    const candidate = path.join(resolved, name);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  throw new Error(`No docker-compose file found in ${resolved}`);
+}
+
+/** Best-effort check that Huddle's internal network already exists. */
+function huddleNetworkExists(internalNet: string, runtime?: string): boolean | undefined {
+  try {
+    const rt = resolveRuntime(runtime);
+    execSync(`${rt.name} network inspect ${internalNet}`, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return undefined; // runtime unavailable or network missing — don't block.
+  }
+}
+
+export async function runMigrate(opts: MigrateOptions): Promise<void> {
+  const composeFile = resolveComposeFile(opts.path);
+  const projectDir = path.dirname(composeFile);
+  const caPath = opts.caPath ?? DEFAULT_CA_PATH;
+
+  console.log(`${bold('Migrating')} ${cyan(composeFile)} to run behind Huddle...\n`);
+
+  const raw = fs.readFileSync(composeFile, 'utf8');
+  let compose: ComposeDoc;
+  try {
+    compose = parseYaml(raw);
+  } catch (err) {
+    throw new Error(`Could not parse ${composeFile}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  const result = buildOverride(compose, { caPath, dockerSocket: opts.dockerSocket });
+
+  console.log(`Marked network:  ${bold(result.markedNetwork)}`);
+  console.log(`Wired services:  ${result.services.length ? result.services.map(bold).join(', ') : dim('(none)')}`);
+  for (const w of result.warnings) console.log(yellow(`[!] ${w}`));
+  console.log();
+
+  const overrideText =
+    '# Generated by `huddle migrate` — do NOT edit by hand; re-run the command instead.\n' +
+    '# Merge this on top of your docker-compose.yml so the marked services reach the\n' +
+    '# internet only through the Huddle proxy. Your own compose file stays untouched.\n' +
+    dumpYaml(result.override);
+
+  const outPath = opts.output ? path.resolve(opts.output) : path.join(projectDir, OVERRIDE_FILENAME);
+  if (fs.existsSync(outPath) && !opts.force) {
+    throw new Error(`${outPath} already exists. Re-run with --force to overwrite.`);
+  }
+  fs.writeFileSync(outPath, overrideText);
+  console.log(green(`[OK] Wrote override: ${outPath}`));
+  console.log();
+
+  // Best-effort readiness hint.
+  if (huddleNetworkExists(INTERNAL_NET, opts.runtime) === undefined) {
+    console.log(yellow(`[!] Could not confirm the "${INTERNAL_NET}" network exists. Run \`huddle init\` first.`));
+    console.log();
+  }
+
+  printNextSteps(composeFile, outPath, caPath, !!opts.dockerSocket);
+}
+
+function printNextSteps(composeFile: string, outPath: string, caPath: string, dockerSocket: boolean): void {
+  const composeBase = path.basename(composeFile);
+  const overrideBase = path.basename(outPath);
+
+  console.log(bold('Next steps (this command only GENERATED the override — it did not start anything):'));
+  console.log();
+  console.log('  1. Make sure Huddle is running:');
+  console.log(cyan('       huddle init'));
+  console.log();
+  console.log('  2. Fetch the Huddle CA inside the container. Add to your devcontainer.json:');
+  console.log(
+    cyan(
+      `       "postCreateCommand": "curl -fsS http://huddle:3000/api/tls/ca.crt -o ${caPath} || echo 'CA not fetched (HTTPS tunnelled, no MITM)'"`,
+    ),
+  );
+  console.log(dim(`     (Adjust ${caPath} to your remoteUser's home if it differs; pass --ca-path to change it.)`));
+  console.log();
+  console.log('  3. Reference the override so the IDE merges it. In devcontainer.json:');
+  console.log(cyan(`       "dockerComposeFile": ["${composeBase}", "${overrideBase}"]`));
+  console.log(dim('     Or start it yourself:'));
+  console.log(cyan(`       docker compose -f ${composeBase} -f ${overrideBase} up -d`));
+  console.log();
+  if (dockerSocket) {
+    console.log(yellow('  Note (--docker-socket): the socket mount is GENERATED but NOT yet served.'));
+    console.log(
+      dim(
+        '     Huddle does not yet pre-provision the per-container filtered socket for IDE-started\n' +
+          '     containers (issue #66 follow-up). Until it does, the mount source will not exist and\n' +
+          '     DOCKER_HOST will point at a missing socket. Only enable this once that lands.',
+      ),
+    );
+    console.log();
+  }
+  console.log(dim('See docs/migrate-devcontainers.md for the full guide and the marked-network convention.'));
+}

--- a/docs/migrate-devcontainers.md
+++ b/docs/migrate-devcontainers.md
@@ -1,0 +1,173 @@
+# Migrating an existing Dev Container / Docker Compose project to Huddle
+
+Already have a `.devcontainer/devcontainer.json` that uses `dockerComposeFile` with
+several services (app, database, seed, dashboard, …) and start it with **"Dev Containers:
+Clone Repository in Named Container Volume"**? You can keep that setup and route it through
+the Huddle proxy without rewriting it.
+
+`huddle migrate` generates a small Compose **override file** that wires your services behind
+Huddle. Your own `docker-compose.yml`, `devcontainer.json`, extensions, features,
+`initializeCommand`, `postCreateCommand` and forwarded ports all stay exactly as they are.
+
+## How it works
+
+Huddle's `devcontainer-net` network (created by `huddle init`) is **internal**: it has no
+route to the internet of its own. The only way out is the Huddle proxy on `huddle:80`, which
+enforces the firewall and terminates TLS with its own CA. So two things have to be true for a
+service to reach the internet through Huddle:
+
+1. It is attached to the internal `devcontainer-net` network.
+2. Its egress goes through the proxy (`HTTP(S)_PROXY`) and it trusts the Huddle CA.
+
+`huddle migrate` produces both for you, in an override file, so you never hand-write proxy
+env vars, `NO_PROXY`, CA paths or socket mounts.
+
+## The convention: mark one network
+
+In your `docker-compose.yml`, add the label `huddle.network: "true"` to the (internal)
+network your services already share. That is the **only** change you make to your own files —
+it tells `huddle migrate` which services to wire.
+
+```yaml
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: my-project-devcontainer
+    command: sleep infinity
+    networks: [development]
+    depends_on: [db]
+
+  db:
+    image: mcr.microsoft.com/mssql/server:2019-latest
+    networks: [development]
+
+  dashboard:
+    image: mcr.microsoft.com/dotnet/aspire-dashboard:latest
+    networks: [development]
+
+networks:
+  development:
+    internal: true            # required: no direct route to the internet
+    labels:
+      huddle.network: "true"  # Huddle wires every service on this network
+```
+
+> The network **must** be `internal: true`. If it is not, a service could reach the internet
+> directly and bypass Huddle's firewall/proxy — `huddle migrate` warns when it sees this.
+
+## Generate the override
+
+From your project directory (where `docker-compose.yml` lives), with Huddle already running
+(`huddle init`):
+
+```bash
+huddle migrate
+```
+
+This writes `docker-compose.huddle.yml` next to your compose file. For each service on the
+marked network it adds, in the override only:
+
+* the proxy env vars — `HTTP_PROXY` / `HTTPS_PROXY` (+ lowercase) `= http://huddle:80`;
+* `NO_PROXY` including `huddle` (so the direct CA fetch to `huddle:3000` skips the proxy);
+* `NODE_EXTRA_CA_CERTS` pointing at the CA path;
+* a second network, `huddle`, that maps to the existing `devcontainer-net`
+  (`external: true`) — your own `development` network is left untouched.
+
+Example generated `docker-compose.huddle.yml`:
+
+```yaml
+services:
+  app:
+    networks:
+      development:
+      huddle:
+    environment:
+      HTTP_PROXY: "http://huddle:80"
+      HTTPS_PROXY: "http://huddle:80"
+      http_proxy: "http://huddle:80"
+      https_proxy: "http://huddle:80"
+      NO_PROXY: "localhost,127.0.0.1,::1,[::1],huddle"
+      no_proxy: "localhost,127.0.0.1,::1,[::1],huddle"
+      NODE_EXTRA_CA_CERTS: /home/vscode/.huddle-ca.crt
+  # …db, dashboard likewise…
+networks:
+  huddle:
+    external: true
+    name: devcontainer-net
+```
+
+## Wire it into your project
+
+`huddle migrate` only **generates** the override — it does not start anything. Three steps
+to finish:
+
+1. **Make sure Huddle is running** so `devcontainer-net` exists:
+
+   ```bash
+   huddle init
+   ```
+
+2. **Fetch the Huddle CA** inside the container. Add this to your `devcontainer.json`
+   (`huddle` is in `NO_PROXY`, so the call goes directly to the Huddle API):
+
+   ```jsonc
+   "postCreateCommand": "curl -fsS http://huddle:3000/api/tls/ca.crt -o /home/vscode/.huddle-ca.crt || echo 'CA not fetched (HTTPS tunnelled, no MITM)'"
+   ```
+
+   Use the home of your `remoteUser`; pass `--ca-path` to `huddle migrate` if it differs
+   (e.g. `--ca-path /home/node/.huddle-ca.crt`). If the CA is never fetched, HTTPS is
+   tunnelled un-intercepted and the container still works.
+
+3. **Reference the override** so the IDE merges it when it (re)creates the containers. In
+   `devcontainer.json`:
+
+   ```jsonc
+   "dockerComposeFile": ["docker-compose.yml", "docker-compose.huddle.yml"]
+   ```
+
+   Or start it yourself:
+
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.huddle.yml up -d
+   ```
+
+You can keep using "Clone Repository in Named Container Volume" — the override is just an
+extra Compose file the Dev Containers extension merges.
+
+## Options
+
+| Flag | Purpose |
+| --- | --- |
+| `--ca-path <path>` | Where the CA lands in the container (`NODE_EXTRA_CA_CERTS`). Default `/home/vscode/.huddle-ca.crt`. |
+| `--docker-socket` | Also wire Huddle's filtered Docker socket + `DOCKER_HOST` (see caveat below). |
+| `--output <path>` | Write the override somewhere other than `docker-compose.huddle.yml`. |
+| `--force` | Overwrite an existing override file. |
+
+## Docker-in-Docker (`--docker-socket`) — not complete yet
+
+If your outer devcontainer itself runs Docker (`docker compose up`, Testcontainers, …) it
+must talk to Huddle's **filtered** socket, never the raw engine. `--docker-socket` generates
+the mount (`/tmp/dc-sockets/<container_name>:/var/run/huddle`) and
+`DOCKER_HOST=unix:///var/run/huddle/docker.sock` for each service that has a fixed
+`container_name`.
+
+**This part is generated but not yet served.** When the IDE starts the container against the
+real engine, Huddle is not in the create path and cannot inject the socket at create time.
+Huddle would need to *pre-provision* the per-container filtered socket at a name-keyed path
+before the container exists (tracked as a follow-up on issue #66). Until that lands, the
+mount source will not exist and `DOCKER_HOST` will point at a missing socket — so only enable
+`--docker-socket` once that gateway support is available. `huddle migrate` prints the same
+warning.
+
+The proxy/CA/network wiring (the default, without `--docker-socket`) is fully functional
+today; it is the same pattern the Huddle repository's own [`.devcontainer/`](../.devcontainer)
+uses.
+
+## Security requirements
+
+* The marked network **must** be `internal: true`.
+* A wired service **must not** also be attached to a second, non-internal network — that
+  would be an unfiltered route out. `huddle migrate` warns on both.
+* Do not grant the container `NET_ADMIN`; it could otherwise tear down the injected routing.

--- a/gateway/test/migrate.test.ts
+++ b/gateway/test/migrate.test.ts
@@ -87,6 +87,25 @@ describe('parseYaml (minimal compose reader)', () => {
     );
     expect(normalizeLabels((doc.networks?.dev as any).labels)).toEqual({ 'huddle.network': 'true' });
   });
+
+  it('rejects block scalars fail-closed instead of silently mis-parsing (finding #9)', () => {
+    const withBlock = [
+      'services:',
+      '  api:',
+      '    command: |',
+      '      echo hi',
+      '    networks: [backend]',
+      '  web:',
+      '    networks: [backend]',
+      'networks:',
+      '  backend: { internal: true, labels: { huddle.network: "true" } }',
+    ].join('\n');
+    expect(() => parseYaml(withBlock)).toThrow(/block scalar/i);
+  });
+
+  it('rejects YAML anchors and merge keys fail-closed (finding #9)', () => {
+    expect(() => parseYaml('base: &anchor\n  x: 1\nsvc:\n  <<: *anchor\n')).toThrow(/anchor|merge/i);
+  });
 });
 
 describe('marked-network detection', () => {

--- a/gateway/test/migrate.test.ts
+++ b/gateway/test/migrate.test.ts
@@ -227,4 +227,40 @@ describe('dumpYaml round-trip', () => {
     expect(text).toContain('c: true');
     expect(text).toContain('d: 42');
   });
+
+  // Regression: object KEYS (service/network names) come straight from an
+  // untrusted compose file. If emitted unquoted, a crafted key could break out
+  // of its line and inject sibling compose directives, or silently corrupt the
+  // security override. Keys must be quoted/escaped like scalar values are.
+  it('quotes malicious keys so they cannot inject or corrupt the override', () => {
+    const text = dumpYaml({
+      'a: b': null,
+      'evil #comment': 1,
+      'app\n  privileged: true': { x: 1 },
+    });
+    // Colon-in-key and comment-in-key are quoted, not left to corrupt structure.
+    expect(text).toContain('"a: b":');
+    expect(text).toContain('"evil #comment":');
+    // A newline in a key is escaped, never emitted raw (which would inject a
+    // `privileged: true` sibling directive).
+    expect(text).not.toMatch(/\n\s*privileged: true/);
+    expect(text).toContain('"app\\n  privileged: true":');
+
+    // And it must round-trip: the quoted key parses back to exactly one key.
+    const reparsed = parseYaml(dumpYaml({ 'a: b': 'v' }));
+    expect(reparsed).toEqual({ 'a: b': 'v' });
+  });
+
+  it('emits a structurally sound override even for a compose with a hostile service name', () => {
+    const doc: ComposeDoc = {
+      services: { 'a: b': { networks: ['dev'] } as any },
+      networks: { dev: { internal: true, labels: { [HUDDLE_NETWORK_LABEL]: 'true' } } as any },
+    };
+    const { override } = buildOverride(doc);
+    const text = dumpYaml(override);
+    // The full override still parses, and the hostile name survives as a single
+    // key rather than splitting into an injected `b:` mapping.
+    const reparsed = parseYaml(text);
+    expect(Object.keys(reparsed.services ?? {})).toEqual(['a: b']);
+  });
 });

--- a/gateway/test/migrate.test.ts
+++ b/gateway/test/migrate.test.ts
@@ -106,6 +106,27 @@ describe('parseYaml (minimal compose reader)', () => {
   it('rejects YAML anchors and merge keys fail-closed (finding #9)', () => {
     expect(() => parseYaml('base: &anchor\n  x: 1\nsvc:\n  <<: *anchor\n')).toThrow(/anchor|merge/i);
   });
+
+  it('also rejects anchors/aliases embedded in flow collections (bypass fix)', () => {
+    // Plain `x: *a` was already caught; flow forms must be too, else a marked
+    // service could be silently left unwired.
+    expect(() => parseYaml('services:\n  x:\n    networks: [*net]\n')).toThrow(/alias/i);
+    expect(() => parseYaml('services:\n  x:\n    networks: {n: *net}\n')).toThrow(/alias/i);
+    expect(() => parseYaml('x:\n  y: [&a, 1]\n')).toThrow(/anchor/i);
+  });
+
+  it('does NOT reject scalars that merely contain * or & (globs, env URLs)', () => {
+    // `*.log` (glob) and `a=1&b=2` (URL query) are ordinary scalars, not aliases.
+    expect(() => parseYaml('services:\n  x:\n    command: rm *.log\n')).not.toThrow();
+    expect(() => parseYaml('services:\n  x:\n    environment:\n      - URL=http://h/?a=1&b=2\n')).not.toThrow();
+  });
+
+  it('caps parse recursion depth (CWE-674) instead of overflowing the stack', () => {
+    // 200 levels of nested mapping — well past MAX_DEPTH (64).
+    let y = '';
+    for (let i = 0; i < 200; i++) y += '  '.repeat(i) + `k${i}:\n`;
+    expect(() => parseYaml(y)).toThrow(/nesting exceeds/i);
+  });
 });
 
 describe('marked-network detection', () => {
@@ -185,15 +206,17 @@ describe('buildOverride', () => {
     expect(warnings.some((w) => w.includes('container_name'))).toBe(true);
   });
 
-  it('warns when the marked network is not internal', () => {
+  it('blocks (fail-closed) when the marked network is not internal', () => {
     const doc: ComposeDoc = {
       services: { app: { networks: ['dev'] } },
       networks: { dev: { labels: { [HUDDLE_NETWORK_LABEL]: 'true' } } },
     };
-    expect(buildOverride(doc).warnings.some((w) => w.includes('internal'))).toBe(true);
+    // Security-critical → a blocker, not an advisory warning (runMigrate refuses
+    // to write the override unless --force).
+    expect(buildOverride(doc).blockers.some((b) => b.includes('internal'))).toBe(true);
   });
 
-  it('warns when a wired service also sits on a second non-internal network', () => {
+  it('blocks (fail-closed) when a wired service also sits on a second non-internal network', () => {
     const doc: ComposeDoc = {
       services: { app: { networks: ['dev', 'public'] } },
       networks: {
@@ -201,7 +224,35 @@ describe('buildOverride', () => {
         public: {},
       },
     };
-    expect(buildOverride(doc).warnings.some((w) => w.includes('public'))).toBe(true);
+    expect(buildOverride(doc).blockers.some((b) => b.includes('public'))).toBe(true);
+  });
+
+  it('does not collapse the egress net when the marked network is literally "huddle"', () => {
+    const doc: ComposeDoc = {
+      services: { app: { networks: ['huddle'] } },
+      networks: { huddle: { internal: true, labels: { [HUDDLE_NETWORK_LABEL]: 'true' } } },
+    };
+    const { override } = buildOverride(doc);
+    // The egress key must differ from the marked network, else the service's
+    // networks map { huddle, huddle } collapses and the egress net is dropped.
+    const egressKey = Object.keys(override.networks ?? {})[0];
+    expect(egressKey).not.toBe('huddle');
+    expect((override.services?.app as any).networks).toHaveProperty(egressKey);
+    expect((override.services?.app as any).networks).toHaveProperty('huddle');
+  });
+
+  it('finds a unique egress key when both "huddle" and "huddle-egress" already exist', () => {
+    const doc: ComposeDoc = {
+      services: { app: { networks: ['dev'] } },
+      networks: {
+        dev: { internal: true, labels: { [HUDDLE_NETWORK_LABEL]: 'true' } },
+        huddle: { internal: true },
+        'huddle-egress': { internal: true },
+      },
+    };
+    const egressKey = Object.keys(buildOverride(doc).override.networks ?? {})[0];
+    expect(['huddle', 'huddle-egress']).not.toContain(egressKey);
+    expect(egressKey).toBe('huddle-egress-1');
   });
 
   it('renames the egress network key if the project already uses "huddle"', () => {

--- a/gateway/test/migrate.test.ts
+++ b/gateway/test/migrate.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect } from 'vitest';
+// The CLI package ships with zero runtime dependencies, so vitest is not
+// installed there. Its pure helpers live in cli/src/migrate.ts and are exercised
+// here, from the gateway package where the repo's vitest runner already lives.
+import {
+  parseYaml,
+  dumpYaml,
+  findMarkedNetworks,
+  serviceNetworkKeys,
+  normalizeLabels,
+  buildOverride,
+  huddleProxyEnv,
+  HUDDLE_NETWORK_LABEL,
+  HUDDLE_NET_KEY,
+  DEFAULT_CA_PATH,
+  type ComposeDoc,
+} from '../../cli/src/migrate';
+
+// A representative existing project: an outer devcontainer plus supporting
+// services (db, seed, dashboard) on one internal, marked network.
+const COMPOSE = `
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: my-project-devcontainer
+    command: sleep infinity
+    networks: [development]
+    depends_on:
+      - db
+  db:
+    image: mcr.microsoft.com/mssql/server:2019-latest
+    networks:
+      - development
+  dashboard:
+    image: mcr.microsoft.com/dotnet/aspire-dashboard:latest
+    networks:
+      - development
+
+networks:
+  development:
+    internal: true
+    labels:
+      huddle.network: "true"
+`;
+
+describe('parseYaml (minimal compose reader)', () => {
+  it('parses nested maps, block + flow sequences and quoted scalars', () => {
+    const doc = parseYaml(COMPOSE);
+    expect(Object.keys(doc.services ?? {})).toEqual(['app', 'db', 'dashboard']);
+    expect(doc.services?.app.container_name).toBe('my-project-devcontainer');
+    expect(doc.services?.app.command).toBe('sleep infinity');
+    // Flow sequence form.
+    expect(doc.services?.app.networks).toEqual(['development']);
+    // Block sequence form.
+    expect(doc.services?.db.networks).toEqual(['development']);
+    // depends_on block sequence.
+    expect(doc.services?.app.depends_on).toEqual(['db']);
+    // Nested build map.
+    expect((doc.services?.app.build as any).dockerfile).toBe('Dockerfile');
+    // Quoted "true" stays a string; internal: true is a boolean.
+    expect((doc.networks?.development as any).internal).toBe(true);
+    expect((doc.networks?.development as any).labels).toEqual({ 'huddle.network': 'true' });
+  });
+
+  it('does not treat a colon inside a URL or a # inside quotes as structure', () => {
+    const doc = parseYaml(
+      [
+        'services:',
+        '  app:',
+        '    environment:',
+        '      HTTP_PROXY: http://huddle:80',
+        '      NOTE: "value # not a comment"',
+        '    image: nginx  # trailing comment',
+      ].join('\n'),
+    );
+    const env = doc.services?.app.environment as Record<string, unknown>;
+    expect(env.HTTP_PROXY).toBe('http://huddle:80');
+    expect(env.NOTE).toBe('value # not a comment');
+    expect(doc.services?.app.image).toBe('nginx');
+  });
+
+  it('reads list-form labels (key=value)', () => {
+    const doc = parseYaml(
+      ['networks:', '  dev:', '    internal: true', '    labels:', '      - huddle.network=true'].join('\n'),
+    );
+    expect(normalizeLabels((doc.networks?.dev as any).labels)).toEqual({ 'huddle.network': 'true' });
+  });
+});
+
+describe('marked-network detection', () => {
+  it('finds a network labelled huddle.network (map form)', () => {
+    expect(findMarkedNetworks(parseYaml(COMPOSE))).toEqual(['development']);
+  });
+
+  it('finds a network labelled via list form', () => {
+    const doc = parseYaml(
+      ['networks:', '  dev:', '    internal: true', '    labels:', '      - huddle.network=true'].join('\n'),
+    );
+    expect(findMarkedNetworks(doc)).toEqual(['dev']);
+  });
+
+  it('ignores networks without the label', () => {
+    const doc: ComposeDoc = { networks: { other: { internal: true } } };
+    expect(findMarkedNetworks(doc)).toEqual([]);
+  });
+
+  it('serviceNetworkKeys handles list and map forms', () => {
+    expect(serviceNetworkKeys({ networks: ['a', 'b'] })).toEqual(['a', 'b']);
+    expect(serviceNetworkKeys({ networks: { a: null, b: { aliases: ['x'] } } })).toEqual(['a', 'b']);
+    expect(serviceNetworkKeys({})).toEqual([]);
+  });
+});
+
+describe('huddleProxyEnv', () => {
+  it('routes all egress via huddle:80 and keeps huddle in NO_PROXY', () => {
+    const env = huddleProxyEnv('/home/vscode/.huddle-ca.crt', false);
+    expect(env.HTTP_PROXY).toBe('http://huddle:80');
+    expect(env.HTTPS_PROXY).toBe('http://huddle:80');
+    expect(env.http_proxy).toBe('http://huddle:80');
+    expect(env.NO_PROXY).toContain('huddle');
+    expect(env.no_proxy).toContain('huddle');
+    expect(env.NODE_EXTRA_CA_CERTS).toBe('/home/vscode/.huddle-ca.crt');
+    expect(env.DOCKER_HOST).toBeUndefined();
+  });
+
+  it('adds DOCKER_HOST only when the socket is wired', () => {
+    expect(huddleProxyEnv('/x', true).DOCKER_HOST).toBe('unix:///var/run/huddle/docker.sock');
+  });
+});
+
+describe('buildOverride', () => {
+  it('wires every service on the marked network and attaches the huddle egress net', () => {
+    const { markedNetwork, services, override, warnings } = buildOverride(parseYaml(COMPOSE));
+    expect(markedNetwork).toBe('development');
+    expect(services).toEqual(['app', 'db', 'dashboard']);
+    expect(warnings).toEqual([]); // internal network, single net → clean
+
+    const app = override.services?.app;
+    expect(app?.networks).toEqual({ development: null, [HUDDLE_NET_KEY]: null });
+    expect((app?.environment as Record<string, string>).HTTPS_PROXY).toBe('http://huddle:80');
+    expect((app?.environment as Record<string, string>).NODE_EXTRA_CA_CERTS).toBe(DEFAULT_CA_PATH);
+    // No socket mount unless opted in.
+    expect(app?.volumes).toBeUndefined();
+
+    // Egress network reuses Huddle's existing internal network.
+    expect(override.networks?.[HUDDLE_NET_KEY]).toEqual({ external: true, name: 'devcontainer-net' });
+  });
+
+  it('injects the filtered socket mount when dockerSocket is set', () => {
+    const { override } = buildOverride(parseYaml(COMPOSE), { dockerSocket: true });
+    expect(override.services?.app.volumes).toEqual(['/tmp/dc-sockets/my-project-devcontainer:/var/run/huddle']);
+    expect((override.services?.app.environment as Record<string, string>).DOCKER_HOST).toBe(
+      'unix:///var/run/huddle/docker.sock',
+    );
+  });
+
+  it('warns (does not crash) when dockerSocket is set but a service lacks container_name', () => {
+    const doc: ComposeDoc = {
+      services: { app: { networks: ['dev'] } },
+      networks: { dev: { internal: true, labels: { [HUDDLE_NETWORK_LABEL]: 'true' } } },
+    };
+    const { override, warnings } = buildOverride(doc, { dockerSocket: true });
+    expect(override.services?.app.volumes).toBeUndefined();
+    expect(warnings.some((w) => w.includes('container_name'))).toBe(true);
+  });
+
+  it('warns when the marked network is not internal', () => {
+    const doc: ComposeDoc = {
+      services: { app: { networks: ['dev'] } },
+      networks: { dev: { labels: { [HUDDLE_NETWORK_LABEL]: 'true' } } },
+    };
+    expect(buildOverride(doc).warnings.some((w) => w.includes('internal'))).toBe(true);
+  });
+
+  it('warns when a wired service also sits on a second non-internal network', () => {
+    const doc: ComposeDoc = {
+      services: { app: { networks: ['dev', 'public'] } },
+      networks: {
+        dev: { internal: true, labels: { [HUDDLE_NETWORK_LABEL]: 'true' } },
+        public: {},
+      },
+    };
+    expect(buildOverride(doc).warnings.some((w) => w.includes('public'))).toBe(true);
+  });
+
+  it('renames the egress network key if the project already uses "huddle"', () => {
+    const doc: ComposeDoc = {
+      services: { app: { networks: ['dev', 'huddle'] } },
+      networks: {
+        dev: { internal: true, labels: { [HUDDLE_NETWORK_LABEL]: 'true' } },
+        huddle: { internal: true },
+      },
+    };
+    const { override } = buildOverride(doc);
+    expect(override.networks?.['huddle-egress']).toEqual({ external: true, name: 'devcontainer-net' });
+  });
+
+  it('throws when no network is marked', () => {
+    expect(() => buildOverride({ networks: { dev: { internal: true } } })).toThrow(/No network marked/);
+  });
+
+  it('throws when more than one network is marked', () => {
+    const doc: ComposeDoc = {
+      networks: {
+        a: { labels: { [HUDDLE_NETWORK_LABEL]: 'true' } },
+        b: { labels: { [HUDDLE_NETWORK_LABEL]: 'true' } },
+      },
+    };
+    expect(() => buildOverride(doc)).toThrow(/Multiple networks/);
+  });
+});
+
+describe('dumpYaml round-trip', () => {
+  it('emits an override that parses back to the same object', () => {
+    const { override } = buildOverride(parseYaml(COMPOSE));
+    const text = dumpYaml(override);
+    const reparsed = parseYaml(text);
+    expect(reparsed).toEqual(override);
+  });
+
+  it('quotes values that would otherwise change type or break structure', () => {
+    const text = dumpYaml({ a: 'true', b: 'localhost,::1,[::1],huddle', c: true, d: 42 });
+    expect(text).toContain('a: "true"');
+    expect(text).toContain('b: "localhost,::1,[::1],huddle"');
+    expect(text).toContain('c: true');
+    expect(text).toContain('d: 42');
+  });
+});


### PR DESCRIPTION
Adds `huddle migrate`, which wires an existing docker-compose Dev Container project behind Huddle without the developer editing proxy/CA/socket settings into their own files.

Convention: the developer labels one (internal) network with `huddle.network: "true"`. The command generates a compose **override** (`docker-compose.huddle.yml`) that, for each service on that network, injects the proxy env vars (`HTTP(S)_PROXY`, `NO_PROXY` including `huddle`), `NODE_EXTRA_CA_CERTS`, and attaches the service to Huddle's existing internal `devcontainer-net` (as `external: true`). The user's compose/devcontainer.json, extensions, features and lifecycle commands stay untouched. Verified end-to-end with `docker compose config`.

- Override generation and a dependency-free compose YAML reader/emitter are pure, unit-tested functions (`gateway/test/migrate.test.ts`)
- `--docker-socket` generates the filtered-socket mount + `DOCKER_HOST`, explicitly flagged as generated-not-yet-served: gateway-side socket pre-provisioning is a follow-up
- Docs: `docs/migrate-devcontainers.md` (linked from README)

Closes #66