### PR TITLE
fix(gateway): resolve Windows bind mounts under Docker Desktop

### DIFF
--- a/gateway/src/docker.ts
+++ b/gateway/src/docker.ts
@@ -839,12 +839,46 @@ touch /tmp/sudo-audit.log
 `;
 }
 
-function toLinuxPath(p: string): string {
+/**
+ * Where the engine's host filesystem is mounted, as seen from INSIDE the
+ * Docker engine's own mount namespace (not the gateway container's). A bind
+ * mount `Source` is resolved by the engine, so it must use whichever prefix
+ * that engine recognizes:
+ *  - 'wsl2-native': dockerd runs directly inside a WSL2 distro (no Docker
+ *    Desktop) — that distro auto-mounts Windows drives at `/mnt/<drive>`.
+ *  - 'docker-desktop': dockerd runs inside Docker Desktop's own hidden
+ *    utility VM, which exposes Windows drives at
+ *    `/run/desktop/mnt/host/<drive>` instead (issue #93).
+ */
+export type WindowsMountStyle = 'wsl2-native' | 'docker-desktop';
+
+/**
+ * Detects which of the above styles the connected engine uses, by asking it
+ * directly — Docker Desktop's `/info` reports the literal
+ * `OperatingSystem: "Docker Desktop"`, while a native dockerd (including one
+ * installed straight into a WSL2 distro) reports its real Linux distro name.
+ * Not cached: this only runs once per container start, alongside several
+ * other one-off Docker API calls already made there, so the negligible cost
+ * of asking again isn't worth the complexity of invalidating a cache if the
+ * engine behind the socket ever changes.
+ */
+export async function detectWindowsMountStyle(): Promise<WindowsMountStyle> {
+  try {
+    const info = await dockerRequest('GET', '/info');
+    return info?.OperatingSystem === 'Docker Desktop' ? 'docker-desktop' : 'wsl2-native';
+  } catch {
+    return 'wsl2-native';
+  }
+}
+
+export function toLinuxPath(p: string, style: WindowsMountStyle = 'wsl2-native'): string {
   if (p.startsWith('/')) return p;
   const normalized = p.replace(/\\/g, '/');
   const match = normalized.match(/^([a-zA-Z]):\/(.*)/);
-  if (match) return `/mnt/${match[1].toLowerCase()}/${match[2]}`;
-  return p;
+  if (!match) return p;
+  const drive = match[1].toLowerCase();
+  const rest = match[2];
+  return style === 'docker-desktop' ? `/run/desktop/mnt/host/${drive}/${rest}` : `/mnt/${drive}/${rest}`;
 }
 
 interface FolderMount { Type: 'bind' | 'volume'; Source: string; Target: string; ReadOnly?: boolean; }
@@ -988,7 +1022,9 @@ export async function createAndStartContainer(params: StartParams): Promise<stri
     ]),
   ];
 
-  const effectiveSource = empty ? '' : await ensureWorktree(toLinuxPath(workspaceDir), containerName);
+  const effectiveSource = empty
+    ? ''
+    : await ensureWorktree(toLinuxPath(workspaceDir, await detectWindowsMountStyle()), containerName);
 
   const folderMounts = buildFolderMounts(containerName);
 

--- a/gateway/test/windows-mount-path.test.ts
+++ b/gateway/test/windows-mount-path.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EventEmitter } from 'events';
+
+// ── Windows bind-mount source translation (issue #93) ───────────────────────
+// `docker.ts` needs to translate a Windows workspace path (e.g. `Z:\temp\foo`)
+// into whatever path the DOCKER ENGINE itself will accept as a bind-mount
+// `Source`. That path is resolved by the engine's own mount namespace, which
+// differs depending on how the engine is set up:
+//  - dockerd running directly inside a WSL2 distro (no Docker Desktop) mounts
+//    Windows drives at /mnt/<drive> — the previous (only) behavior.
+//  - Docker Desktop runs dockerd inside its own hidden utility VM, which
+//    exposes Windows drives at /run/desktop/mnt/host/<drive> instead. Passing
+//    the /mnt/<drive> form there fails container creation with "bind source
+//    path does not exist" (#93).
+//
+// docker.ts imports ./db (native better-sqlite3 binding, absent in a fresh
+// devcontainer — see rules.test.ts) transitively via socket-proxy/sudo-grant,
+// so it is mocked here purely to allow the module to load.
+vi.mock('../src/db', () => ({
+  getSetting: () => null,
+  listFolderMappings: () => [],
+  isHostPortApproved: () => false,
+  getGrant: () => null,
+  getActionPolicy: () => null,
+  setSudoGrant: () => {},
+  deleteSudoGrant: () => {},
+  getExpiredSudoGrants: () => [],
+}));
+
+// dockerRequest() talks to the engine over http.request({ socketPath: ... }).
+// Mocking 'http' lets us feed a fake /info response without a live daemon.
+type FakeResponse = { statusCode?: number; body: string };
+let nextResponse: FakeResponse = { statusCode: 200, body: '{}' };
+let lastRequestOptions: any;
+
+vi.mock('http', () => ({
+  default: {
+    request: (options: any, callback: (res: any) => void) => {
+      lastRequestOptions = options;
+      const res = new EventEmitter() as EventEmitter & { statusCode?: number };
+      res.statusCode = nextResponse.statusCode;
+      const req = new EventEmitter() as EventEmitter & { write: (s: string) => void; end: () => void };
+      req.write = () => {};
+      req.end = () => {
+        queueMicrotask(() => {
+          callback(res);
+          res.emit('data', nextResponse.body);
+          res.emit('end');
+        });
+      };
+      return req;
+    },
+  },
+}));
+
+const { toLinuxPath, detectWindowsMountStyle } = await import('../src/docker');
+
+beforeEach(() => {
+  nextResponse = { statusCode: 200, body: '{}' };
+});
+
+describe('toLinuxPath', () => {
+  it('leaves already-Linux paths untouched', () => {
+    expect(toLinuxPath('/home/vscode/project')).toBe('/home/vscode/project');
+    expect(toLinuxPath('/home/vscode/project', 'docker-desktop')).toBe('/home/vscode/project');
+  });
+
+  it('leaves non drive-letter input untouched (no match)', () => {
+    expect(toLinuxPath('relative/path')).toBe('relative/path');
+  });
+
+  it('defaults to the /mnt/<drive> form (native WSL2 dockerd)', () => {
+    expect(toLinuxPath('Z:\\temp\\huddle-test')).toBe('/mnt/z/temp/huddle-test');
+    expect(toLinuxPath('C:/work/huddle-test')).toBe('/mnt/c/work/huddle-test');
+  });
+
+  it('uses /mnt/<drive> explicitly for the wsl2-native style', () => {
+    expect(toLinuxPath('Z:\\temp\\huddle-test', 'wsl2-native')).toBe('/mnt/z/temp/huddle-test');
+  });
+
+  // Regression (#93): Docker Desktop's dockerd cannot resolve /mnt/<drive> —
+  // it must use /run/desktop/mnt/host/<drive> instead.
+  it('uses /run/desktop/mnt/host/<drive> for the docker-desktop style', () => {
+    expect(toLinuxPath('Z:\\temp\\huddle-test', 'docker-desktop')).toBe('/run/desktop/mnt/host/z/temp/huddle-test');
+    expect(toLinuxPath('C:/work/huddle-test', 'docker-desktop')).toBe('/run/desktop/mnt/host/c/work/huddle-test');
+  });
+
+  it('lowercases the drive letter', () => {
+    expect(toLinuxPath('Z:\\temp\\huddle-test', 'docker-desktop')).toBe('/run/desktop/mnt/host/z/temp/huddle-test');
+    expect(toLinuxPath('z:\\temp\\huddle-test', 'docker-desktop')).toBe('/run/desktop/mnt/host/z/temp/huddle-test');
+  });
+});
+
+describe('detectWindowsMountStyle', () => {
+  it('detects Docker Desktop from the /info OperatingSystem field', async () => {
+    nextResponse = { statusCode: 200, body: JSON.stringify({ OperatingSystem: 'Docker Desktop' }) };
+    expect(await detectWindowsMountStyle()).toBe('docker-desktop');
+    expect(lastRequestOptions.path).toBe('/info');
+  });
+
+  it('treats any other OperatingSystem as native dockerd (WSL2 or Linux)', async () => {
+    nextResponse = { statusCode: 200, body: JSON.stringify({ OperatingSystem: 'Ubuntu 22.04.3 LTS' }) };
+    expect(await detectWindowsMountStyle()).toBe('wsl2-native');
+  });
+
+  it('falls back to wsl2-native if the engine cannot be reached', async () => {
+    nextResponse = { statusCode: 500, body: '{"message":"boom"}' };
+    expect(await detectWindowsMountStyle()).toBe('wsl2-native');
+  });
+
+  it('queries the engine fresh each call (no stale caching)', async () => {
+    nextResponse = { statusCode: 200, body: JSON.stringify({ OperatingSystem: 'Docker Desktop' }) };
+    expect(await detectWindowsMountStyle()).toBe('docker-desktop');
+    nextResponse = { statusCode: 200, body: JSON.stringify({ OperatingSystem: 'Ubuntu 22.04.3 LTS' }) };
+    expect(await detectWindowsMountStyle()).toBe('wsl2-native');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes bind-mount source path resolution for Windows workspaces when Docker Desktop is the container engine. `toLinuxPath()` always translated a Windows path (e.g. `Z:\huddle`) to `/mnt/<drive>/...`, which is only valid when dockerd runs natively inside a WSL2 distro. Under Docker Desktop, dockerd runs inside its own hidden utility VM, which exposes Windows drives at `/run/desktop/mnt/host/<drive>` instead — so container creation failed with `invalid mount config for type "bind": bind source path does not exist`.

Added `detectWindowsMountStyle()`, which asks the connected engine's `/info` endpoint (`OperatingSystem: "Docker Desktop"` is a reliable, daemon-reported signal) and returns whether to use the Docker Desktop or native-WSL2 mount prefix. `toLinuxPath()` now accepts this style and emits the correct prefix. Not cached — the extra `/info` call is negligible next to the other Docker API calls already made per container start, and avoids any cache-invalidation complexity.

## Related issue

Fixes #93

## Type of change

- [x] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Documentation (`docs`)
- [ ] Refactor / maintenance (`refactor` / `chore`)
- [ ] Other:

## Checklist

- [x] My branch is up to date with `main` and focused on a single change.
- [x] The project **builds** and **type-checks** locally.
- [x] Tests pass (`npm --prefix gateway test`) and I added/updated tests where relevant.
- [x] I ran Prettier and did not reformat unrelated code.
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] I did not introduce logging of secrets, tokens, or credentials.
- [ ] Documentation is updated where needed (README / relevant docs).

## Notes for reviewers

- New file `gateway/test/windows-mount-path.test.ts` covers `toLinuxPath()` for both mount styles (incl. drive-letter casing, already-Linux paths) and `detectWindowsMountStyle()` (Docker Desktop detection, native-dockerd fallback, engine-unreachable fallback, and that it queries fresh each call rather than caching).
- `/run/desktop/mnt/host/<drive>` was chosen over the `/host_mnt/<drive>` path used in the issue's temporary workaround because it's the canonical path Docker Desktop's daemon itself resolves internally (confirmed by the daemon's own bind-mount bookkeeping paths); `/host_mnt` is a legacy compatibility symlink to the same location.