### PR TITLE
feat: multi-folder mounts with shared AI-context wiring

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -25,8 +25,17 @@ huddle                 # start an IntelliJ devcontainer for the current director
 huddle ./project       # start for a specific directory
 huddle --ide rider
 huddle --ide vscode --name devcontainer-demo
+huddle --ide vscode --mount backend=../docker-corpa --mount frontend=../frontend-consolidated-real-estate-info --name corpa-dev
 huddle fw list
 huddle firewall list -i
+```
+
+`--mount <name>=<path>` mounts an additional folder, worktree-isolated like the main workspace, under `/workspaces/<name>` in the container. Repeatable — pass one per folder. Cannot be combined with `--workspace`/`--empty`; when at least one `--mount` is given, the container's shared workspace root becomes `/workspaces` instead of `/workspaces/<leaf>`.
+
+`--context <name>` marks one of the `--mount` folders as shared context (e.g. an AI-context/skills repo): Huddle writes a stub `/workspaces/CLAUDE.md` pointing at it, so an agent working in any of the other mounted repos picks it up as an ancestor file. `<name>` must match a declared `--mount` name; the stub is only written if `/workspaces/CLAUDE.md` doesn't already exist.
+
+```bash
+huddle --ide vscode --mount ai=../ai-context-repo --mount backend=../backend-repo --mount frontend=../frontend-repo --context ai --name corpa-dev
 ```
 
 Default API URL: `http://localhost:3000`. Override it with `--url` or `HUDDLE_URL`.
