### PR TITLE
chore(port): change default Huddle port from 3000 to 24842

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
   // Haal de Huddle-MITM-CA op naar een user-eigen pad (zonder root). Loopt direct
   // naar de Huddle-API (huddle staat in NO_PROXY). Lukt het niet, dan tunnelt de
   // proxy HTTPS alsnog ongeïntercepteerd — de devcontainer werkt gewoon door.
-  "postCreateCommand": "curl -fsS http://huddle:3000/api/tls/ca.crt -o $HOME/.huddle-ca.crt && echo 'Huddle CA opgehaald -> $HOME/.huddle-ca.crt' || echo 'Huddle CA niet opgehaald (HTTPS wordt getunneld, geen MITM)'",
+  "postCreateCommand": "curl -fsS http://huddle:24842/api/tls/ca.crt -o $HOME/.huddle-ca.crt && echo 'Huddle CA opgehaald -> $HOME/.huddle-ca.crt' || echo 'Huddle CA niet opgehaald (HTTPS wordt getunneld, geen MITM)'",
 
   "customizations": {
     "vscode": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
     # ── Alle egress verplicht via de Huddle-proxy ───────────────────────────────
     # Het interne netwerk heeft geen eigen internettoegang; dit is de enige uitweg.
-    # `huddle` staat in NO_PROXY zodat directe calls naar de Huddle-API (poort 3000)
+    # `huddle` staat in NO_PROXY zodat directe calls naar de Huddle-API (poort 24842)
     # en het ophalen van de CA niet door de proxy (poort 80) hoeven.
     environment:
       HTTP_PROXY: http://huddle:80

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
           docker run -d \
             --name huddle \
             --network devcontainer-net \
-            -p 3000:3000 \
+            -p 24842:24842 \
             -e HUDDLE_OPERATOR_TOKEN="$HUDDLE_OPERATOR_TOKEN" \
             -v huddle-data:/data \
             -v /var/run/docker.sock:/var/run/docker.sock \
@@ -72,7 +72,7 @@ jobs:
       - name: Wait for Huddle
         run: |
           for i in $(seq 1 20); do
-            curl -sf -H "Authorization: Bearer $HUDDLE_OPERATOR_TOKEN" http://localhost:3000/api/rules && break
+            curl -sf -H "Authorization: Bearer $HUDDLE_OPERATOR_TOKEN" http://localhost:24842/api/rules && break
             sleep 2
           done
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Devcontainer
        └─ label isolation + time-limited grant check
 
 Browser
-  └─ Angular SPA (port 3000) + WebSocket live push
+  └─ Angular SPA (port 24842) + WebSocket live push
        └─ Fastify REST API (/api/...)
 ```
 
@@ -46,7 +46,7 @@ Two servers run in the same process:
 | Server | Port | Purpose |
 |--------|------|---------|
 | HTTP proxy | 80 | Forward/intercept all outbound container traffic |
-| API + UI | 3000 | REST API, Angular frontend, WebSocket push |
+| API + UI | 24842 | REST API, Angular frontend, WebSocket push |
 
 <p align="center">
   <img src="docs/images/huddle-gateway.png" alt="Huddle gateway: traffic, Docker access, and logs flow through the DMZ under control" width="820">
@@ -113,7 +113,7 @@ This closes security-review finding **#10** (plaintext admin credentials retriev
 - Filterable by container, domain, and action prefix
 
 ### Live UI
-- Angular 21 SPA on port 3000
+- Angular 21 SPA on port 24842
 - WebSocket connection pushes a `reload` event on every state change
 - Unified icon system (`app-icon`) backed by a central SVG registry
 - Pie-action menus in the firewall and container views (approve / snooze / reject)
@@ -153,7 +153,7 @@ npm install -g @infosupport/huddle-cli
 huddle init
 ```
 
-`huddle init` pulls the latest Huddle image and starts the container. It automatically detects whether Docker or Podman is available; use `huddle init --runtime <docker|podman>` (or the `HUDDLE_RUNTIME` env var) to pick a runtime explicitly. The web UI is available at `http://localhost:3000`.
+`huddle init` pulls the latest Huddle image and starts the container. It automatically detects whether Docker or Podman is available; use `huddle init --runtime <docker|podman>` (or the `HUDDLE_RUNTIME` env var) to pick a runtime explicitly. The web UI is available at `http://localhost:24842`.
 
 After that, you start devcontainers directly from a project directory:
 
@@ -200,7 +200,7 @@ docker build -t base-devimage-rider     -f base-devimage-rider/Dockerfile     .
 
 ## Starting containers
 
-You can start devcontainers via the CLI or via the web UI at `http://localhost:3000`.
+You can start devcontainers via the CLI or via the web UI at `http://localhost:24842`.
 
 ### Via the CLI
 
@@ -430,7 +430,7 @@ All state-mutating endpoints send a WebSocket `{ type: "reload" }` event to conn
 │   ├── src/
 │   │   ├── index.ts             # Init DB, start proxy + API, restore socket proxies
 │   │   ├── proxy.ts             # HTTP/HTTPS proxy (port 80), rule enforcement, audit
-│   │   ├── api.ts               # Fastify REST API + WebSocket push (port 3000)
+│   │   ├── api.ts               # Fastify REST API + WebSocket push (port 24842)
 │   │   ├── docker.ts            # Docker API helpers, container lifecycle
 │   │   ├── socket-proxy.ts      # Per-container Docker socket proxy with label policy
 │   │   ├── rules.ts             # Rule lookup with per-container + global fallback
@@ -470,7 +470,7 @@ npm run build          # builds the gateway (API + frontend)
 npm run cli:build      # builds the CLI
 npm run cli:typecheck  # type-checks the CLI
 
-npm start              # runs the gateway locally (UI at http://localhost:3000)
+npm start              # runs the gateway locally (UI at http://localhost:24842)
 ```
 
 Running tests:
@@ -520,7 +520,7 @@ There are two ways an `experiment-<nr>` build gets published:
 | `docker login ghcr.io` or `npm install` fails with **401/403** | Your token expired or lacks the `read:packages` scope. Create a new token and log in again (see [Getting Started](#getting-started)). |
 | `huddle init` finds no runtime | Make sure Docker or Podman is running. Force it explicitly with `huddle init --runtime docker` (or `podman`), or set `HUDDLE_RUNTIME`. |
 | Rancher Desktop not detected | Use **dockerd (moby)** mode (not `containerd`), activate the context with `docker context use rancher-desktop`, verify `docker info` works, then re-run `huddle init --runtime docker`. |
-| Web UI not reachable at `http://localhost:3000` | Check that the Huddle container is running (`docker ps`). The management API binds to `127.0.0.1` by default — reach it locally, not from another host. |
+| Web UI not reachable at `http://localhost:24842` | Check that the Huddle container is running (`docker ps`). The management API binds to `127.0.0.1` by default — reach it locally, not from another host. |
 | Devcontainer can't reach a domain | Expected behavior: all traffic goes through the firewall. Allow the domain via **Firewall** in the UI or `huddle fw list`. |
 | JetBrains Gateway doesn't see the container right away | The JetBrains backend needs a moment to start; the CLI prints the gateway link once it's ready. |
 | `docker` inside the devcontainer gives *permission denied* | Docker access runs through a time-bound grant. Grant access via **Docker Access** in the UI (or `PUT /api/authz/grants/:container`). |

--- a/cli/README.md
+++ b/cli/README.md
@@ -29,7 +29,7 @@ huddle fw list
 huddle firewall list -i
 ```
 
-Default API URL: `http://localhost:3000`. Override it with `--url` or `HUDDLE_URL`.
+Default API URL: `http://localhost:24842`. Override it with `--url` or `HUDDLE_URL`.
 
 ## Experiments
 

--- a/cli/src/api.ts
+++ b/cli/src/api.ts
@@ -1,6 +1,6 @@
 import { operatorToken } from './config';
 
-let baseUrl = normalizeBaseUrl(process.env.HUDDLE_URL ?? 'http://localhost:3000');
+let baseUrl = normalizeBaseUrl(process.env.HUDDLE_URL ?? 'http://localhost:24842');
 
 export class ApiError extends Error {
   constructor(

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -150,7 +150,7 @@ Firewall add options:
   --deny                             Create a block rule (default: allow)
 
 Global options:
-  --url <url>                        Huddle URL (default: http://localhost:3000)
+  --url <url>                        Huddle URL (default: http://localhost:24842)
                                      Or via the HUDDLE_URL env var
   --help, -h                         Show help
   --version, -v                      Show version (as published to
@@ -181,7 +181,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  const url = flagString(flags, 'url') ?? process.env.HUDDLE_URL ?? 'http://localhost:3000';
+  const url = flagString(flags, 'url') ?? process.env.HUDDLE_URL ?? 'http://localhost:24842';
   setBaseUrl(url);
 
   const startsWithExistingPath = cmd !== undefined && !COMMANDS.has(cmd) && fs.existsSync(path.resolve(cmd));

--- a/cli/src/init.ts
+++ b/cli/src/init.ts
@@ -22,7 +22,7 @@ export const INTERNAL_NET = 'devcontainer-net';
  * `huddle migrate` can generate the matching bind mount.
  */
 export const HOST_SOCKET_DIR = '/tmp/dc-sockets';
-const HOST_PORT = process.env.HUDDLE_PORT ?? '3000';
+const HOST_PORT = process.env.HUDDLE_PORT ?? '24842';
 
 export interface InitOptions {
   runtime?: string;
@@ -158,7 +158,7 @@ export async function runInit(opts: InitOptions, images: ResolvedImages): Promis
     securityOptFlags +
     ` -e HUDDLE_RUNTIME=${runtime.name}` +
     ` -e HUDDLE_OPERATOR_TOKEN=${operatorToken}` +
-    ` -p ${HOST_PORT}:3000` +
+    ` -p ${HOST_PORT}:24842` +
     ` -v ${VOLUME}:/data` +
     ` -v "${runtime.socketPath}:/var/run/docker.sock"` +
     ` -v "${hostTmpSockets}:/tmp/dc-sockets"` +

--- a/cli/src/migrate.ts
+++ b/cli/src/migrate.ts
@@ -66,7 +66,7 @@ export interface AnalysisResult {
 // ─────────────────────────────────────────────────────────────────────────────
 // Egress wiring that gets injected (mirrors the working .devcontainer example,
 // which issue-66-reply.md calls the source of truth). `huddle` stays in NO_PROXY
-// so the direct CA fetch to huddle:3000 does not loop through the proxy on :80.
+// so the direct CA fetch to huddle:24842 does not loop through the proxy on :80.
 // ─────────────────────────────────────────────────────────────────────────────
 
 export function huddleProxyEnv(caPath: string, dockerSocket: boolean): Record<string, string> {
@@ -722,7 +722,7 @@ function printNextSteps(composeFile: string, outPath: string, caPath: string, do
   console.log('  2. Fetch the Huddle CA inside the container. Add to your devcontainer.json:');
   console.log(
     cyan(
-      `       "postCreateCommand": "curl -fsS http://huddle:3000/api/tls/ca.crt -o ${caPath} || echo 'CA not fetched (HTTPS tunnelled, no MITM)'"`,
+      `       "postCreateCommand": "curl -fsS http://huddle:24842/api/tls/ca.crt -o ${caPath} || echo 'CA not fetched (HTTPS tunnelled, no MITM)'"`,
     ),
   );
   console.log(dim(`     (Adjust ${caPath} to your remoteUser's home if it differs; pass --ca-path to change it.)`));

--- a/docs/migrate-devcontainers.md
+++ b/docs/migrate-devcontainers.md
@@ -70,7 +70,7 @@ This writes `docker-compose.huddle.yml` next to your compose file. For each serv
 marked network it adds, in the override only:
 
 * the proxy env vars — `HTTP_PROXY` / `HTTPS_PROXY` (+ lowercase) `= http://huddle:80`;
-* `NO_PROXY` including `huddle` (so the direct CA fetch to `huddle:3000` skips the proxy);
+* `NO_PROXY` including `huddle` (so the direct CA fetch to `huddle:24842` skips the proxy);
 * `NODE_EXTRA_CA_CERTS` pointing at the CA path;
 * a second network, `huddle`, that maps to the existing `devcontainer-net`
   (`external: true`) — your own `development` network is left untouched.
@@ -113,7 +113,7 @@ to finish:
    (`huddle` is in `NO_PROXY`, so the call goes directly to the Huddle API):
 
    ```jsonc
-   "postCreateCommand": "curl -fsS http://huddle:3000/api/tls/ca.crt -o /home/vscode/.huddle-ca.crt || echo 'CA not fetched (HTTPS tunnelled, no MITM)'"
+   "postCreateCommand": "curl -fsS http://huddle:24842/api/tls/ca.crt -o /home/vscode/.huddle-ca.crt || echo 'CA not fetched (HTTPS tunnelled, no MITM)'"
    ```
 
    Use the home of your `remoteUser`; pass `--ca-path` to `huddle migrate` if it differs

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -29,5 +29,5 @@ COPY package.json ./
 COPY extensions ./extensions
 ENV DB_PATH=/data/huddle.db
 ENV EXT_DIR=/app/extensions
-EXPOSE 80 3000
+EXPOSE 80 24842
 CMD ["node", "dist/index.js"]

--- a/gateway/frontend/README.md
+++ b/gateway/frontend/README.md
@@ -1,6 +1,6 @@
 # Huddle DMZ Portal — Frontend
 
-Angular 21 SPA served by the gateway on port 3000. See the [gateway README](../README.md) for the full project overview.
+Angular 21 SPA served by the gateway on port 24842. See the [gateway README](../README.md) for the full project overview.
 
 ## Pages
 
@@ -22,6 +22,6 @@ Angular 21 SPA served by the gateway on port 3000. See the [gateway README](../R
 
 ```bash
 npm install
-ng serve        # dev server on :4200, proxies /api/* to :3000
+ng serve        # dev server on :4200, proxies /api/* to :24842
 ng build        # production build → ../dist/ui/browser/
 ```

--- a/gateway/frontend/proxy.conf.json
+++ b/gateway/frontend/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api": {
-    "target": "http://localhost:3000",
+    "target": "http://localhost:24842",
     "secure": false
   }
 }

--- a/gateway/src/api.ts
+++ b/gateway/src/api.ts
@@ -50,7 +50,7 @@ import {
   EXT_DIR,
 } from './extensions/registry';
 
-const API_PORT = 3000;
+const API_PORT = 24842;
 const UI_DIR = path.join(__dirname, '..', 'dist', 'ui', 'browser');
 
 type RuleStatus = 'requested' | 'allow' | 'deny';

--- a/gateway/src/auth.ts
+++ b/gateway/src/auth.ts
@@ -5,8 +5,8 @@ import { IncomingMessage } from 'http';
 
 // ── Operator-authenticatie voor de control plane ────────────────────────────
 // Root-cause van de "missing auth"-cluster (findings #4/#5/#9/#10/#11/#13): de
-// enige toegangscontrole op :3000 was een source-IP-gate. Omdat de gateway een
-// container is die via `-p 3000:3000` gepubliceerd wordt, arriveren de operator
+// enige toegangscontrole op :24842 was een source-IP-gate. Omdat de gateway een
+// container is die via `-p 24842:24842` gepubliceerd wordt, arriveren de operator
 // (browser + CLI) én een LAN-/sibling-aanvaller met HETZELFDE bridge-gateway-IP
 // — source-IP kan ze principieel niet scheiden. Alleen een gedeeld operator-
 // token doet dat. Dit is bewust minimaal (geen sessie-store): de cookie/bearer
@@ -59,7 +59,7 @@ export function getOperatorToken(): string {
   }
   cachedToken = generated;
   console.log(
-    `\n[auth] Operator token generated. Log in to the portal (http://localhost:3000) with:\n\n    ${generated}\n\n` +
+    `\n[auth] Operator token generated. Log in to the portal (http://localhost:24842) with:\n\n    ${generated}\n\n` +
     `Set HUDDLE_OPERATOR_TOKEN to choose a fixed token.\n`
   );
   return generated;

--- a/gateway/src/docker.ts
+++ b/gateway/src/docker.ts
@@ -722,7 +722,7 @@ chmod 440 /etc/sudoers.d/99-huddle-audit 2>/dev/null || true
 touch /tmp/sudo-audit.log
 ( tail -F /tmp/sudo-audit.log 2>/dev/null | while IFS= read -r line; do
     [ -z "\$line" ] && continue
-    curl -sf -X POST "http://huddle:3000/api/audit/sudo" \\
+    curl -sf -X POST "http://huddle:24842/api/audit/sudo" \\
       -H "Content-Type: application/json" \\
       -d "{\\"container\\":\\"${containerName}\\",\\"entry\\":\\"\$(echo "\$line" | sed 's/\\"/\\\\\\"/g')\\"}" >/dev/null 2>&1 || true
   done ) &
@@ -831,7 +831,7 @@ chmod 440 /etc/sudoers.d/99-huddle-audit 2>/dev/null || true
 touch /tmp/sudo-audit.log
 ( tail -F /tmp/sudo-audit.log 2>/dev/null | while IFS= read -r line; do
     [ -z "\$line" ] && continue
-    curl -sf -X POST "http://huddle:3000/api/audit/sudo" \\
+    curl -sf -X POST "http://huddle:24842/api/audit/sudo" \\
       -H "Content-Type: application/json" \\
       -d "{\\"container\\":\\"${containerName}\\",\\"entry\\":\\"\$(echo "\$line" | sed 's/\\"/\\\\\\"/g')\\"}" >/dev/null 2>&1 || true
   done ) &

--- a/gateway/src/proxy.ts
+++ b/gateway/src/proxy.ts
@@ -74,9 +74,9 @@ function send403(res: http.ServerResponse, domain: string, status: string, conta
     reason: status === 'requested'
       ? 'This endpoint has not yet been approved for this devcontainer.'
       : 'This endpoint is denied by a firewall rule.',
-    actionRequired: 'The user must approve this endpoint in the Huddle portal (http://huddle:3000) before this request can continue.',
+    actionRequired: 'The user must approve this endpoint in the Huddle portal (http://huddle:24842) before this request can continue.',
     devcontainerId: containerId ?? undefined,
-    huddlePortal: 'http://localhost:3000',
+    huddlePortal: 'http://localhost:24842',
   });
   res.writeHead(403, {
     'content-type': 'application/json',
@@ -110,9 +110,9 @@ function rejectSocket(socket: stream.Duplex, status: number, blockStatus: string
     reason: blockStatus === 'requested'
       ? 'This endpoint has not yet been approved for this devcontainer.'
       : 'This endpoint is denied by a firewall rule.',
-    actionRequired: 'The user must approve this endpoint in the Huddle portal (http://huddle:3000) before this request can continue.',
+    actionRequired: 'The user must approve this endpoint in the Huddle portal (http://huddle:24842) before this request can continue.',
     devcontainerId: containerId ?? undefined,
-    huddlePortal: 'http://localhost:3000',
+    huddlePortal: 'http://localhost:24842',
   });
   socket.write(
     `HTTP/1.1 ${status} ${REJECT_REASON[status] ?? 'Forbidden'}\r\n` +
@@ -384,7 +384,7 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
     if (host === 'huddle') {
       // Self-traffic: devcontainers may only reach a fixed set of huddle paths.
       const allowed =
-        (target.port === '3000' && req.method === 'POST' && normPath === '/api/audit/sudo');
+        (target.port === '24842' && req.method === 'POST' && normPath === '/api/audit/sudo');
       if (!allowed) {
         logAudit({
           containerId,
@@ -449,7 +449,7 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
       });
     };
 
-    // MCP traffic to huddle always via the API port (3000), not the proxy port (80).
+    // MCP traffic to huddle always via the API port (24842), not the proxy port (80).
     const upstreamPort = target.port || 80;
 
     const upstream = tryCreateUpstreamRequest(() => http.request(
@@ -745,9 +745,9 @@ export function createProxyServer(port: number = PROXY_PORT): http.Server {
           reason: pathResult.status === 'requested'
             ? 'This path has not yet been approved for this devcontainer.'
             : 'This path is denied by a firewall rule.',
-          actionRequired: 'The user must approve this path in the Huddle portal (http://huddle:3000) before this request can continue.',
+          actionRequired: 'The user must approve this path in the Huddle portal (http://huddle:24842) before this request can continue.',
           devcontainerId: containerId ?? undefined,
-          huddlePortal: 'http://localhost:3000',
+          huddlePortal: 'http://localhost:24842',
         });
         innerRes.writeHead(403, {
           'content-type': 'application/json',

--- a/gateway/test/auth.test.ts
+++ b/gateway/test/auth.test.ts
@@ -80,16 +80,16 @@ describe('isAuthenticated', () => {
 
 describe('isAllowedOrigin (CSWSH-verdediging, finding #4)', () => {
   it('geen Origin (niet-browser) → toegestaan (auth-check blijft gelden)', () => {
-    expect(isAllowedOrigin(undefined, 'localhost:3000')).toBe(true);
+    expect(isAllowedOrigin(undefined, 'localhost:24842')).toBe(true);
   });
   it('same-origin → toegestaan', () => {
-    expect(isAllowedOrigin('http://localhost:3000', 'localhost:3000')).toBe(true);
+    expect(isAllowedOrigin('http://localhost:24842', 'localhost:24842')).toBe(true);
   });
   it('cross-origin (aanvaller-pagina) → geweigerd', () => {
-    expect(isAllowedOrigin('https://evil.example.com', 'localhost:3000')).toBe(false);
+    expect(isAllowedOrigin('https://evil.example.com', 'localhost:24842')).toBe(false);
   });
   it('onparseerbare Origin → geweigerd', () => {
-    expect(isAllowedOrigin('not a url', 'localhost:3000')).toBe(false);
+    expect(isAllowedOrigin('not a url', 'localhost:24842')).toBe(false);
   });
 });
 

--- a/gateway/test/e2e/boundary.e2e.ts
+++ b/gateway/test/e2e/boundary.e2e.ts
@@ -271,15 +271,15 @@ describe.skipIf(!E2E_ENABLED)('live security boundary', () => {
     //   1. via de egress-proxy (default: curlrc/http_proxy wijst naar huddle:80)
     //      → de self-traffic-gate van de proxy weigert alles behalve de
     //        audit-ingest met 403, de request bereikt de API nooit;
-    //   2. direct naar :3000 (iptables staat al het TCP-verkeer naar het
+    //   2. direct naar :24842 (iptables staat al het TCP-verkeer naar het
     //      huddle-IP toe) → daar is het operator-token de barrière: 401.
     it('proxy blokkeert self-traffic naar de management-API (→ 403)', () => {
-      const code = curlStatusIn(E2E_NAME, 'http://huddle:3000/api/rules');
+      const code = curlStatusIn(E2E_NAME, 'http://huddle:24842/api/rules');
       expect(code).toBe('403');
     });
 
     it('directe management-API-call zonder operator-token krijgt 401', () => {
-      const code = curlStatusIn(E2E_NAME, 'http://huddle:3000/api/rules', `--noproxy '*'`);
+      const code = curlStatusIn(E2E_NAME, 'http://huddle:24842/api/rules', `--noproxy '*'`);
       expect(code).toBe('401');
     });
 
@@ -287,7 +287,7 @@ describe.skipIf(!E2E_ENABLED)('live security boundary', () => {
       const r = execIn(
         E2E_NAME,
         `curl -s -o /dev/null -w '%{http_code}' -X POST -H 'Content-Type: application/json' ` +
-        `-d '{"container":"${E2E_NAME}","entry":"e2e-test"}' http://huddle:3000/api/audit/sudo`,
+        `-d '{"container":"${E2E_NAME}","entry":"e2e-test"}' http://huddle:24842/api/audit/sudo`,
       );
       expect(r.stdout.trim()).toBe('200');
     });

--- a/gateway/test/e2e/helpers.ts
+++ b/gateway/test/e2e/helpers.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process';
 
 // ── Config (overschrijfbaar via env) ────────────────────────────────────────
-export const HUDDLE_URL = process.env.HUDDLE_URL ?? 'http://localhost:3000';
+export const HUDDLE_URL = process.env.HUDDLE_URL ?? 'http://localhost:24842';
 export const E2E_IMAGE  = process.env.HUDDLE_E2E_IMAGE ?? 'ghcr.io/infosupport/base-devimage-vscode';
 export const E2E_IDE    = process.env.HUDDLE_E2E_IDE ?? 'vscode';
 export const E2E_NAME   = process.env.HUDDLE_E2E_NAME ?? 'devcontainer-e2e-boundary';
@@ -39,7 +39,7 @@ export function containerRunning(name: string): boolean {
   return r.status === 0 && r.stdout.trim() === 'true';
 }
 
-// ── Huddle management API (admin, vanaf de host op :3000) ────────────────────
+// ── Huddle management API (admin, vanaf de host op :24842) ────────────────────
 // De API eist een operator-token (auth.ts); geef de gateway-onder-test hetzelfde
 // token via HUDDLE_OPERATOR_TOKEN, dan authenticeren de helpers daarmee.
 async function api(method: string, path: string, body?: unknown): Promise<any> {


### PR DESCRIPTION
Move the default service port off the commonly-used 3000 to the less collision-prone 24842. Uniform change: the internal API listen port (API_PORT), the published host port default (HUDDLE_PORT) and the in-network references (huddle:3000 -> huddle:24842) all move together, so container mapping becomes 24842:24842.

Purely a mechanical port substitution; timeouts, epoch timestamps and the arbitrary example port in the socket-proxy parser test are left untouched.

<!--
Thanks for contributing to Huddle! Please fill in this template.
See CONTRIBUTING.md for the full workflow, coding standards, and commit conventions.
-->

## Summary

<!-- What does this PR do and why? -->

## Related issue

<!-- e.g. Fixes #123. Open an issue first for large changes. -->
Fixes #

## Type of change

- [ ] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Documentation (`docs`)
- [ ] Refactor / maintenance (`refactor` / `chore`)
- [ ] Other:

## Checklist

- [ ] My branch is up to date with `main` and focused on a single change.
- [ ] The project **builds** and **type-checks** locally.
- [ ] Tests pass (`npm --prefix gateway test`) and I added/updated tests where relevant.
- [ ] I ran Prettier and did not reformat unrelated code.
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/).
- [ ] I did not introduce logging of secrets, tokens, or credentials.
- [ ] Documentation is updated where needed (README / relevant docs).

## Notes for reviewers

<!-- Anything reviewers should pay special attention to, testing instructions, screenshots, etc. -->