@@ -59,6 +68,7 @@ Main flags:
 ```text
 --ide <intellij|rider|vscode>
 --workspace <path>
+--mount <name>=<path>   (repeatable)
 --name <name>
 --image <image>
 --empty

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -20,15 +20,17 @@ import {
 interface ParsedArgs {
   positional: string[];
   flags: Record<string, string | boolean>;
+  mounts: string[];
 }
 
-const VALUE_FLAGS = new Set(['url', 'ide', 'name', 'image', 'workspace', 'container', 'status', 'runtime', 'experiment']);
+const VALUE_FLAGS = new Set(['url', 'ide', 'name', 'image', 'workspace', 'container', 'status', 'runtime', 'experiment', 'context']);
 const BOOLEAN_FLAGS = new Set(['help', 'h', 'empty', 'i', 'interactive', 'version', 'v']);
 const COMMANDS = new Set(['start', 'firewall', 'fw', 'init', 'experiment', 'help', 'version']);
 
 function parseArgs(argv: string[]): ParsedArgs {
   const positional: string[] = [];
   const flags: Record<string, string | boolean> = {};
+  const mounts: string[] = [];
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -42,6 +44,23 @@ function parseArgs(argv: string[]): ParsedArgs {
       const eq = raw.indexOf('=');
       const name = eq >= 0 ? raw.slice(0, eq) : raw;
       if (!name) throw new Error(`Invalid option: ${arg}`);
+
+      // Repeatable, unlike every other value flag (one `--mount name=path` per folder).
+      if (name === 'mount') {
+        let value: string;
+        if (eq >= 0) {
+          value = raw.slice(eq + 1);
+        } else {
+          const next = argv[i + 1];
+          if (next === undefined || next.startsWith('-')) {
+            throw new Error('Option --mount expects a value (name=path)');
+          }
+          value = next;
+          i++;
+        }
+        mounts.push(value);
+        continue;
+      }
 
       if (eq >= 0) {
         flags[name] = raw.slice(eq + 1);
@@ -78,7 +97,13 @@ function parseArgs(argv: string[]): ParsedArgs {
     positional.push(arg);
   }
 
-  return { positional, flags };
+  return { positional, flags, mounts };
+}
+
+function parseMountFlag(raw: string): { name: string; path: string } {
+  const eq = raw.indexOf('=');
+  if (eq <= 0) throw new Error(`Invalid --mount value "${raw}", expected name=path`);
+  return { name: raw.slice(0, eq), path: raw.slice(eq + 1) };
 }
 
 function readVersion(): string {
@@ -118,6 +143,11 @@ Init options:
 Start options:
   --ide <intellij|rider|vscode>      IDE (default: intellij)
   --workspace <path>                 Workspace directory (default: current directory)
+  --mount <name>=<path>              Mount an additional folder under /workspaces/<name>
+                                     (repeatable; cannot combine with --workspace/--empty)
+  --context <name>                   Mark one --mount as the shared context folder; writes a
+                                     stub /workspaces/CLAUDE.md pointing at it (must match a
+                                     declared --mount name)
   --name <name>                      Container name (default: devcontainer-<foldername>)
   --image <image>                    Use a specific image
   --empty                            Empty container without a workspace
@@ -146,7 +176,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const { positional, flags } = parsed;
+  const { positional, flags, mounts } = parsed;
   const [cmd, sub] = positional;
 
   if (flagBool(flags, 'version', 'v') || cmd === 'version') {
@@ -172,6 +202,8 @@ async function main(): Promise<void> {
     await runStart({
       ide: flagString(flags, 'ide') ?? 'intellij',
       workspace: flagString(flags, 'workspace') ?? startArgs[0],
+      mounts: mounts.length ? mounts.map(parseMountFlag) : undefined,
+      context: flagString(flags, 'context'),
       name: flagString(flags, 'name'),
       image: flagString(flags, 'image'),
       empty: flagBool(flags, 'empty'),

--- a/cli/src/start.ts
+++ b/cli/src/start.ts
@@ -6,6 +6,8 @@ import { bold, green, cyan, dim } from './utils';
 export interface StartOptions {
   ide: string;
   workspace?: string;
+  mounts?: { name: string; path: string }[];
+  context?: string;
   name?: string;
   image?: string;
   empty: boolean;
@@ -24,12 +26,42 @@ interface StartResponse {
 
 export async function runStart(opts: StartOptions): Promise<void> {
   const ide = parseIde(opts.ide);
-  const workspaceDir = opts.empty ? undefined : resolveWorkspace(opts.workspace);
-  const baseName = opts.empty ? 'empty' : path.basename(workspaceDir!);
+  const hasMounts = !!opts.mounts && opts.mounts.length > 0;
+  if (hasMounts && opts.workspace) {
+    throw new Error('Cannot combine --workspace with --mount; use --mount for every folder instead.');
+  }
+  if (hasMounts && opts.empty) {
+    throw new Error('Cannot combine --empty with --mount.');
+  }
+
+  const resolvedMounts = hasMounts
+    ? opts.mounts!.map((m) => ({ name: validateMountName(m.name), path: resolveWorkspace(m.path) }))
+    : undefined;
+  if (resolvedMounts) {
+    const seen = new Set<string>();
+    for (const m of resolvedMounts) {
+      if (seen.has(m.name)) throw new Error(`Duplicate --mount name: ${m.name}`);
+      seen.add(m.name);
+    }
+  }
+
+  const contextMount = opts.context?.trim() || undefined;
+  if (contextMount && !hasMounts) {
+    throw new Error('--context requires at least one --mount.');
+  }
+  if (contextMount && !resolvedMounts!.some((m) => m.name === contextMount)) {
+    throw new Error(`--context "${contextMount}" does not match any --mount name.`);
+  }
+
+  const workspaceDir = opts.empty || hasMounts ? undefined : resolveWorkspace(opts.workspace);
+  const baseName = opts.empty ? 'empty' : hasMounts ? resolvedMounts![0].name : path.basename(workspaceDir!);
   const containerName = opts.name ? validateContainerName(opts.name) : defaultContainerName(baseName);
 
   console.log(`Starting ${bold(containerName)} with ${bold(ide)}...`);
   if (workspaceDir) console.log(dim(`Workspace: ${workspaceDir}`));
+  if (resolvedMounts) {
+    for (const m of resolvedMounts) console.log(dim(`Mount ${m.name}: ${m.path}${m.name === contextMount ? ' (context)' : ''}`));
+  }
 
   let imageName = opts.image;
   if (!imageName) {
@@ -44,6 +76,8 @@ export async function runStart(opts: StartOptions): Promise<void> {
     ideName: IdeName;
     empty?: boolean;
     workspaceDir?: string;
+    mounts?: { name: string; path: string }[];
+    contextMount?: string;
   } = {
     imageName,
     containerName,
@@ -52,6 +86,9 @@ export async function runStart(opts: StartOptions): Promise<void> {
 
   if (opts.empty) {
     body.empty = true;
+  } else if (resolvedMounts) {
+    body.mounts = resolvedMounts;
+    if (contextMount) body.contextMount = contextMount;
   } else {
     body.workspaceDir = workspaceDir;
   }
@@ -103,6 +140,14 @@ function validateContainerName(name: string): string {
   const trimmed = name.trim();
   if (!/^[a-zA-Z0-9][a-zA-Z0-9_.-]*$/.test(trimmed)) {
     throw new Error(`Invalid container name: ${name}`);
+  }
+  return trimmed;
+}
+
+function validateMountName(name: string): string {
+  const trimmed = (name ?? '').trim();
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/.test(trimmed)) {
+    throw new Error(`Invalid --mount name: "${name}". Use letters, digits, '-', '_' (used as the container subfolder name).`);
   }
   return trimmed;
 }

--- a/gateway/frontend/src/app/core/models/container.model.ts
+++ b/gateway/frontend/src/app/core/models/container.model.ts
@@ -10,6 +10,7 @@ export interface Container {
   status: string;
   created: number;
   workspacePath?: string;
+  mounts?: { name: string; path: string; isContext?: boolean }[];
   presentableName?: string;
   inNetwork?: boolean;
   huddleInNetwork?: boolean;

--- a/gateway/frontend/src/app/core/services/api.service.ts
+++ b/gateway/frontend/src/app/core/services/api.service.ts
@@ -115,10 +115,10 @@ export class ApiService {
     return this.handle(this.http.get<{ imageName: string; ide: string }>('/api/docker/base-image', { params: { ide } }));
   }
 
-  startContainer(params: { image: string; ide: string; workspace: string; containerName: string; empty?: boolean }): Observable<{ id: string; containerName: string }> {
+  startContainer(params: { image: string; ide: string; workspace: string; mounts?: { name: string; path: string }[]; contextMount?: string; containerName: string; empty?: boolean }): Observable<{ id: string; containerName: string }> {
     return this.handle(this.http.post<{ id: string; containerName: string }>('/api/docker/start', {
       imageName: params.image,
-      workspaceDir: params.workspace,
+      ...(params.mounts?.length ? { mounts: params.mounts, ...(params.contextMount ? { contextMount: params.contextMount } : {}) } : { workspaceDir: params.workspace }),
       containerName: params.containerName,
       ideName: params.ide,
       empty: params.empty === true,

--- a/gateway/frontend/src/app/pages/container-detail/container-detail.component.html
+++ b/gateway/frontend/src/app/pages/container-detail/container-detail.component.html
@@ -9,6 +9,7 @@
   @let net           = d.inspect.NetworkSettings?.Networks?.['dc-net-' + name] ?? d.inspect.NetworkSettings?.Networks?.['devcontainer-net'];
   @let ide           = cfg?.Labels?.['com.devcontainer.ide'] ?? '';
   @let workspace     = cfg?.Labels?.['com.intellij.devcontainer.workspace.path'] ?? '—';
+  @let mounts        = parseMounts(cfg?.Labels?.['com.intellij.devcontainer.mounts']);
   @let inNetwork     = !!net;
   @let huddleConn    = d.huddleInNetwork !== false;
   @let cRules        = excludePathMode(d.rules);
@@ -80,6 +81,16 @@
       <span class="cd-meta__label">Workspace</span>
       <span class="cd-meta__value" [title]="workspace">{{ workspace }}</span>
     </div>
+    @if (mounts.length) {
+      <div class="cd-meta__item">
+        <span class="cd-meta__label">Mounts</span>
+        <span class="cd-meta__value">
+          @for (m of mounts; track m.name; let last = $last) {
+            <span [title]="m.path">{{ m.name }}</span>@if (m.isContext) {<span class="cd-badge cd-badge--ok" style="padding:1px 6px;font-size:10px;margin:0 4px">AI context</span>}@if (!last) {<span>, </span>}
+          }
+        </span>
+      </div>
+    }
     <div class="cd-meta__item">
       <span class="cd-meta__label">Created</span>
       <span class="cd-meta__value">{{ d.inspect.Created | date:'dd-MM-yy HH:mm' }}</span>

--- a/gateway/frontend/src/app/pages/container-detail/container-detail.component.ts
+++ b/gateway/frontend/src/app/pages/container-detail/container-detail.component.ts
@@ -145,6 +145,16 @@ export class ContainerDetailComponent implements OnInit {
   pathDomains(rules: Rule[]) { return buildPathDomains(rules); }
   excludePathMode(rules: Rule[]) { return excludePathModeRules(rules); }
 
+  parseMounts(raw: string | undefined): { name: string; path: string; isContext?: boolean }[] {
+    if (!raw) return [];
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  }
+
   enablePathMode(rule: Rule): void {
     this.api.setPathMode(rule.id, true).subscribe(() => { this.state.loadAll(); this.load(); });
   }

--- a/gateway/frontend/src/app/pages/containers/containers.component.ts
+++ b/gateway/frontend/src/app/pages/containers/containers.component.ts
@@ -39,6 +39,7 @@ export class ContainersComponent {
   }
   scoreClass(s: number | null) { return s === null ? 'muted' : s > 70 ? 'green' : s > 40 ? 'yellow' : 'red'; }
   sourcesLeaf(c: Container) {
+    if (c.mounts?.length) return c.mounts.map(m => m.name).join(', ');
     const p = c.workspacePath || c.labels?.['com.intellij.devcontainer.sources.path'] || c.Labels?.['com.intellij.devcontainer.sources.path'] || '';
     return p ? p.replace(/\\/g, '/').split('/').filter(Boolean).pop() || '—' : '—';
   }

--- a/gateway/frontend/src/app/shared/modals/start-container-modal/start-container-modal.component.html
+++ b/gateway/frontend/src/app/shared/modals/start-container-modal/start-container-modal.component.html
@@ -33,8 +33,38 @@
           Empty (clone manually)
         </label>
 
-        <label for="start-workspace">Workspace directory</label>
-        <input id="start-workspace" type="text" [(ngModel)]="workspace" (ngModelChange)="onWorkspaceInput()" placeholder="C:/projects/my-project" [disabled]="empty" />
+        @if (!empty) {
+          <label class="empty-toggle">
+            <input type="checkbox" [ngModel]="mode === 'multi'" (ngModelChange)="toggleMultiMode()" />
+            Multiple folders (mounted side by side, each its own worktree)
+          </label>
+        }
+
+        @if (!empty && mode === 'single') {
+          <label for="start-workspace">Workspace directory</label>
+          <input id="start-workspace" type="text" [(ngModel)]="workspace" (ngModelChange)="onWorkspaceInput()" placeholder="C:/projects/my-project" />
+        }
+
+        @if (!empty && mode === 'multi') {
+          <label>Folders</label>
+          @for (m of mounts; track $index) {
+            <div class="mount-row">
+              <input type="text" [(ngModel)]="m.name" (ngModelChange)="onMountInput()" placeholder="name (e.g. backend)" />
+              <input type="text" [(ngModel)]="m.path" (ngModelChange)="onMountInput()" placeholder="C:/projects/my-repo" />
+              <button
+                type="button"
+                class="btn btn-ghost btn-sm"
+                [class.btn-context-on]="contextMountIndex === $index"
+                (click)="toggleContext($index)"
+                title="Mark as shared AI/agent context folder">{{ contextMountIndex === $index ? '★' : '☆' }}</button>
+              <button type="button" class="btn btn-ghost btn-sm" (click)="removeMount($index)" [disabled]="mounts.length === 1" title="Remove folder">✕</button>
+            </div>
+          }
+          <button type="button" class="btn btn-ghost btn-sm" (click)="addMount()">+ Add folder</button>
+          @if (contextMountIndex !== null) {
+            <p class="mount-context-hint">A stub CLAUDE.md pointing at "{{ mounts[contextMountIndex].name || '…' }}" will be written to the shared workspace root.</p>
+          }
+        }
 
         <label for="start-name">Container name</label>
         <input id="start-name" type="text" [(ngModel)]="containerName" (input)="nameTouched = true" placeholder="devcontainer-my-project" />

--- a/gateway/frontend/src/app/shared/modals/start-container-modal/start-container-modal.component.ts
+++ b/gateway/frontend/src/app/shared/modals/start-container-modal/start-container-modal.component.ts
@@ -6,12 +6,21 @@ import { StateService } from '../../../core/services/state.service';
 import { DockerImage } from '../../../core/models/container.model';
 import { FmtBytesPipe } from '../../pipes/fmt-bytes.pipe';
 
+const MOUNT_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/;
+
 @Component({
   selector: 'app-start-container-modal',
   standalone: true,
   imports: [FormsModule, FmtBytesPipe],
   templateUrl: './start-container-modal.component.html',
-  styles: []
+  styles: [`
+    .mount-row { display: flex; gap: .5rem; align-items: center; }
+    .mount-row input:first-child { flex: 0 0 35%; }
+    .mount-row input:nth-child(2) { flex: 1; }
+    .mount-row .btn { flex: 0 0 auto; }
+    .btn-context-on { color: var(--warning, #d97706); }
+    .mount-context-hint { font-size: 12px; color: var(--text-muted); margin: -.25rem 0 .5rem; }
+  `]
 })
 export class StartContainerModalComponent {
   modalService = inject(ModalService);
@@ -22,7 +31,10 @@ export class StartContainerModalComponent {
   baseImage = '';
   selectedImage = '';
   ide: 'rider' | 'intellij' | 'vscode' = 'intellij';
+  mode: 'single' | 'multi' = 'single';
   workspace = '';
+  mounts: { name: string; path: string }[] = [];
+  contextMountIndex: number | null = null;
   containerName = '';
   nameTouched = false;
   empty = false;
@@ -43,7 +55,10 @@ export class StartContainerModalComponent {
   onOpen(): void {
     this.selectedImage = '';
     this.ide = 'intellij';
+    this.mode = 'single';
     this.workspace = '';
+    this.mounts = [];
+    this.contextMountIndex = null;
     this.containerName = '';
     this.nameTouched = false;
     this.empty = false;
@@ -68,33 +83,106 @@ export class StartContainerModalComponent {
     });
   }
 
-  onWorkspaceInput(): void {
-    if (!this.nameTouched) {
-      const leaf = this.workspace.replace(/\\/g, '/').split('/').filter(Boolean).pop() ?? '';
-      this.containerName = leaf ? `devcontainer-${leaf}` : '';
+  toggleMultiMode(): void {
+    this.mode = this.mode === 'multi' ? 'single' : 'multi';
+    if (this.mode === 'multi') {
+      this.workspace = '';
+      if (this.mounts.length === 0) this.addMount();
+    } else {
+      this.mounts = [];
+      this.contextMountIndex = null;
     }
+    this.updateAutoName();
+  }
+
+  addMount(): void {
+    this.mounts.push({ name: '', path: '' });
+  }
+
+  removeMount(i: number): void {
+    this.mounts.splice(i, 1);
+    if (this.contextMountIndex === i) this.contextMountIndex = null;
+    else if (this.contextMountIndex !== null && this.contextMountIndex > i) this.contextMountIndex--;
+    this.updateAutoName();
+  }
+
+  toggleContext(i: number): void {
+    this.contextMountIndex = this.contextMountIndex === i ? null : i;
+  }
+
+  onWorkspaceInput(): void {
+    this.updateAutoName();
+  }
+
+  onMountInput(): void {
+    this.updateAutoName();
+  }
+
+  private updateAutoName(): void {
+    if (this.nameTouched) return;
+    if (this.empty) {
+      this.containerName = 'devcontainer-empty';
+      return;
+    }
+    if (this.mode === 'multi') {
+      const leaf = (this.mounts[0]?.name ?? '').trim();
+      this.containerName = leaf ? `devcontainer-${leaf}` : '';
+      return;
+    }
+    const leaf = this.workspace.replace(/\\/g, '/').split('/').filter(Boolean).pop() ?? '';
+    this.containerName = leaf ? `devcontainer-${leaf}` : '';
   }
 
   onEmptyToggle(): void {
     if (this.empty) {
       this.workspace = '';
+      this.mounts = [];
+      this.contextMountIndex = null;
+      this.mode = 'single';
       if (!this.nameTouched && !this.containerName) {
         this.containerName = 'devcontainer-empty';
       }
     }
+    this.updateAutoName();
+  }
+
+  private validate(): string | null {
+    if (!this.selectedImage || !this.containerName) return 'All fields are required';
+    if (this.empty) return null;
+    if (this.mode === 'multi') {
+      if (this.mounts.length === 0) return 'Add at least one folder';
+      const seen = new Set<string>();
+      for (const m of this.mounts) {
+        const name = m.name.trim();
+        const path = m.path.trim();
+        if (!name || !path) return 'Every folder needs a name and a path';
+        if (!MOUNT_NAME_RE.test(name)) return `Invalid folder name: "${name}" (letters, digits, '-', '_' only)`;
+        if (seen.has(name)) return `Duplicate folder name: ${name}`;
+        seen.add(name);
+      }
+      return null;
+    }
+    if (!this.workspace) return 'All fields are required';
+    return null;
   }
 
   confirm(): void {
-    if (!this.selectedImage || !this.containerName || (!this.empty && !this.workspace)) {
-      this.error = 'All fields are required'; return;
-    }
+    const err = this.validate();
+    if (err) { this.error = err; return; }
     this.error = '';
     this.loading = true;
     this.status = 'Starting container…';
+    const isMulti = this.mode === 'multi' && !this.empty;
     this.api.startContainer({
       image: this.selectedImage,
       ide: this.ide,
-      workspace: this.workspace,
+      workspace: this.mode === 'single' ? this.workspace : '',
+      mounts: isMulti
+        ? this.mounts.map(m => ({ name: m.name.trim(), path: m.path.trim() }))
+        : undefined,
+      contextMount: isMulti && this.contextMountIndex !== null
+        ? this.mounts[this.contextMountIndex].name.trim()
+        : undefined,
       containerName: this.containerName,
       empty: this.empty,
     }).subscribe({

--- a/gateway/src/api.ts
+++ b/gateway/src/api.ts
@@ -566,26 +566,67 @@ export async function createApiServer(): Promise<FastifyInstance> {
       .send(getCaCertPem());
   });
 
-  app.post<{ Body: { imageName: string; workspaceDir?: string; containerName: string; ideName?: string; empty?: boolean; presentableName?: string; memory?: string; cpus?: string } }>(
+  app.post<{ Body: {
+    imageName: string;
+    workspaceDir?: string;
+    mounts?: { name: string; path: string }[];
+    contextMount?: string;
+    containerName: string;
+    ideName?: string;
+    empty?: boolean;
+    presentableName?: string;
+    memory?: string;
+    cpus?: string;
+  } }>(
     '/api/docker/start',
     async (req, reply) => {
-      const { imageName, workspaceDir, containerName, ideName, empty, presentableName: presentableNameOverride, memory, cpus } = req.body;
+      const { imageName, workspaceDir, mounts, contextMount, containerName, ideName, empty, presentableName: presentableNameOverride, memory, cpus } = req.body;
       if (!imageName || !containerName) {
         return reply.code(400).send({ error: 'imageName and containerName required' });
       }
-      if (!empty && !workspaceDir) {
-        return reply.code(400).send({ error: 'workspaceDir required when empty is not set' });
+      if (workspaceDir && mounts?.length) {
+        return reply.code(400).send({ error: 'Provide either workspaceDir or mounts, not both' });
+      }
+      if (!empty && !workspaceDir && !mounts?.length) {
+        return reply.code(400).send({ error: 'workspaceDir or mounts required when empty is not set' });
+      }
+      if (contextMount && !mounts?.length) {
+        return reply.code(400).send({ error: 'contextMount requires mounts' });
+      }
+      let normalizedMounts: { name: string; path: string }[] | undefined;
+      if (mounts?.length) {
+        try {
+          const seen = new Set<string>();
+          normalizedMounts = mounts.map((m) => {
+            const name = (m.name ?? '').trim();
+            if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]*$/.test(name)) {
+              throw new Error(`Invalid mount name: "${m.name}"`);
+            }
+            if (seen.has(name)) throw new Error(`Duplicate mount name: ${name}`);
+            seen.add(name);
+            return { name, path: (m.path ?? '').replace(/\\/g, '/').replace(/\/$/, '') };
+          });
+        } catch (err: any) {
+          return reply.code(400).send({ error: err.message });
+        }
+      }
+      if (contextMount && !normalizedMounts!.some((m) => m.name === contextMount)) {
+        return reply.code(400).send({ error: `contextMount "${contextMount}" does not match any mount name` });
       }
       const fwd = (workspaceDir ?? '').replace(/\\/g, '/').replace(/\/$/, '');
       const leaf = empty
         ? containerName.replace(/^devcontainer-/, '') || containerName
-        : (fwd.split('/').pop() ?? containerName);
+        : normalizedMounts
+          ? normalizedMounts[0].name
+          : (fwd.split('/').pop() ?? containerName);
       const ide: IdeName = isIdeName(ideName) ? ideName : 'intellij';
       const params: StartParams = {
         imageName,
         workspaceDir: empty ? '' : fwd,
+        mounts: normalizedMounts,
+        contextMount: normalizedMounts ? contextMount : undefined,
         containerName,
-        containerWorkspace: `/workspaces/${leaf}`,
+        containerWorkspace: normalizedMounts ? '/workspaces' : `/workspaces/${leaf}`,
         presentableName: presentableNameOverride || leaf,
         ideName: ide,
         empty: empty === true,

--- a/gateway/src/docker.ts
+++ b/gateway/src/docker.ts
@@ -94,10 +94,21 @@ export interface DevcontainerInfo {
   image: string;
   status: string;
   workspacePath: string;
+  mounts?: { name: string; path: string; isContext?: boolean }[];
   presentableName: string;
   created: number;
   inNetwork: boolean;
   huddleInNetwork: boolean;
+}
+
+function parseMountsLabel(raw: string | undefined): { name: string; path: string; isContext?: boolean }[] | undefined {
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 // Set van dc-net-* netwerken waar de huddle-container zelf in zit. Wordt
@@ -130,6 +141,7 @@ export async function listDevcontainers(): Promise<DevcontainerInfo[]> {
       image: c.Image,
       status: c.Status,
       workspacePath: c.Labels?.['com.intellij.devcontainer.sources.path'] ?? '',
+      mounts: parseMountsLabel(c.Labels?.['com.intellij.devcontainer.mounts']),
       presentableName: c.Labels?.['com.intellij.devcontainer.presentable.name'] ?? '',
       created: c.Created,
       inNetwork: Boolean(dcNet?.IPAddress),
@@ -423,6 +435,21 @@ for pair in ${pairs}; do
 done`;
 }
 
+// Genereert een stub /workspaces/CLAUDE.md die naar de gekozen context-mount
+// verwijst. /workspaces is de gedeelde parent van alle mounts, dus een agent
+// met cwd in eender welke sibling-mount pikt dit bestand op als ancestor
+// (zelfde manier waarop CLAUDE.md-discovery normaal al werkt). Nooit
+// overschrijven als het bestand al bestaat — zelfde "niet clobberen"-conventie
+// als buildFolderMappingSeedScript hierboven (cp -rn).
+function buildContextStubScript(containerWorkspace: string, contextMountName: string | undefined): string {
+  if (!contextMountName) return '';
+  return `# Wire the context mount into a stub CLAUDE.md at the shared workspace root.
+if [ ! -f "${containerWorkspace}/CLAUDE.md" ]; then
+  printf 'See /workspaces/%s for shared project context, skills, and conventions.\\n' "${contextMountName}" > "${containerWorkspace}/CLAUDE.md"
+  chown vscode:vscode "${containerWorkspace}/CLAUDE.md" 2>/dev/null || true
+fi`;
+}
+
 // Docker-toegang loopt via de socket in de gemounte directory /var/run/huddle
 // (zie DOCKER_HOST). Symlink het defaultpad voor tools die DOCKER_HOST negeren.
 // Gedeeld tussen het JetBrains- en het VS Code-startscript.
@@ -488,7 +515,7 @@ fi`;
 
 // ── jb-config.sh — same logic as devcontainer-manager.ps1 ───────────────────
 
-function buildJbConfigScript(containerWorkspace: string, containerName: string, ideName: IdeName, password: string, caCertPem: string, seedScript: string): string {
+function buildJbConfigScript(containerWorkspace: string, containerName: string, ideName: IdeName, password: string, caCertPem: string, seedScript: string, contextStubScript: string): string {
   const ideFilter = ideName === 'rider' ? 'rider' : 'idea';
   const caB64 = Buffer.from(caCertPem, 'utf8').toString('base64');
   return `#!/bin/sh
@@ -588,6 +615,8 @@ chmod -R u+rwX "${containerWorkspace}" 2>/dev/null || true
 
 ${seedScript}
 
+${contextStubScript}
+
 # Configure sudo audit logging
 mkdir -p /etc/sudoers.d
 printf 'Defaults logfile=/tmp/sudo-audit.log\\n' > /etc/sudoers.d/99-huddle-audit
@@ -652,7 +681,7 @@ export function buildVscodeMachineSettings(): Record<string, unknown> {
   };
 }
 
-function buildVscodeConfigScript(containerWorkspace: string, containerName: string, password: string, caCertPem: string, seedScript: string): string {
+function buildVscodeConfigScript(containerWorkspace: string, containerName: string, password: string, caCertPem: string, seedScript: string, contextStubScript: string): string {
   const caB64 = Buffer.from(caCertPem, 'utf8').toString('base64');
   const settingsB64 = Buffer.from(JSON.stringify(buildVscodeMachineSettings(), null, 2), 'utf8').toString('base64');
   return `#!/bin/sh
@@ -692,6 +721,8 @@ chown -R vscode:vscode "${containerWorkspace}" 2>/dev/null || true
 chmod -R u+rwX "${containerWorkspace}" 2>/dev/null || true
 
 ${seedScript}
+
+${contextStubScript}
 
 # Finding #15: harden het VS Code Remote IDE-kanaal met machine-level settings.
 # Attach-to-running-container leest deze uit ~/.vscode-server/data/Machine/ (en
@@ -748,9 +779,11 @@ function buildFolderMounts(containerName: string): FolderMount[] {
 
 export interface StartParams {
   imageName: string;
-  workspaceDir: string;     // host path, forward slashes; empty string when empty=true
+  workspaceDir: string;     // host path, forward slashes; empty string when empty=true or mounts is set
+  mounts?: { name: string; path: string }[]; // multiple named mounts; takes precedence over workspaceDir when set
+  contextMount?: string;    // name of the mount (from `mounts`) to wire in as shared AI/agent context
   containerName: string;
-  containerWorkspace: string; // /workspaces/<leaf>
+  containerWorkspace: string; // /workspaces/<leaf> for a single mount, /workspaces (shared parent) for multiple
   presentableName: string;
   ideName?: IdeName;
   empty?: boolean;
@@ -778,9 +811,10 @@ function parseCpuQuota(s: string): number {
 }
 
 export async function createAndStartContainer(params: StartParams): Promise<string> {
-  const { imageName, workspaceDir, containerName, containerWorkspace, presentableName } = params;
+  const { imageName, workspaceDir, mounts: mountParams, containerName, containerWorkspace, presentableName } = params;
   const ideName = params.ideName ?? 'intellij';
   const empty = params.empty === true;
+  const isMultiMount = !empty && !!mountParams?.length;
   // VS Code installeert zijn eigen backend (VS Code Server) bij het attachen: geen
   // JB host-config, geen RemoteDev-distro-volume, geen remote-dev-server launch.
   const isVscode = ideName === 'vscode';
@@ -870,7 +904,34 @@ export async function createAndStartContainer(params: StartParams): Promise<stri
     ]),
   ];
 
-  const effectiveSource = empty ? '' : await ensureWorktree(toLinuxPath(workspaceDir), containerName);
+  // Elke mount is een eigen git-repo (of geen repo — ensureWorktree valt dan
+  // terug op de padnaam zelf), dus elke mount krijgt zijn eigen worktree-call.
+  // Bij één mount is dat het klassieke gedrag; bij meerdere mounts wordt
+  // containerWorkspace de gedeelde parent ('/workspaces') en krijgt elke mount
+  // zijn eigen subfolder eronder — zelfde patroon als poc-corpa-ai's
+  // hand-rolled compose-bestand, wat maakt dat alleen deze mounts zichtbaar
+  // zijn in VS Code's file-explorer/Source Control, niets anders.
+  // contextMount wijst naar een van de mountParams (gevalideerd op de API-grens,
+  // gateway/src/api.ts); alleen zinvol in multi-mount mode.
+  const contextMountName = isMultiMount && params.contextMount && mountParams!.some(m => m.name === params.contextMount)
+    ? params.contextMount
+    : undefined;
+
+  const workspaceMounts: FolderMount[] = [];
+  let sourcesPathLabel = '';
+  if (!empty) {
+    if (isMultiMount) {
+      for (const m of mountParams!) {
+        const effectiveSource = await ensureWorktree(toLinuxPath(m.path), containerName);
+        workspaceMounts.push({ Type: 'bind', Source: effectiveSource, Target: `${containerWorkspace}/${m.name}` });
+      }
+      sourcesPathLabel = mountParams![0].path;
+    } else {
+      const effectiveSource = await ensureWorktree(toLinuxPath(workspaceDir), containerName);
+      workspaceMounts.push({ Type: 'bind', Source: effectiveSource, Target: containerWorkspace });
+      sourcesPathLabel = workspaceDir;
+    }
+  }
 
   const folderMounts = buildFolderMounts(containerName);
 
@@ -882,11 +943,7 @@ export async function createAndStartContainer(params: StartParams): Promise<stri
       Source: 'jb_devcontainers_shared_volume',
       Target: '/.jbdevcontainer/JetBrains/RemoteDev/dist',
     }]),
-    ...(empty ? [] : [{
-      Type: 'bind',
-      Source: effectiveSource,
-      Target: containerWorkspace,
-    }]),
+    ...workspaceMounts,
     {
       // Mount de per-container socket-DIRECTORY, niet het socket-bestand zelf:
       // een file-bind pint de inode en wijst na een huddle-herstart (unlink +
@@ -907,7 +964,13 @@ export async function createAndStartContainer(params: StartParams): Promise<stri
     Labels: {
       'com.intellij.devcontainer.id': devcontainerId,
       'com.intellij.devcontainer.presentable.name': presentableName,
-      'com.intellij.devcontainer.sources.path': empty ? '' : workspaceDir,
+      // Bij meerdere mounts staat hier enkel het primaire (eerste) mount-pad,
+      // voor backwards-compat met alles wat dit label als één string leest.
+      // De volledige lijst zit in het aparte 'mounts'-label hieronder.
+      'com.intellij.devcontainer.sources.path': empty ? '' : sourcesPathLabel,
+      ...(isMultiMount ? { 'com.intellij.devcontainer.mounts': JSON.stringify(
+        mountParams!.map(m => m.name === contextMountName ? { ...m, isContext: true } : m)
+      ) } : {}),
       'com.intellij.devcontainer.workspace.path': containerWorkspace,
       'com.intellij.devcontainer.model': modelJson,
       'com.devcontainer.ide': ideName,
@@ -930,11 +993,12 @@ export async function createAndStartContainer(params: StartParams): Promise<stri
 
   const containerPaths = folderMounts.map(m => m.Target);
   const seedScript = buildFolderMappingSeedScript(containerPaths);
+  const contextStubScript = buildContextStubScript(containerWorkspace, contextMountName);
 
   // Run config script via exec — VS Code-variant zonder JB host-config/backend.
   const script = isVscode
-    ? buildVscodeConfigScript(containerWorkspace, containerName, password, getCaCertPem(), seedScript)
-    : buildJbConfigScript(containerWorkspace, containerName, ideName, password, getCaCertPem(), seedScript);
+    ? buildVscodeConfigScript(containerWorkspace, containerName, password, getCaCertPem(), seedScript, contextStubScript)
+    : buildJbConfigScript(containerWorkspace, containerName, ideName, password, getCaCertPem(), seedScript, contextStubScript);
   const execCreate = await dockerRequest('POST', `/containers/${id}/exec`, {
     User: 'root',
     Cmd: ['sh', '-c', script],


### PR DESCRIPTION
- Ability to mount multiple folders to one devcontainer in order to create a 'monorepo' in your devcontainer where the agent is still capable of sharing context between repos. 
- Ability to flag one of the folders as context, in which it will automatically create the workspace
- created and tested for a VS code workspace

<!--
Thanks for contributing to Huddle! Please fill in this template.
See CONTRIBUTING.md for the full workflow, coding standards, and commit conventions.
-->

## Summary
- Adds repeatable `--mount name=path` to mount multiple worktree-isolated folders into one devcontainer, under /workspaces/<name>

- Adds `--context <name>` to mark one mount as shared AI/agent context, writing a stub /workspaces/CLAUDE.md that sibling mounts pick up as ancestor context

- Verified end-to-end against a real VS Code devcontainer

## Type of change

- [ ] Bug fix (`fix`)
- [x] New feature (`feat`)
- [ ] Documentation (`docs`)
- [ ] Refactor / maintenance (`refactor` / `chore`)
- [ ] Other:

## Checklist

- [x] My branch is up to date with `main` and focused on a single change.
- [x] The project **builds** and **type-checks** locally.
- [x] Tests pass (`npm --prefix gateway test`) and I added/updated tests where relevant.
- [x] I ran Prettier and did not reformat unrelated code.
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] I did not introduce logging of secrets, tokens, or credentials.
- [x] Documentation is updated where needed (README / relevant docs).

## Notes for reviewers

Only tested on VS Code